### PR TITLE
Refine root search bounds and add Slow Mover option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Wordfish 2.0 Chess Engine (310825)
+# Wordfish 2.0 dev Chess Engine (010925)
 
 <div align="center">
-  <h3>Wordfish 2.0</h3>
+  <h3>Wordfish 2.0 dev</h3>
 
   A free and open-source UCI chess engine combining classical algorithms with neural network innovations.
   <br>
@@ -78,6 +78,14 @@ Full compilation guides available in [documentation][doc-link].
  `SyzygyPremap` boolean option. When set to `true`, `Tablebases::init` pre-maps all
  available WDL and DTZ tables during initialization, reducing probe latency at the
  expense of additional startup time and memory usage.
+
+## Slow Mover Option
+
+ The `Slow Mover` UCI option controls how aggressively the engine spends its
+ available time during a game. Higher values make Wordfish use a larger
+ percentage of its clock on each move, playing more slowly, while lower values
+ encourage faster play. This setting only affects game play and has no impact
+ when running analysis.
 
 ## Experience Book
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-EXE = wordfish.exe
+EXE = wordfish-2.0-dev.exe
 else
-EXE = wordfish
+EXE = wordfish-2.0-dev
 endif
 
 ### Installation dir definitions
@@ -842,12 +842,12 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 # UCI "id name" string shown in GUIs.
 # Defaults:
-#   - ENGINE_NAME: "Wordfish 2.0"
-#   - ENGINE_BUILD_DATE: 310825 (fixed)
+#   - ENGINE_NAME: "Wordfish 2.0 dev"
+#   - ENGINE_BUILD_DATE: 010925 (fixed)
 # You can override on the command line:
-#   make ENGINE_NAME="Wordfish 2.0" ENGINE_BUILD_DATE=310825
-ENGINE_NAME        ?= Wordfish 2.0
-ENGINE_BUILD_DATE  ?= 310825
+#   make ENGINE_NAME="Wordfish 2.0 dev" ENGINE_BUILD_DATE=010925
+ENGINE_NAME        ?= Wordfish 2.0 dev
+ENGINE_BUILD_DATE  ?= 010925
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 
 ### 3.9 Link Time Optimization

--- a/src/README_CHANGELOG.txt
+++ b/src/README_CHANGELOG.txt
@@ -1,4 +1,4 @@
-Wordfish 2.0
+Wordfish 2.0 dev
 - Initial fork from Stockfish with ideas from Berserk and Obsidian.
 - Updated engine name and build system.
 - Added experience book system with persistent `.exp` file and new UCI options.

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -108,6 +108,7 @@ Engine::Engine(std::optional<std::string> path) :
     options.add("Skill Level", Option(20, 0, 20));
 
     options.add("Move Overhead", Option(10, 0, 5000));
+    options.add("Slow Mover", Option(100, 10, 1000));
 
     options.add("nodestime", Option(0, 0, 10000));
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,5 @@
 /*
-  Wordfish 2.0, a UCI chess engine based on Stockfish, Berserk, and Obsidian
+  Wordfish 2.0 dev, a UCI chess engine based on Stockfish, Berserk, and Obsidian
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
   Copyright (C) 2024 Jorge Ruiz Centelles
   Credits: ChatGPT
@@ -20,11 +20,11 @@
 #include "position.h"
 
 #ifndef ENGINE_BUILD_DATE
-#define ENGINE_BUILD_DATE "310825"
+#define ENGINE_BUILD_DATE "010925"
 #endif
 
 #ifndef ENGINE_NAME
-#define ENGINE_NAME "Wordfish 2.0"
+#define ENGINE_NAME "Wordfish 2.0 dev"
 #endif
 
 using namespace Stockfish;

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -30,10 +30,10 @@
 
 #include "types.h"
 #ifndef ENGINE_BUILD_DATE
-#define ENGINE_BUILD_DATE "310825"
+#define ENGINE_BUILD_DATE "010925"
 #endif
 #ifndef ENGINE_NAME
-#define ENGINE_NAME "Wordfish 2.0"
+#define ENGINE_NAME "Wordfish 2.0 dev"
 #endif
 
 namespace Stockfish {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -360,14 +360,17 @@ void Search::Worker::iterative_deepening() {
             // Reset UCI info selDepth for each depth and each PV line
             selDepth = 0;
 
-            // Reset aspiration window starting size
-            delta     = 5 + std::abs(rootMoves[pvIdx].meanSquaredScore) / 11131;
-            Value avg = rootMoves[pvIdx].averageScore;
-            alpha     = std::max(avg - delta, -VALUE_INFINITE);
-            beta      = std::min(avg + delta, VALUE_INFINITE);
+            // Reset aspiration window starting size using last iteration's
+            // final value (previousScore). Tripple the constant factor to
+            // widen the initial window.
+            delta          = 15 + std::abs(rootMoves[pvIdx].meanSquaredScore) / 11131;
+            Value prev     = rootMoves[pvIdx].previousScore;
+            alpha          = std::max(prev - delta, -VALUE_INFINITE);
+            beta           = std::min(prev + delta, VALUE_INFINITE);
+            Move prevBest  = rootMoves[pvIdx].pv[0];
 
-            // Adjust optimism based on root move's averageScore
-            optimism[us]  = 136 * avg / (std::abs(avg) + 93);
+            // Adjust optimism based on root move's previous score
+            optimism[us]  = 136 * prev / (std::abs(prev) + 93);
             optimism[~us] = -optimism[us];
 
             // Start with a small aspiration window and, in the case of a fail
@@ -404,11 +407,16 @@ void Search::Worker::iterative_deepening() {
                     && nodes > 10000000)
                     main_manager()->pv(*this, threads, tt, rootDepth);
 
-                // In case of failing low/high increase aspiration window and re-search,
-                // otherwise exit the loop.
+                // In case of failing low/high increase aspiration window and
+                // re-search, otherwise exit the loop. New bounds depend on the
+                // old window, the score +/- delta and whether the best move
+                // has changed.
+                bool bestMoveChanged = rootMoves[pvIdx].pv[0] != prevBest;
+                prevBest             = rootMoves[pvIdx].pv[0];
+
                 if (bestValue <= alpha)
                 {
-                    beta  = (3 * alpha + beta) / 4;
+                    beta  = (alpha + beta) / 2;  // ignore FLB[0] params
                     alpha = std::max(bestValue - delta, -VALUE_INFINITE);
 
                     failedHighCnt = 0;
@@ -417,14 +425,19 @@ void Search::Worker::iterative_deepening() {
                 }
                 else if (bestValue >= beta)
                 {
+                    if (bestMoveChanged)
+                        alpha = std::max(bestValue - delta, -VALUE_INFINITE);
+                    else
+                        alpha = (alpha + beta) / 2;
+
                     beta = std::min(bestValue + delta, VALUE_INFINITE);
                     ++failedHighCnt;
                 }
                 else
                     break;
 
-                delta += delta / 3;
-
+                delta += 2 * delta;  // triple C behaviour on subsequent tries
+                
                 assert(alpha >= -VALUE_INFINITE && beta <= VALUE_INFINITE);
             }
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -128,6 +128,11 @@ void TimeManagement::init(Search::LimitsType& limits,
         maxScale = 1.3 + 0.11 * (centiMTG / 100.0);
     }
 
+    // Scale allocated time according to the Slow Mover option (percentage)
+    double slowMover = options["Slow Mover"] / 100.0;
+    optScale *= slowMover;
+    maxScale *= slowMover;
+
     // Limit the maximum possible time for this move
     optimumTime = TimePoint(optScale * timeLeft);
     maximumTime =

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -114,7 +114,7 @@ void UCIEngine::loop() {
 
         else if (token == "uci")
         {
-            // Force a stable, explicit UCI name so GUIs show "Wordfish 2.0 <date>"
+            // Force a stable, explicit UCI name so GUIs show "Wordfish 2.0 dev <date>"
             sync_cout << "id name " << ENGINE_NAME << ' ' << ENGINE_BUILD_DATE << "\n"
                 << "id author Stockfish developers, Jorge Ruiz Centelles and ChatGPT" << "\n"
                 << engine.get_options() << sync_endl;

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -13,10 +13,10 @@
 #include "ucioption.h"
 // --- Engine identity (fallbacks; Makefile can override) ---
 #ifndef ENGINE_NAME
-#define ENGINE_NAME "Wordfish 2.0"
+#define ENGINE_NAME "Wordfish 2.0 dev"
 #endif
 #ifndef ENGINE_BUILD_DATE
-#define ENGINE_BUILD_DATE "310825"  // overridden by Makefile if provided
+#define ENGINE_BUILD_DATE "010925"  // overridden by Makefile if provided
 #endif
 
 


### PR DESCRIPTION
## Summary
- Tune root aspiration window using previous scores and track best-move changes for fail re-searches
- Add "Slow Mover" UCI option and integrate into time management
- Rename executable and defaults to "Wordfish 2.0 dev" with build date 010925

## Testing
- `make build ARCH=x86-64-sse41-popcnt -j2`
- `./src/wordfish-2.0-dev bench 1`


------
https://chatgpt.com/codex/tasks/task_e_68b5ad86810483278480f8cdb0c386a4