### PR TITLE
Load experience file from binary directory

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -166,10 +166,10 @@ Engine::Engine(std::optional<std::string> path) :
 
     options.add("Experience Enabled", Option(true, [this](const Option& o) {
                     if (bool(o)) {
-                        experience.load(options["Experience File"]);
+                        experience.load(experience_path(options["Experience File"]));
                     } else {
                         if (!(bool) options["Experience Readonly"])
-                            experience.save(options["Experience File"]);
+                            experience.save(experience_path(options["Experience File"]));
                         experience.clear();
                     }
                     return std::nullopt;
@@ -178,9 +178,9 @@ Engine::Engine(std::optional<std::string> path) :
     options.add("Experience File", Option("wordfish.exp", [this](const Option& o) {
                     if ((bool) options["Experience Enabled"]) {
                         if (!(bool) options["Experience Readonly"])
-                            experience.save(options["Experience File"]);
+                            experience.save(experience_path(options["Experience File"]));
                         experience.clear();
-                        experience.load(o);
+                        experience.load(experience_path(o));
                     }
                     return std::nullopt;
                 }));
@@ -211,7 +211,7 @@ Engine::Engine(std::optional<std::string> path) :
       }));
 
     if ((bool) options["Experience Enabled"])
-        experience.load(options["Experience File"]);
+        experience.load(experience_path(options["Experience File"]));
 
     load_networks();
     resize_threads();
@@ -242,7 +242,12 @@ void Engine::search_clear() {
     Tablebases::release();
 
     if ((bool) options["Experience Enabled"] && !(bool) options["Experience Readonly"])
-        experience.save(options["Experience File"]);
+        experience.save(experience_path(options["Experience File"]));
+}
+
+std::string Engine::experience_path(const std::string& file) const {
+    std::ifstream in(binaryDirectory + file);
+    return in.good() ? binaryDirectory + file : file;
 }
 
 void Engine::set_on_update_no_moves(std::function<void(const Engine::InfoShort&)>&& f) {

--- a/src/engine.h
+++ b/src/engine.h
@@ -123,6 +123,8 @@ class Engine {
 
     Search::SearchManager::UpdateContext  updateContext;
     std::function<void(std::string_view)> onVerifyNetworks;
+
+    std::string experience_path(const std::string& file) const;
 };
 
 }  // namespace Stockfish


### PR DESCRIPTION
## Summary
- Resolve experience file relative to the engine binary
- Centralize experience file path handling in a helper

## Testing
- `make -C src build`
- `./wordfish-2.0-dev bench`


------
https://chatgpt.com/codex/tasks/task_e_68b90a557e90832782acc21829a6b788