### PR TITLE
Improve SugaR experience handling

### DIFF
--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -7,6 +7,10 @@
 #include <fstream>
 #include <vector>
 
+#include <iostream>
+
+#include "misc.h"
+
 namespace Stockfish {
 
 Experience experience;
@@ -32,28 +36,41 @@ void Experience::clear() { table.fill({}); }
 
 void Experience::load(const std::filesystem::path& file, bool readonly) {
     readOnly = readonly;
-    std::ifstream in(file, std::ios::binary | std::ios::ate);
-    std::size_t   size = in ? static_cast<std::size_t>(in.tellg()) : 0;
+    std::vector<char> buffer(1 << 20);
+    std::ifstream     in(file, std::ios::binary | std::ios::ate);
+    if (in)
+        in.rdbuf()->pubsetbuf(buffer.data(), buffer.size());
+    std::size_t size = in ? static_cast<std::size_t>(in.tellg()) : 0;
 
     if (!in || size < SugarExpHeaderSize + sizeof(ExperienceSlot) * TableSize)
     {
+        sync_cout << "info string Experience: invalid or too small" << sync_endl;
         if (readonly)
             return;
 
-        std::ofstream out(file, std::ios::binary | std::ios::trunc);
+        std::vector<char> outBuffer(1 << 20);
+        std::fstream      out(file, std::ios::binary | std::ios::in | std::ios::out | std::ios::trunc);
         if (!out)
+        {
+            sync_cout << "info string Experience: invalid or too small" << sync_endl;
             return;
-
+        }
+        out.rdbuf()->pubsetbuf(outBuffer.data(), outBuffer.size());
         out.write(SugarExpMagic, sizeof(SugarExpMagic) - 1);
         out.write(reinterpret_cast<const char*>(SugarExpBlock), sizeof(SugarExpBlock));
         ExperienceSlot zero{};
         for (std::size_t i = 0; i < TableSize; ++i)
             out.write(reinterpret_cast<const char*>(&zero), sizeof(zero));
+        out.flush();
         out.close();
 
         in.open(file, std::ios::binary | std::ios::ate);
         if (!in)
+        {
+            sync_cout << "info string Experience: invalid or too small" << sync_endl;
             return;
+        }
+        in.rdbuf()->pubsetbuf(buffer.data(), buffer.size());
     }
 
     in.seekg(0);
@@ -61,25 +78,38 @@ void Experience::load(const std::filesystem::path& file, bool readonly) {
 
     char magic[sizeof(SugarExpMagic) - 1];
     if (!in.read(magic, sizeof(magic)) || std::memcmp(magic, SugarExpMagic, sizeof(magic)) != 0)
+    {
+        sync_cout << "info string Experience: invalid or too small" << sync_endl;
         return;
+    }
 
     std::uint8_t version;
     if (!in.read(reinterpret_cast<char*>(&version), 1) || version != 2)
+    {
+        sync_cout << "info string Experience: invalid or too small" << sync_endl;
         return;
+    }
     in.ignore(sizeof(SugarExpBlock) - 1);
 
     in.read(reinterpret_cast<char*>(table.data()), table.size() * sizeof(ExperienceSlot));
+    sync_cout << "info string Experience: loaded file " << file.string()
+              << (readOnly ? " (readonly)" : "") << sync_endl;
 }
 
 void Experience::save(const std::filesystem::path& file) const {
     if (readOnly)
         return;
-    std::ofstream out(file, std::ios::binary | std::ios::trunc);
+
+    std::vector<char> buffer(1 << 20);
+    std::fstream      out(file, std::ios::binary | std::ios::in | std::ios::out);
     if (!out)
         return;
+    out.rdbuf()->pubsetbuf(buffer.data(), buffer.size());
+    out.seekp(0);
     out.write(SugarExpMagic, sizeof(SugarExpMagic) - 1);
     out.write(reinterpret_cast<const char*>(SugarExpBlock), sizeof(SugarExpBlock));
     out.write(reinterpret_cast<const char*>(table.data()), table.size() * sizeof(ExperienceSlot));
+    out.flush();
 }
 
 Move Experience::probe(
@@ -138,8 +168,12 @@ void Experience::update(const Position& pos, Move move, int score, int depth) {
         }
         if (rec.key == key && rec.move == mv)
         {
-            rec.score = static_cast<std::int16_t>(score);
-            rec.depth = static_cast<std::int16_t>(depth);
+            int oldDepth = rec.depth;
+            int newDepth = depth;
+            int total    = oldDepth + newDepth;
+            if (total)
+                rec.score = static_cast<std::int16_t>((rec.score * oldDepth + score * newDepth) / total);
+            rec.depth = static_cast<std::int16_t>(std::max(oldDepth, newDepth));
             if (rec.count < 32767)
                 rec.count++;
             return;


### PR DESCRIPTION
## Summary
- buffer experience file I/O and flush on save
- log experience load errors and success including readonly
- merge existing experience entries using max depth and weighted score

## Testing
- `make build`
- `./src/wordfish-2.0-dev <<'EOF'
uci
quit
EOF`
- `./src/wordfish-2.0-dev <<'EOF'
uci
quit
EOF` with empty experience file
- `./src/wordfish-2.0-dev <<'EOF'
uci
setoption name Experience Readonly value true
setoption name Experience File value wordfish.exp
quit
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68b91c0a848c83278261d2ef98771e20