### PR TITLE
Improve experience book integration and table management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Wordfish 2.0 dev Chess Engine (010925)
+#Wordfish 2.0 dev Chess Engine(010925)
 
 <div align="center">
   <h3>Wordfish 2.0 dev</h3>
@@ -93,7 +93,7 @@ Full compilation guides available in [documentation][doc-link].
 Las siguientes opciones UCI controlan este sistema:
 
 - `Experience Enabled`: activa o desactiva la experiencia (por defecto `true`).
- - `Experience File`: nombre del archivo donde se almacena la experiencia (por defecto `wordfish.exp`).
+- `Experience File`: nombre del archivo donde se almacena la experiencia (por defecto `wordfish.exp`). La ruta admite caracteres Unicode y se recarga al usar `setoption`, `isready` y `ucinewgame`.
 - `Experience Readonly`: si es `true`, no se escriben cambios en el archivo.
 - `Experience Book`: usa la experiencia como libro de aperturas.
 - `Experience Book Width`: número de movimientos principales a considerar (1–20).

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -22,6 +22,7 @@
 #include <cassert>
 #include <deque>
 #include <fstream>
+#include <filesystem>
 #include <iosfwd>
 #include <memory>
 #include <ostream>
@@ -63,8 +64,7 @@ Engine::Engine(std::optional<std::string> path) :
       NN::Networks(
         NN::NetworkBig({EvalFileDefaultNameBig, "None", ""}, NN::EmbeddedNNUEType::BIG),
         NN::NetworkSmall({EvalFileDefaultNameSmall, "None", ""}, NN::EmbeddedNNUEType::SMALL),
-        NN::NetworkFalcon({EvalFileDefaultNameFalcon, "None", ""},
-                          NN::EmbeddedNNUEType::FALCON))) {
+        NN::NetworkFalcon({EvalFileDefaultNameFalcon, "None", ""}, NN::EmbeddedNNUEType::FALCON))) {
     pos.set(StartFEN, false, &states->back());
 
 
@@ -165,11 +165,13 @@ Engine::Engine(std::optional<std::string> path) :
     options.add("Book2 Width", Option(1, 1, 10));
 
     options.add("Experience Enabled", Option(true, [this](const Option& o) {
-                    if (bool(o)) {
-                        experience.load(
-                          experience_path(options["Experience File"]),
-                          (bool) options["Experience Readonly"]);
-                    } else {
+                    if (bool(o))
+                    {
+                        experience.load(experience_path(options["Experience File"]),
+                                        (bool) options["Experience Readonly"]);
+                    }
+                    else
+                    {
                         if (!(bool) options["Experience Readonly"])
                             experience.save(experience_path(options["Experience File"]));
                         experience.clear();
@@ -178,12 +180,12 @@ Engine::Engine(std::optional<std::string> path) :
                 }));
 
     options.add("Experience File", Option("wordfish.exp", [this](const Option& o) {
-                    if ((bool) options["Experience Enabled"]) {
+                    if ((bool) options["Experience Enabled"])
+                    {
                         if (!(bool) options["Experience Readonly"])
                             experience.save(experience_path(options["Experience File"]));
                         experience.clear();
-                        experience.load(
-                          experience_path(o), (bool) options["Experience Readonly"]);
+                        experience.load(experience_path(o), (bool) options["Experience Readonly"]);
                     }
                     return std::nullopt;
                 }));
@@ -214,9 +216,8 @@ Engine::Engine(std::optional<std::string> path) :
       }));
 
     if ((bool) options["Experience Enabled"])
-        experience.load(
-          experience_path(options["Experience File"]),
-          (bool) options["Experience Readonly"]);
+        experience.load(experience_path(options["Experience File"]),
+                        (bool) options["Experience Readonly"]);
 
     load_networks();
     resize_threads();
@@ -250,9 +251,17 @@ void Engine::search_clear() {
         experience.save(experience_path(options["Experience File"]));
 }
 
-std::string Engine::experience_path(const std::string& file) const {
-    std::ifstream in(binaryDirectory + file);
-    return in.good() ? binaryDirectory + file : file;
+void Engine::reload_experience() {
+    if ((bool) options["Experience Enabled"])
+        experience.load(experience_path(options["Experience File"]),
+                        (bool) options["Experience Readonly"]);
+}
+
+std::filesystem::path Engine::experience_path(const std::string& file) const {
+    namespace fs = std::filesystem;
+    fs::path p   = fs::u8path(file);
+    fs::path bp  = fs::u8path(binaryDirectory) / p;
+    return fs::exists(bp) ? bp : p;
 }
 
 void Engine::set_on_update_no_moves(std::function<void(const Engine::InfoShort&)>&& f) {

--- a/src/engine.h
+++ b/src/engine.h
@@ -27,6 +27,7 @@
 #include <string_view>
 #include <utility>
 #include <vector>
+#include <filesystem>
 
 #include "nnue/network.h"
 #include "numa.h"
@@ -74,6 +75,7 @@ class Engine {
     void set_tt_size(size_t mb);
     void set_ponderhit(bool);
     void search_clear();
+    void reload_experience();
 
     void set_on_update_no_moves(std::function<void(const InfoShort&)>&&);
     void set_on_update_full(std::function<void(const InfoFull&)>&&);
@@ -124,7 +126,7 @@ class Engine {
     Search::SearchManager::UpdateContext  updateContext;
     std::function<void(std::string_view)> onVerifyNetworks;
 
-    std::string experience_path(const std::string& file) const;
+    std::filesystem::path experience_path(const std::string& file) const;
 };
 
 }  // namespace Stockfish

--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -3,14 +3,13 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <vector>
 
 namespace Stockfish {
 
 Experience experience;
-
-void Experience::clear() { table.clear(); }
 
 namespace {
 
@@ -19,33 +18,24 @@ constexpr std::uint8_t SugarExpBlock[16] = {0x02, 0x00, 0x80, 0xE2, 0x63, 0xA4, 
                                             0x10, 0x06, 0x00, 0x00, 0x22, 0x00, 0x00, 0x00};
 
 constexpr std::size_t SugarExpHeaderSize = (sizeof(SugarExpMagic) - 1) + sizeof(SugarExpBlock);
-constexpr std::size_t SugarExpTableSize  = 1ULL << 16;  // must be power of two
 
-#pragma pack(push, 1)
-struct SugarEntry {
-    std::uint64_t key;
-    std::uint16_t move;
-    std::int16_t  score;
-    std::int16_t  depth;
-    std::int16_t  count;
-    std::int32_t  wins;
-    std::int32_t  losses;
-    std::int32_t  draws;
-    std::int16_t  flags;
-    std::int16_t  age;
-    std::int16_t  pad;
+struct ExperienceEntry {
+    Move move;
+    int  score;
+    int  depth;
+    int  count;
 };
-#pragma pack(pop)
-
-static_assert(sizeof(SugarEntry) == 34, "SugarEntry must be 34 bytes");
 
 }  // namespace
 
-void Experience::load(const std::string& file, bool readonly) {
+void Experience::clear() { table.fill({}); }
+
+void Experience::load(const std::filesystem::path& file, bool readonly) {
+    readOnly = readonly;
     std::ifstream in(file, std::ios::binary | std::ios::ate);
     std::size_t   size = in ? static_cast<std::size_t>(in.tellg()) : 0;
 
-    if (!in || size < SugarExpHeaderSize + sizeof(SugarEntry) * SugarExpTableSize)
+    if (!in || size < SugarExpHeaderSize + sizeof(ExperienceSlot) * TableSize)
     {
         if (readonly)
             return;
@@ -56,8 +46,9 @@ void Experience::load(const std::string& file, bool readonly) {
 
         out.write(SugarExpMagic, sizeof(SugarExpMagic) - 1);
         out.write(reinterpret_cast<const char*>(SugarExpBlock), sizeof(SugarExpBlock));
-        std::vector<char> zero(sizeof(SugarEntry) * SugarExpTableSize, 0);
-        out.write(zero.data(), zero.size());
+        ExperienceSlot zero{};
+        for (std::size_t i = 0; i < TableSize; ++i)
+            out.write(reinterpret_cast<const char*>(&zero), sizeof(zero));
         out.close();
 
         in.open(file, std::ios::binary | std::ios::ate);
@@ -66,7 +57,7 @@ void Experience::load(const std::string& file, bool readonly) {
     }
 
     in.seekg(0);
-    table.clear();
+    table.fill({});
 
     char magic[sizeof(SugarExpMagic) - 1];
     if (!in.read(magic, sizeof(magic)) || std::memcmp(magic, SugarExpMagic, sizeof(magic)) != 0)
@@ -77,56 +68,39 @@ void Experience::load(const std::string& file, bool readonly) {
         return;
     in.ignore(sizeof(SugarExpBlock) - 1);
 
-    SugarEntry rec;
-    for (std::size_t i = 0;
-         i < SugarExpTableSize && in.read(reinterpret_cast<char*>(&rec), sizeof(rec)); ++i)
-    {
-        if (rec.move)
-        {
-            int ct = rec.count <= 0 ? 1 : rec.count;
-            table[rec.key].push_back({Move(static_cast<int>(rec.move)), rec.score, rec.depth, ct});
-        }
-    }
+    in.read(reinterpret_cast<char*>(table.data()), table.size() * sizeof(ExperienceSlot));
 }
 
-void Experience::save(const std::string& file) const {
-    std::vector<SugarEntry> tableBin(SugarExpTableSize);
-
-    for (const auto& [key, vec] : table)
-        for (const auto& e : vec)
-        {
-            std::size_t idx = static_cast<std::size_t>(key) & (SugarExpTableSize - 1);
-            for (std::size_t n = 0; n < SugarExpTableSize; ++n)
-            {
-                SugarEntry& rec = tableBin[idx];
-                if (rec.move == 0)
-                {
-                    rec.key   = key;
-                    rec.move  = static_cast<std::uint16_t>(e.move.raw());
-                    rec.score = static_cast<std::int16_t>(e.score);
-                    rec.depth = static_cast<std::int16_t>(e.depth);
-                    rec.count = static_cast<std::int16_t>(std::clamp(e.count, 0, 32767));
-                    break;
-                }
-                idx = (idx + 1) & (SugarExpTableSize - 1);
-            }
-        }
-
+void Experience::save(const std::filesystem::path& file) const {
+    if (readOnly)
+        return;
     std::ofstream out(file, std::ios::binary | std::ios::trunc);
     if (!out)
         return;
     out.write(SugarExpMagic, sizeof(SugarExpMagic) - 1);
     out.write(reinterpret_cast<const char*>(SugarExpBlock), sizeof(SugarExpBlock));
-    out.write(reinterpret_cast<const char*>(tableBin.data()), tableBin.size() * sizeof(SugarEntry));
+    out.write(reinterpret_cast<const char*>(table.data()), table.size() * sizeof(ExperienceSlot));
 }
 
 Move Experience::probe(
-  Position& pos, [[maybe_unused]] int width, int evalImportance, int minDepth, int maxMoves) {
-    auto it = table.find(pos.key());
-    if (it == table.end())
-        return Move::none();
+  const Position& pos, [[maybe_unused]] int width, int evalImportance, int minDepth, int maxMoves) {
+    Key                          key = pos.key();
+    std::vector<ExperienceEntry> vec;
 
-    auto vec = it->second;
+    std::size_t idx = static_cast<std::size_t>(key) & (TableSize - 1);
+    for (std::size_t n = 0; n < TableSize; ++n)
+    {
+        const ExperienceSlot& rec = table[idx];
+        if (rec.move == 0)
+            break;
+        if (rec.key == key)
+        {
+            int ct = rec.count <= 0 ? 1 : rec.count;
+            vec.push_back({Move(static_cast<int>(rec.move)), rec.score, rec.depth, ct});
+        }
+        idx = (idx + 1) & (TableSize - 1);
+    }
+
     if (vec.empty())
         return Move::none();
 
@@ -142,17 +116,36 @@ Move Experience::probe(
     return best.move;
 }
 
-void Experience::update(Position& pos, Move move, int score, int depth) {
-    auto& vec = table[pos.key()];
-    for (auto& e : vec)
-        if (e.move == move)
+void Experience::update(const Position& pos, Move move, int score, int depth) {
+    if (readOnly)
+        return;
+
+    Key           key = pos.key();
+    std::uint16_t mv  = static_cast<std::uint16_t>(move.raw());
+    std::size_t   idx = static_cast<std::size_t>(key) & (TableSize - 1);
+
+    for (std::size_t n = 0; n < TableSize; ++n)
+    {
+        ExperienceSlot& rec = table[idx];
+        if (rec.move == 0)
         {
-            e.score = score;
-            e.depth = depth;
-            e.count++;
+            rec.key   = key;
+            rec.move  = mv;
+            rec.score = static_cast<std::int16_t>(score);
+            rec.depth = static_cast<std::int16_t>(depth);
+            rec.count = 1;
             return;
         }
-    vec.push_back({move, score, depth, 1});
+        if (rec.key == key && rec.move == mv)
+        {
+            rec.score = static_cast<std::int16_t>(score);
+            rec.depth = static_cast<std::int16_t>(depth);
+            if (rec.count < 32767)
+                rec.count++;
+            return;
+        }
+        idx = (idx + 1) & (TableSize - 1);
+    }
 }
 
 }  // namespace Stockfish

--- a/src/experience.h
+++ b/src/experience.h
@@ -1,34 +1,50 @@
 #ifndef EXPERIENCE_H_INCLUDED
 #define EXPERIENCE_H_INCLUDED
 
-#include <unordered_map>
-#include <vector>
-#include <string>
+#include <array>
 #include <cstdint>
+#include <filesystem>
 
 #include "position.h"
 #include "types.h"
 
 namespace Stockfish {
 
-struct ExperienceEntry {
-    Move move;
-    int  score;
-    int  depth;
-    int  count;
+#pragma pack(push, 1)
+struct ExperienceSlot {
+    std::uint64_t key;
+    std::uint16_t move;
+    std::int16_t  score;
+    std::int16_t  depth;
+    std::int16_t  count;
+    std::int32_t  wins;
+    std::int32_t  losses;
+    std::int32_t  draws;
+    std::int16_t  flags;
+    std::int16_t  age;
+    std::int16_t  pad;
 };
+#pragma pack(pop)
+
+static_assert(sizeof(ExperienceSlot) == 34, "ExperienceSlot must be 34 bytes");
 
 class Experience {
    public:
     void clear();
-    void load(const std::string& file, bool readonly);
-    void save(const std::string& file) const;
-    Move probe(
-      Position& pos, [[maybe_unused]] int width, int evalImportance, int minDepth, int maxMoves);
-    void update(Position& pos, Move move, int score, int depth);
+    void load(const std::filesystem::path& file, bool readonly);
+    void save(const std::filesystem::path& file) const;
+    Move probe(const Position&      pos,
+               [[maybe_unused]] int width,
+               int                  evalImportance,
+               int                  minDepth,
+               int                  maxMoves);
+    void update(const Position& pos, Move move, int score, int depth);
 
    private:
-    std::unordered_map<Key, std::vector<ExperienceEntry>> table;
+    static constexpr std::size_t TableSize = 1ULL << 16;  // must be power of two
+    static_assert((TableSize & (TableSize - 1)) == 0, "TableSize must be power of two");
+    std::array<ExperienceSlot, TableSize> table{};
+    bool                                  readOnly = false;
 };
 
 extern Experience experience;

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -88,7 +88,8 @@ MovePicker::MovePicker(const Position&              p,
                        const CapturePieceToHistory* cph,
                        const PieceToHistory**       ch,
                        const PawnHistory*           ph,
-                       int                          pl) :
+                       int                          pl,
+                       Move                         em) :
     pos(p),
     mainHistory(mh),
     lowPlyHistory(lph),
@@ -97,7 +98,8 @@ MovePicker::MovePicker(const Position&              p,
     pawnHistory(ph),
     ttMove(ttm),
     depth(d),
-    ply(pl) {
+    ply(pl),
+    expMove(em) {
 
     if (pos.checkers())
         stage = EVASION_TT + !(ttm && pos.pseudo_legal(ttm));
@@ -108,11 +110,13 @@ MovePicker::MovePicker(const Position&              p,
 
 // MovePicker constructor for ProbCut: we generate captures with Static Exchange
 // Evaluation (SEE) greater than or equal to the given threshold.
-MovePicker::MovePicker(const Position& p, Move ttm, int th, const CapturePieceToHistory* cph) :
+MovePicker::MovePicker(
+  const Position& p, Move ttm, int th, const CapturePieceToHistory* cph, Move em) :
     pos(p),
     captureHistory(cph),
     ttMove(ttm),
-    threshold(th) {
+    threshold(th),
+    expMove(em) {
     assert(!pos.checkers());
 
     stage = PROBCUT_TT
@@ -192,6 +196,9 @@ ExtMove* MovePicker::score(MoveList<Type>& ml) {
                     m.value += 2 * (*lowPlyHistory)[ply][m.from_to()] / (1 + ply);
             }
         }
+
+        if (expMove && m == expMove)
+            m.value += 1 << 30;
     }
     return it;
 }

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -46,8 +46,9 @@ class MovePicker {
                const CapturePieceToHistory*,
                const PieceToHistory**,
                const PawnHistory*,
-               int);
-    MovePicker(const Position&, Move, int, const CapturePieceToHistory*);
+               int,
+               Move = Move::none());
+    MovePicker(const Position&, Move, int, const CapturePieceToHistory*, Move = Move::none());
     Move next_move();
     void skip_quiet_moves();
     bool can_move_king_or_pawn() const;
@@ -74,6 +75,7 @@ class MovePicker {
     int                          ply;
     bool                         skipQuiets = false;
     ExtMove                      moves[MAX_MOVES];
+    Move                         expMove;
 };
 
 }  // namespace Stockfish

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -173,7 +173,16 @@ void Search::Worker::start_searching() {
                             main_manager()->originalTimeAdjust);
     tt.new_search();
 
+    Move orderMove = Move::none();
+    if ((bool) options["Experience Enabled"])
+        orderMove = experience.probe(rootPos, (int) options["Experience Book Width"],
+                                     (int) options["Experience Book Eval Importance"],
+                                     (int) options["Experience Book Min Depth"],
+                                     (int) options["Experience Book Max Moves"]);
+
     Move bookMove = Move::none();
+    if ((bool) options["Experience Enabled"] && (bool) options["Experience Book"])
+        bookMove = orderMove;
 
     if (rootMoves.empty())
     {
@@ -185,12 +194,6 @@ void Search::Worker::start_searching() {
     {
         if (!limits.infinite && !limits.mate)
         {
-            if ((bool) options["Experience Enabled"] && (bool) options["Experience Book"])
-                bookMove = experience.probe(rootPos, (int) options["Experience Book Width"],
-                                            (int) options["Experience Book Eval Importance"],
-                                            (int) options["Experience Book Min Depth"],
-                                            (int) options["Experience Book Max Moves"]);
-
             if (bookMove == Move::none() && (bool) options["Book1"]
                 && rootPos.game_ply() / 2 < (int) options["Book1 Depth"])
                 bookMove = polybook[0].probe(rootPos, (bool) options["Book1 BestBookMove"],
@@ -212,6 +215,13 @@ void Search::Worker::start_searching() {
         }
         else
         {
+            if (orderMove != Move::none()
+                && std::find(rootMoves.begin(), rootMoves.end(), orderMove) != rootMoves.end())
+                for (auto&& th : threads)
+                    std::swap(th->worker.get()->rootMoves[0],
+                              *std::find(th->worker.get()->rootMoves.begin(),
+                                         th->worker.get()->rootMoves.end(), orderMove));
+
             threads.start_searching();  // start non-main threads
             iterative_deepening();      // main thread start searching
         }
@@ -262,7 +272,7 @@ void Search::Worker::start_searching() {
     auto bestmove = UCIEngine::move(bestThread->rootMoves[0].pv[0], rootPos.is_chess960());
     main_manager()->updates.onBestmove(bestmove, ponder);
 
-    if ((bool) options["Experience Enabled"] && !(bool) options["Experience Readonly"])
+    if ((bool) options["Experience Enabled"])
         experience.update(rootPos, bestThread->rootMoves[0].pv[0], bestThread->rootMoves[0].score,
                           bestThread->completedDepth);
 }
@@ -363,11 +373,11 @@ void Search::Worker::iterative_deepening() {
             // Reset aspiration window starting size using last iteration's
             // final value (previousScore). Tripple the constant factor to
             // widen the initial window.
-            delta          = 15 + std::abs(rootMoves[pvIdx].meanSquaredScore) / 11131;
-            Value prev     = rootMoves[pvIdx].previousScore;
-            alpha          = std::max(prev - delta, -VALUE_INFINITE);
-            beta           = std::min(prev + delta, VALUE_INFINITE);
-            Move prevBest  = rootMoves[pvIdx].pv[0];
+            delta         = 15 + std::abs(rootMoves[pvIdx].meanSquaredScore) / 11131;
+            Value prev    = rootMoves[pvIdx].previousScore;
+            alpha         = std::max(prev - delta, -VALUE_INFINITE);
+            beta          = std::min(prev + delta, VALUE_INFINITE);
+            Move prevBest = rootMoves[pvIdx].pv[0];
 
             // Adjust optimism based on root move's previous score
             optimism[us]  = 136 * prev / (std::abs(prev) + 93);
@@ -437,7 +447,7 @@ void Search::Worker::iterative_deepening() {
                     break;
 
                 delta += 2 * delta;  // triple C behaviour on subsequent tries
-                
+
                 assert(alpha >= -VALUE_INFINITE && beta <= VALUE_INFINITE);
             }
 
@@ -965,7 +975,12 @@ Value Search::Worker::search(
     {
         assert(probCutBeta < VALUE_INFINITE && probCutBeta > beta);
 
-        MovePicker mp(pos, ttData.move, probCutBeta - ss->staticEval, &captureHistory);
+        Move expMove = Move::none();
+        if ((bool) options["Experience Enabled"])
+            expMove = experience.probe(pos, 0, (int) options["Experience Book Eval Importance"],
+                                       (int) options["Experience Book Min Depth"],
+                                       (int) options["Experience Book Max Moves"]);
+        MovePicker mp(pos, ttData.move, probCutBeta - ss->staticEval, &captureHistory, expMove);
         Depth      dynamicReduction = (ss->staticEval - beta) / 300;
         Depth      probCutDepth     = std::max(depth - 5 - dynamicReduction, 0);
 
@@ -1017,8 +1032,13 @@ moves_loop:  // When in check, search starts here
       (ss - 4)->continuationHistory, (ss - 5)->continuationHistory, (ss - 6)->continuationHistory};
 
 
+    Move expMove = Move::none();
+    if ((bool) options["Experience Enabled"])
+        expMove = experience.probe(pos, 0, (int) options["Experience Book Eval Importance"],
+                                   (int) options["Experience Book Min Depth"],
+                                   (int) options["Experience Book Max Moves"]);
     MovePicker mp(pos, ttData.move, depth, &mainHistory, &lowPlyHistory, &captureHistory, contHist,
-                  &pawnHistory, ss->ply);
+                  &pawnHistory, ss->ply, expMove);
 
     value = bestValue;
 
@@ -1653,8 +1673,13 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
     // Initialize a MovePicker object for the current position, and prepare to search
     // the moves. We presently use two stages of move generator in quiescence search:
     // captures, or evasions only when in check.
+    Move expMove = Move::none();
+    if ((bool) options["Experience Enabled"])
+        expMove = experience.probe(pos, 0, (int) options["Experience Book Eval Importance"],
+                                   (int) options["Experience Book Min Depth"],
+                                   (int) options["Experience Book Max Moves"]);
     MovePicker mp(pos, ttData.move, DEPTH_QS, &mainHistory, &lowPlyHistory, &captureHistory,
-                  contHist, &pawnHistory, ss->ply);
+                  contHist, &pawnHistory, ss->ply, expMove);
 
     // Step 5. Loop through all pseudo-legal moves until no moves remain or a beta
     // cutoff occurs.

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -116,8 +116,8 @@ void UCIEngine::loop() {
         {
             // Force a stable, explicit UCI name so GUIs show "Wordfish 2.0 dev <date>"
             sync_cout << "id name " << ENGINE_NAME << ' ' << ENGINE_BUILD_DATE << "\n"
-                << "id author Stockfish developers, Jorge Ruiz Centelles and ChatGPT" << "\n"
-                << engine.get_options() << sync_endl;
+                      << "id author Stockfish developers, Jorge Ruiz Centelles and ChatGPT" << "\n"
+                      << engine.get_options() << sync_endl;
 
             sync_cout << "uciok" << sync_endl;
         }
@@ -134,9 +134,15 @@ void UCIEngine::loop() {
         else if (token == "position")
             position(is);
         else if (token == "ucinewgame")
+        {
             engine.search_clear();
+            engine.reload_experience();
+        }
         else if (token == "isready")
+        {
+            engine.reload_experience();
             sync_cout << "readyok" << sync_endl;
+        }
 
         // Add custom non-UCI commands, mainly for debugging purposes.
         // These commands must not be used during a search!


### PR DESCRIPTION
## Summary
- Replace unordered_map experience table with fixed-size array matching Revolution layout and ensure 34-byte entries
- Add Unicode-aware Experience File handling and reload on `setoption`, `isready`, and `ucinewgame`
- Probe experience data for move ordering even when not using book moves

## Testing
- `./src/wordfish-2.0-dev bench | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68b9197a30c483278ccd1b8a8251c457