### PR TITLE
Integrate Falcon NNUE network and update engine metadata

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -260,6 +260,10 @@ xefoci7612
 Xiang Wang (KatyushaScarlet)
 zz4032
 
+# Wordfish contributors
+Jorge Ruiz Centelles
+ChatGPT
+
 # Additionally, we acknowledge the authors and maintainers of fishtest,
 # an amazing and essential framework for Stockfish development!
 #

--- a/README.md
+++ b/README.md
@@ -1,26 +1,23 @@
-# Revolution Chess Engine
+# Wordfish 2.0 Chess Engine (310825)
 
 <div align="center">
-  <img src="[https://ijccrl.com/wp-content/uploads/2025/08/revolution.png]" 
-  <h3>Revolution</h3>
-  
+  <h3>Wordfish 2.0</h3>
+
   A free and open-source UCI chess engine combining classical algorithms with neural network innovations.
   <br>
-  <strong><a href="#">Explore Revolution Documentation »</a>
+  <em>Authors: Stockfish developers, Jorge Ruiz, ChatGPT</em>
 
-  <em>Author: Jorge Ruiz Centelles</em>
-  
 </div>
 
 ## Overview
 
-**Revolution** is a free, open-source UCI chess engine implementing cutting-edge search algorithms combined with neural network evaluation. Derived from fundamental chess programming principles, Revolution analyzes positions through parallelized alpha-beta search enhanced with null-move pruning and late move reductions.
+**Wordfish** is a free, open-source UCI chess engine implementing cutting-edge search algorithms combined with neural network evaluation. Derived from fundamental chess programming principles, Wordfish analyzes positions through parallelized alpha-beta search enhanced with null-move pruning and late move reductions.
 
-As a UCI-compliant engine, Revolution operates through **standard chess interfaces** without an integrated graphical interface. Users must employ compatible chess GUIs (Arena, Scid vs PC, etc.) for board visualization and move input. Consult your GUI documentation for implementation details.
+As a UCI-compliant engine, Wordfish operates through **standard chess interfaces** without an integrated graphical interface. Users must employ compatible chess GUIs (Arena, Scid vs PC, etc.) for board visualization and move input. Consult your GUI documentation for implementation details.
 
 ## Technical Architecture
 
-Revolution's architecture features:
+Wordfish's architecture features:
 
 - Hybrid evaluation system combining classical heuristics with NNUE networks
 - SMP parallelization with YBWC (Young Brothers Wait Concept)

--- a/scripts/net.sh
+++ b/scripts/net.sh
@@ -73,4 +73,5 @@ fetch_network() {
 }
 
 fetch_network EvalFileDefaultNameBig && \
-fetch_network EvalFileDefaultNameSmall
+fetch_network EvalFileDefaultNameSmall && \
+fetch_network EvalFileDefaultNameFalcon

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -61,7 +61,9 @@ Engine::Engine(std::optional<std::string> path) :
       numaContext,
       NN::Networks(
         NN::NetworkBig({EvalFileDefaultNameBig, "None", ""}, NN::EmbeddedNNUEType::BIG),
-        NN::NetworkSmall({EvalFileDefaultNameSmall, "None", ""}, NN::EmbeddedNNUEType::SMALL))) {
+        NN::NetworkSmall({EvalFileDefaultNameSmall, "None", ""}, NN::EmbeddedNNUEType::SMALL),
+        NN::NetworkFalcon({EvalFileDefaultNameFalcon, "None", ""},
+                          NN::EmbeddedNNUEType::FALCON))) {
     pos.set(StartFEN, false, &states->back());
 
 
@@ -193,6 +195,12 @@ Engine::Engine(std::optional<std::string> path) :
           return std::nullopt;
       }));
 
+    options.add(  //
+      "EvalFileFalcon", Option(EvalFileDefaultNameFalcon, [this](const Option& o) {
+          load_falcon_network(o);
+          return std::nullopt;
+      }));
+
     if ((bool) options["Experience Enabled"])
         experience.load(options["Experience File"]);
 
@@ -314,12 +322,14 @@ void Engine::set_ponderhit(bool b) { threads.main_manager()->ponder = b; }
 void Engine::verify_networks() const {
     networks->big.verify(options["EvalFile"], onVerifyNetworks);
     networks->small.verify(options["EvalFileSmall"], onVerifyNetworks);
+    networks->falcon.verify(options["EvalFileFalcon"], onVerifyNetworks);
 }
 
 void Engine::load_networks() {
     networks.modify_and_replicate([this](NN::Networks& networks_) {
         networks_.big.load(binaryDirectory, options["EvalFile"]);
         networks_.small.load(binaryDirectory, options["EvalFileSmall"]);
+        networks_.falcon.load(binaryDirectory, options["EvalFileFalcon"]);
     });
     threads.clear();
     threads.ensure_network_replicated();
@@ -339,10 +349,18 @@ void Engine::load_small_network(const std::string& file) {
     threads.ensure_network_replicated();
 }
 
-void Engine::save_network(const std::pair<std::optional<std::string>, std::string> files[2]) {
+void Engine::load_falcon_network(const std::string& file) {
+    networks.modify_and_replicate(
+      [this, &file](NN::Networks& networks_) { networks_.falcon.load(binaryDirectory, file); });
+    threads.clear();
+    threads.ensure_network_replicated();
+}
+
+void Engine::save_network(const std::pair<std::optional<std::string>, std::string> files[3]) {
     networks.modify_and_replicate([&files](NN::Networks& networks_) {
         networks_.big.save(files[0].first);
         networks_.small.save(files[1].first);
+        networks_.falcon.save(files[2].first);
     });
 }
 

--- a/src/engine.h
+++ b/src/engine.h
@@ -87,7 +87,8 @@ class Engine {
     void load_networks();
     void load_big_network(const std::string& file);
     void load_small_network(const std::string& file);
-    void save_network(const std::pair<std::optional<std::string>, std::string> files[2]);
+    void load_falcon_network(const std::string& file);
+    void save_network(const std::pair<std::optional<std::string>, std::string> files[3]);
 
     // utility functions
 

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -35,6 +35,7 @@ namespace Eval {
 // in the Makefile/Fishtest.
 #define EvalFileDefaultNameBig "nn-1c0000000000.nnue"
 #define EvalFileDefaultNameSmall "nn-37f18f62d772.nnue"
+#define EvalFileDefaultNameFalcon "nn-51892d3e267f.nnue"
 
 namespace NNUE {
 struct Networks;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,8 @@
 /*
-  Wordfish, a UCI chess engine based on Stockfish, Berserk, and Obsidian
+  Wordfish 2.0, a UCI chess engine based on Stockfish, Berserk, and Obsidian
+  Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
   Copyright (C) 2024 Jorge Ruiz Centelles
+  Credits: ChatGPT
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -18,13 +20,11 @@
 #include "position.h"
 
 #ifndef ENGINE_BUILD_DATE
-// Fallback to compilation date if not provided by the build system
-#define ENGINE_BUILD_DATE __DATE__
+#define ENGINE_BUILD_DATE "310825"
 #endif
 
 #ifndef ENGINE_NAME
-// Override at build time with:  -DENGINE_NAME="\"Wordfish 1.0.1 dev\""
-#define ENGINE_NAME "Wordfish 1.0.1 dev"
+#define ENGINE_NAME "Wordfish 2.0"
 #endif
 
 using namespace Stockfish;
@@ -33,7 +33,8 @@ int main(int argc, char* argv[]) {
 
     // Clear, consistent banner (many GUIs echo this to their logs)
     std::cout << ENGINE_NAME << ' ' << ENGINE_BUILD_DATE << ' ' << __TIME__
-              << " by Jorge Ruiz Centelles" << std::endl;
+              << " by Stockfish developers, Jorge Ruiz Centelles and ChatGPT"
+              << std::endl;
 
     std::cout << compiler_info() << std::endl;
 

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -48,6 +48,7 @@
 #if !defined(_MSC_VER) && !defined(NNUE_EMBEDDING_OFF)
 INCBIN(EmbeddedNNUEBig, EvalFileDefaultNameBig);
 INCBIN(EmbeddedNNUESmall, EvalFileDefaultNameSmall);
+INCBIN(EmbeddedNNUEFalcon, EvalFileDefaultNameFalcon);
 #else
 const unsigned char        gEmbeddedNNUEBigData[1]   = {0x0};
 const unsigned char* const gEmbeddedNNUEBigEnd       = &gEmbeddedNNUEBigData[1];
@@ -55,6 +56,9 @@ const unsigned int         gEmbeddedNNUEBigSize      = 1;
 const unsigned char        gEmbeddedNNUESmallData[1] = {0x0};
 const unsigned char* const gEmbeddedNNUESmallEnd     = &gEmbeddedNNUESmallData[1];
 const unsigned int         gEmbeddedNNUESmallSize    = 1;
+const unsigned char        gEmbeddedNNUEFalconData[1] = {0x0};
+const unsigned char* const gEmbeddedNNUEFalconEnd     = &gEmbeddedNNUEFalconData[1];
+const unsigned int         gEmbeddedNNUEFalconSize    = 1;
 #endif
 
 namespace {
@@ -76,8 +80,9 @@ using namespace Stockfish::Eval::NNUE;
 EmbeddedNNUE get_embedded(EmbeddedNNUEType type) {
     if (type == EmbeddedNNUEType::BIG)
         return EmbeddedNNUE(gEmbeddedNNUEBigData, gEmbeddedNNUEBigEnd, gEmbeddedNNUEBigSize);
-    else
+    if (type == EmbeddedNNUEType::SMALL)
         return EmbeddedNNUE(gEmbeddedNNUESmallData, gEmbeddedNNUESmallEnd, gEmbeddedNNUESmallSize);
+    return EmbeddedNNUE(gEmbeddedNNUEFalconData, gEmbeddedNNUEFalconEnd, gEmbeddedNNUEFalconSize);
 }
 
 }

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -45,6 +45,7 @@ namespace Stockfish::Eval::NNUE {
 enum class EmbeddedNNUEType {
     BIG,
     SMALL,
+    FALCON,
 };
 
 using NetworkOutput = std::tuple<Value, Value>;
@@ -118,17 +119,24 @@ using SmallNetworkArchitecture =
 using BigFeatureTransformer  = FeatureTransformer<TransformedFeatureDimensionsBig>;
 using BigNetworkArchitecture = NetworkArchitecture<TransformedFeatureDimensionsBig, L2Big, L3Big>;
 
+using FalconFeatureTransformer  = FeatureTransformer<TransformedFeatureDimensionsBig>;
+using FalconNetworkArchitecture =
+  NetworkArchitecture<TransformedFeatureDimensionsBig, L2Big, L3Big>;
+
 using NetworkBig   = Network<BigNetworkArchitecture, BigFeatureTransformer>;
 using NetworkSmall = Network<SmallNetworkArchitecture, SmallFeatureTransformer>;
+using NetworkFalcon = Network<FalconNetworkArchitecture, FalconFeatureTransformer>;
 
 
 struct Networks {
-    Networks(NetworkBig&& nB, NetworkSmall&& nS) :
+    Networks(NetworkBig&& nB, NetworkSmall&& nS, NetworkFalcon&& nF) :
         big(std::move(nB)),
-        small(std::move(nS)) {}
+        small(std::move(nS)),
+        falcon(std::move(nF)) {}
 
-    NetworkBig   big;
-    NetworkSmall small;
+    NetworkBig    big;
+    NetworkSmall  small;
+    NetworkFalcon falcon;
 };
 
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -154,13 +154,16 @@ void UCIEngine::loop() {
             sync_cout << compiler_info() << sync_endl;
         else if (token == "export_net")
         {
-            std::pair<std::optional<std::string>, std::string> files[2];
+            std::pair<std::optional<std::string>, std::string> files[3];
 
             if (is >> std::skipws >> files[0].second)
                 files[0].first = files[0].second;
 
             if (is >> std::skipws >> files[1].second)
                 files[1].first = files[1].second;
+
+            if (is >> std::skipws >> files[2].second)
+                files[2].first = files[2].second;
 
             engine.save_network(files);
         }


### PR DESCRIPTION
## Summary
- Add Falcon neural network alongside existing small and big nets
- Update engine name to Wordfish 2.0 with fixed build date
- Credit Stockfish developers, Jorge Ruiz, and ChatGPT in docs and headers

## Testing
- `sh ../scripts/net.sh` *(from `src/`)*
- `make -j2 build ARCH=x86-64-modern`
- `bash tests/perft.sh` *(fails: exit code 127)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a535e23c832796387f6f846f592f