### PR TITLE
Validate experience file header and handle truncated files

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -166,7 +166,9 @@ Engine::Engine(std::optional<std::string> path) :
 
     options.add("Experience Enabled", Option(true, [this](const Option& o) {
                     if (bool(o)) {
-                        experience.load(experience_path(options["Experience File"]));
+                        experience.load(
+                          experience_path(options["Experience File"]),
+                          (bool) options["Experience Readonly"]);
                     } else {
                         if (!(bool) options["Experience Readonly"])
                             experience.save(experience_path(options["Experience File"]));
@@ -180,7 +182,8 @@ Engine::Engine(std::optional<std::string> path) :
                         if (!(bool) options["Experience Readonly"])
                             experience.save(experience_path(options["Experience File"]));
                         experience.clear();
-                        experience.load(experience_path(o));
+                        experience.load(
+                          experience_path(o), (bool) options["Experience Readonly"]);
                     }
                     return std::nullopt;
                 }));
@@ -211,7 +214,9 @@ Engine::Engine(std::optional<std::string> path) :
       }));
 
     if ((bool) options["Experience Enabled"])
-        experience.load(experience_path(options["Experience File"]));
+        experience.load(
+          experience_path(options["Experience File"]),
+          (bool) options["Experience Readonly"]);
 
     load_networks();
     resize_threads();

--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -41,24 +41,25 @@ static_assert(sizeof(SugarEntry) == 34, "SugarEntry must be 34 bytes");
 
 }  // namespace
 
-void Experience::load(const std::string& file) {
+void Experience::load(const std::string& file, bool readonly) {
     std::ifstream in(file, std::ios::binary | std::ios::ate);
-    bool          create = false;
-    if (!in)
-        create = true;
-    else if (std::size_t(in.tellg()) < SugarExpHeaderSize + sizeof(SugarEntry) * SugarExpTableSize)
-        create = true;
+    std::size_t   size = in ? static_cast<std::size_t>(in.tellg()) : 0;
 
-    if (create)
+    if (!in || size < SugarExpHeaderSize + sizeof(SugarEntry) * SugarExpTableSize)
     {
+        if (readonly)
+            return;
+
         std::ofstream out(file, std::ios::binary | std::ios::trunc);
         if (!out)
             return;
+
         out.write(SugarExpMagic, sizeof(SugarExpMagic) - 1);
         out.write(reinterpret_cast<const char*>(SugarExpBlock), sizeof(SugarExpBlock));
         std::vector<char> zero(sizeof(SugarEntry) * SugarExpTableSize, 0);
         out.write(zero.data(), zero.size());
         out.close();
+
         in.open(file, std::ios::binary | std::ios::ate);
         if (!in)
             return;
@@ -71,10 +72,10 @@ void Experience::load(const std::string& file) {
     if (!in.read(magic, sizeof(magic)) || std::memcmp(magic, SugarExpMagic, sizeof(magic)) != 0)
         return;
 
-    std::uint8_t block[sizeof(SugarExpBlock)];
-    if (!in.read(reinterpret_cast<char*>(block), sizeof(block))
-        || std::memcmp(block, SugarExpBlock, sizeof(block)) != 0)
+    std::uint8_t version;
+    if (!in.read(reinterpret_cast<char*>(&version), 1) || version != 2)
         return;
+    in.ignore(sizeof(SugarExpBlock) - 1);
 
     SugarEntry rec;
     for (std::size_t i = 0;

--- a/src/experience.h
+++ b/src/experience.h
@@ -21,7 +21,7 @@ struct ExperienceEntry {
 class Experience {
    public:
     void clear();
-    void load(const std::string& file);
+    void load(const std::string& file, bool readonly);
     void save(const std::string& file) const;
     Move probe(
       Position& pos, [[maybe_unused]] int width, int evalImportance, int minDepth, int maxMoves);


### PR DESCRIPTION
## Summary
- open experience files without truncating and verify magic, version and size
- recreate incomplete experience files when not in readonly mode
- propagate readonly flag when loading experience data

## Testing
- `make build ARCH=x86-64-avx2 -j2`


------
https://chatgpt.com/codex/tasks/task_e_68b9184cfc6083279fd6685d2ba9cc3b