### PR TITLE
Improve experience file handling and options

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -165,16 +165,23 @@ Engine::Engine(std::optional<std::string> path) :
     options.add("Book2 Width", Option(1, 1, 10));
 
     options.add("Experience Enabled", Option(true, [this](const Option& o) {
-                    if (bool(o))
+                    if (bool(o)) {
                         experience.load(options["Experience File"]);
-                    else
+                    } else {
+                        if (!(bool) options["Experience Readonly"])
+                            experience.save(options["Experience File"]);
                         experience.clear();
+                    }
                     return std::nullopt;
                 }));
 
     options.add("Experience File", Option("wordfish.exp", [this](const Option& o) {
-                    if ((bool) options["Experience Enabled"])
+                    if ((bool) options["Experience Enabled"]) {
+                        if (!(bool) options["Experience Readonly"])
+                            experience.save(options["Experience File"]);
+                        experience.clear();
                         experience.load(o);
+                    }
                     return std::nullopt;
                 }));
 

--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -3,6 +3,8 @@
 #include <algorithm>
 #include <fstream>
 #include <sstream>
+#include <cstdint>
+#include <cstring>
 
 namespace Stockfish {
 
@@ -10,22 +12,69 @@ Experience experience;
 
 void Experience::clear() { table.clear(); }
 
+namespace {
+
+constexpr char SugarExpMagic[] = "SugaR Experience version 2\n";
+
+#pragma pack(push, 1)
+struct SugarHeader {
+    uint32_t version;
+    uint32_t reserved;
+};
+
+struct SugarRecord {
+    uint32_t move1, visits1, key1_lo, key1_hi;
+    int32_t  score1;
+    uint32_t depth1;
+    uint32_t move2, visits2, key2_lo, key2_hi;
+    int32_t  score2;
+    uint32_t depth2;
+    uint32_t extraA, extraB;
+};
+#pragma pack(pop)
+
+static_assert(sizeof(SugarRecord) == 56);
+
+}  // namespace
+
 void Experience::load(const std::string& file) {
     std::ifstream in(file, std::ios::binary);
     if (!in)
         return;
     table.clear();
-    while (true) {
-        uint64_t key;
-        unsigned move;
-        int      score, depth, count;
-        if (!in.read(reinterpret_cast<char*>(&key), sizeof(key)))
-            break;
-        in.read(reinterpret_cast<char*>(&move), sizeof(move));
-        in.read(reinterpret_cast<char*>(&score), sizeof(score));
-        in.read(reinterpret_cast<char*>(&depth), sizeof(depth));
-        in.read(reinterpret_cast<char*>(&count), sizeof(count));
-        table[key].emplace_back(ExperienceEntry{Move(static_cast<std::uint16_t>(move)), score, depth, count});
+
+    char magic[sizeof(SugarExpMagic) - 1];
+    if (!in.read(magic, sizeof(magic))
+        || std::memcmp(magic, SugarExpMagic, sizeof(magic)) != 0)
+        return;
+
+    SugarHeader header;
+    if (!in.read(reinterpret_cast<char*>(&header), sizeof(header))
+        || header.version != 2)
+        return;
+
+    SugarRecord rec;
+    while (in.read(reinterpret_cast<char*>(&rec), sizeof(rec))) {
+        if (rec.move1) {
+            uint64_t key = (uint64_t(rec.key1_hi) << 32) | rec.key1_lo;
+            table[key].emplace_back(
+              ExperienceEntry{Move(static_cast<int>(rec.move1)),
+                              static_cast<int16_t>(rec.score1),
+                              static_cast<int16_t>(rec.depth1),
+                              static_cast<uint16_t>(
+                                std::max<uint32_t>(1,
+                                  std::min(rec.visits1, uint32_t(65535))))});
+        }
+        if (rec.move2) {
+            uint64_t key = (uint64_t(rec.key2_hi) << 32) | rec.key2_lo;
+            table[key].emplace_back(
+              ExperienceEntry{Move(static_cast<int>(rec.move2)),
+                              static_cast<int16_t>(rec.score2),
+                              static_cast<int16_t>(rec.depth2),
+                              static_cast<uint16_t>(
+                                std::max<uint32_t>(1,
+                                  std::min(rec.visits2, uint32_t(65535))))});
+        }
     }
 }
 
@@ -33,15 +82,40 @@ void Experience::save(const std::string& file) const {
     std::ofstream out(file, std::ios::binary);
     if (!out)
         return;
-    for (const auto& [key, vec] : table)
-        for (const auto& e : vec) {
-            unsigned move = e.move.raw();
-            out.write(reinterpret_cast<const char*>(&key), sizeof(key));
-            out.write(reinterpret_cast<const char*>(&move), sizeof(move));
-            out.write(reinterpret_cast<const char*>(&e.score), sizeof(e.score));
-            out.write(reinterpret_cast<const char*>(&e.depth), sizeof(e.depth));
-            out.write(reinterpret_cast<const char*>(&e.count), sizeof(e.count));
+
+    out.write(SugarExpMagic, sizeof(SugarExpMagic) - 1);
+    SugarHeader header{2, 0};
+    out.write(reinterpret_cast<const char*>(&header), sizeof(header));
+
+    for (const auto& [key, vecOrig] : table) {
+        auto vec = vecOrig;
+        std::sort(vec.begin(), vec.end(),
+                  [](const ExperienceEntry& a, const ExperienceEntry& b) {
+                      return a.count > b.count;
+                  });
+        for (size_t i = 0; i < vec.size(); i += 2) {
+            SugarRecord rec{};
+            const auto& e1 = vec[i];
+            rec.move1   = static_cast<uint32_t>(e1.move.raw());
+            rec.visits1 = static_cast<uint32_t>(e1.count);
+            rec.key1_lo = static_cast<uint32_t>(key & 0xFFFFFFFFu);
+            rec.key1_hi = static_cast<uint32_t>(key >> 32);
+            rec.score1  = static_cast<int32_t>(e1.score);
+            rec.depth1  = static_cast<uint32_t>(e1.depth);
+
+            if (i + 1 < vec.size()) {
+                const auto& e2 = vec[i + 1];
+                rec.move2   = static_cast<uint32_t>(e2.move.raw());
+                rec.visits2 = static_cast<uint32_t>(e2.count);
+                rec.key2_lo = rec.key1_lo;
+                rec.key2_hi = rec.key1_hi;
+                rec.score2  = static_cast<int32_t>(e2.score);
+                rec.depth2  = static_cast<uint32_t>(e2.depth);
+            }
+
+            out.write(reinterpret_cast<const char*>(&rec), sizeof(rec));
         }
+    }
 }
 
 Move Experience::probe(Position& pos, [[maybe_unused]] int width,
@@ -55,12 +129,13 @@ Move Experience::probe(Position& pos, [[maybe_unused]] int width,
         return Move::none();
 
     std::sort(vec.begin(), vec.end(), [&](const ExperienceEntry& a, const ExperienceEntry& b) {
-        return (a.score + evalImportance * a.depth) > (b.score + evalImportance * b.depth);
+        return (int(a.score) + evalImportance * int(a.depth))
+             > (int(b.score) + evalImportance * int(b.depth));
     });
 
     vec.resize(std::min<int>(maxMoves, static_cast<int>(vec.size())));
     const auto& best = vec.front();
-    if (best.depth < minDepth)
+    if (int(best.depth) < minDepth)
         return Move::none();
 
     return best.move;
@@ -71,12 +146,12 @@ void Experience::update(Position& pos, Move move, int score, int depth) {
     for (auto& e : vec)
         if (e.move == move)
         {
-            e.score = score;
-            e.depth = depth;
-            e.count++;
+            e.score = static_cast<int16_t>(score);
+            e.depth = static_cast<int16_t>(depth);
+            e.count = static_cast<uint16_t>(e.count + 1);
             return;
         }
-    vec.push_back({move, score, depth, 1});
+    vec.push_back({move, static_cast<int16_t>(score), static_cast<int16_t>(depth), 1});
 }
 
 }  // namespace Stockfish

--- a/src/experience.h
+++ b/src/experience.h
@@ -4,6 +4,7 @@
 #include <unordered_map>
 #include <vector>
 #include <string>
+#include <cstdint>
 
 #include "position.h"
 #include "types.h"
@@ -11,10 +12,10 @@
 namespace Stockfish {
 
 struct ExperienceEntry {
-    Move move;
-    int  score;
-    int  depth;
-    int  count;
+    Move      move;
+    int16_t   score;
+    int16_t   depth;
+    uint16_t  count;
 };
 
 class Experience {


### PR DESCRIPTION
## Summary
- Align saved experience files with HypnoS SugaR v2 format, using ASCII header and 56-byte records
- Parse the same format when loading, splitting Zobrist keys and preserving move data

## Testing
- `cd src && make build`


------
https://chatgpt.com/codex/tasks/task_e_68b8f47501d4832790308ec61af082e4