### PR TITLE
Implement full SugaR v2 experience file format

### DIFF
--- a/scripts/generate_wordfish_exp.py
+++ b/scripts/generate_wordfish_exp.py
@@ -1,31 +1,31 @@
 #!/usr/bin/env python3
 """Generate an empty SugaR/BrainLearn v2 experience file.
 
-The generated file contains the 42-byte "SugaR Experience version 2" header
-followed by a zero-filled table of 65,536 entries in the v2 layout (34 bytes
-per entry).  This matches the format used by Revolution and allows external
-tools such as HypnoS to recognise the file even before any experience data is
-stored.
+The generated file contains the full 256-byte "SugaR Experience version 2"
+header followed by a zero-filled table of 65,536 entries in the v2 layout (34
+bytes per entry).  This matches the format used by Revolution and allows
+external tools such as HypnoS to recognise the file even before any experience
+data is stored.
 """
 
 import struct
 
 def main(path: str = "wordfish.exp") -> None:
-    # 26-byte ASCII string + required 16-byte binary block
-    header = b"SugaR Experience version 2" + bytes(
-        [0x02, 0x00, 0x80, 0xE2,
-         0x63, 0xA4, 0x80, 0x33,
-         0x10, 0x06, 0x00, 0x00,
-         0x22, 0x00, 0x00, 0x00]
-    )
-
     entry_size = 34
     table_size = 1 << 16
+    table_bytes = entry_size * table_size
+
+    header = bytearray(256)
+    header[:26] = b"SugaR Experience version 2"
+    struct.pack_into('<H', header, 26, 2)  # version
+    struct.pack_into('<Q', header, 28, 0x06103380A463E280)  # seed/uuid
+    struct.pack_into('<H', header, 36, 256)  # header size
+    struct.pack_into('<I', header, 38, table_bytes)
 
     with open(path, 'wb') as f:
         f.write(header)
-        f.write(b"\x00" * (entry_size * table_size))
-    print(f"Wrote {path} ({len(header) + entry_size * table_size} bytes)")
+        f.write(b"\x00" * table_bytes)
+    print(f"Wrote {path} ({256 + table_bytes} bytes)")
 
 if __name__ == '__main__':
     main()

--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -17,13 +17,10 @@ Experience experience;
 
 namespace {
 
-constexpr char         SugarExpMagic[]   = "SugaR Experience version 2";
-constexpr std::uint8_t SugarExpBlock[16] = {0x02, 0x00, 0x80, 0xE2, 0x63, 0xA4, 0x80, 0x33,
-                                            0x10, 0x06, 0x00, 0x00, 0x22, 0x00, 0x00, 0x00};
+constexpr char         ExpMagic[] = "SugaR Experience version 2";
+constexpr std::uint64_t ExpSeed   = 0x06103380A463E280ULL;
 
-constexpr std::size_t SugarExpHeaderSize = (sizeof(SugarExpMagic) - 1) + sizeof(SugarExpBlock);
-
-struct ExperienceEntry {
+struct ProbeEntry {
     Move move;
     int  score;
     int  depth;
@@ -40,29 +37,39 @@ void Experience::load(const std::filesystem::path& file, bool readonly) {
     std::ifstream     in(file, std::ios::binary | std::ios::ate);
     if (in)
         in.rdbuf()->pubsetbuf(buffer.data(), buffer.size());
-    std::size_t size = in ? static_cast<std::size_t>(in.tellg()) : 0;
 
-    if (!in || size < SugarExpHeaderSize + sizeof(ExperienceSlot) * TableSize)
+    const std::uint32_t tableBytes = TableSize * sizeof(ExpEntry);
+    const std::size_t   expected   = sizeof(ExpHeader) + tableBytes;
+    std::size_t         size       = in ? static_cast<std::size_t>(in.tellg()) : 0;
+
+    if (!in || size < expected)
     {
         sync_cout << "info string Experience: invalid or too small" << sync_endl;
         if (readonly)
             return;
 
         std::vector<char> outBuffer(1 << 20);
-        std::fstream      out(file, std::ios::binary | std::ios::in | std::ios::out | std::ios::trunc);
+        std::fstream      out(file, std::ios::binary | std::ios::out | std::ios::trunc);
         if (!out)
         {
             sync_cout << "info string Experience: invalid or too small" << sync_endl;
             return;
         }
         out.rdbuf()->pubsetbuf(outBuffer.data(), outBuffer.size());
-        out.write(SugarExpMagic, sizeof(SugarExpMagic) - 1);
-        out.write(reinterpret_cast<const char*>(SugarExpBlock), sizeof(SugarExpBlock));
-        ExperienceSlot zero{};
+        ExpHeader header{};
+        std::memcpy(header.magic, ExpMagic, sizeof(ExpMagic) - 1);
+        header.version    = 2;
+        header.seed       = ExpSeed;
+        header.headerSize = sizeof(ExpHeader);
+        header.tableBytes = tableBytes;
+        out.write(reinterpret_cast<const char*>(&header), sizeof(header));
+        ExpEntry zero{};
         for (std::size_t i = 0; i < TableSize; ++i)
             out.write(reinterpret_cast<const char*>(&zero), sizeof(zero));
         out.flush();
         out.close();
+
+        std::filesystem::resize_file(file, expected);
 
         in.open(file, std::ios::binary | std::ios::ate);
         if (!in)
@@ -71,27 +78,23 @@ void Experience::load(const std::filesystem::path& file, bool readonly) {
             return;
         }
         in.rdbuf()->pubsetbuf(buffer.data(), buffer.size());
+        size = static_cast<std::size_t>(in.tellg());
     }
 
     in.seekg(0);
     table.fill({});
 
-    char magic[sizeof(SugarExpMagic) - 1];
-    if (!in.read(magic, sizeof(magic)) || std::memcmp(magic, SugarExpMagic, sizeof(magic)) != 0)
+    ExpHeader header{};
+    if (!in.read(reinterpret_cast<char*>(&header), sizeof(header))
+        || std::memcmp(header.magic, ExpMagic, sizeof(ExpMagic) - 1) != 0
+        || header.version != 2 || header.headerSize != sizeof(ExpHeader)
+        || header.tableBytes != tableBytes || size < header.headerSize + header.tableBytes)
     {
         sync_cout << "info string Experience: invalid or too small" << sync_endl;
         return;
     }
 
-    std::uint8_t version;
-    if (!in.read(reinterpret_cast<char*>(&version), 1) || version != 2)
-    {
-        sync_cout << "info string Experience: invalid or too small" << sync_endl;
-        return;
-    }
-    in.ignore(sizeof(SugarExpBlock) - 1);
-
-    in.read(reinterpret_cast<char*>(table.data()), table.size() * sizeof(ExperienceSlot));
+    in.read(reinterpret_cast<char*>(table.data()), table.size() * sizeof(ExpEntry));
     sync_cout << "info string Experience: loaded file " << file.string()
               << (readOnly ? " (readonly)" : "") << sync_endl;
 }
@@ -105,22 +108,29 @@ void Experience::save(const std::filesystem::path& file) const {
     if (!out)
         return;
     out.rdbuf()->pubsetbuf(buffer.data(), buffer.size());
+    const std::uint32_t tableBytes = TableSize * sizeof(ExpEntry);
+    ExpHeader           header{};
+    std::memcpy(header.magic, ExpMagic, sizeof(ExpMagic) - 1);
+    header.version    = 2;
+    header.seed       = ExpSeed;
+    header.headerSize = sizeof(ExpHeader);
+    header.tableBytes = tableBytes;
     out.seekp(0);
-    out.write(SugarExpMagic, sizeof(SugarExpMagic) - 1);
-    out.write(reinterpret_cast<const char*>(SugarExpBlock), sizeof(SugarExpBlock));
-    out.write(reinterpret_cast<const char*>(table.data()), table.size() * sizeof(ExperienceSlot));
+    out.write(reinterpret_cast<const char*>(&header), sizeof(header));
+    out.write(reinterpret_cast<const char*>(table.data()), table.size() * sizeof(ExpEntry));
     out.flush();
+    std::filesystem::resize_file(file, sizeof(ExpHeader) + tableBytes);
 }
 
 Move Experience::probe(
   const Position& pos, [[maybe_unused]] int width, int evalImportance, int minDepth, int maxMoves) {
-    Key                          key = pos.key();
-    std::vector<ExperienceEntry> vec;
+    Key                     key = pos.key();
+    std::vector<ProbeEntry> vec;
 
     std::size_t idx = static_cast<std::size_t>(key) & (TableSize - 1);
     for (std::size_t n = 0; n < TableSize; ++n)
     {
-        const ExperienceSlot& rec = table[idx];
+        const ExpEntry& rec = table[idx];
         if (rec.move == 0)
             break;
         if (rec.key == key)
@@ -134,7 +144,7 @@ Move Experience::probe(
     if (vec.empty())
         return Move::none();
 
-    std::sort(vec.begin(), vec.end(), [&](const ExperienceEntry& a, const ExperienceEntry& b) {
+    std::sort(vec.begin(), vec.end(), [&](const ProbeEntry& a, const ProbeEntry& b) {
         return (a.score + evalImportance * a.depth) > (b.score + evalImportance * b.depth);
     });
 
@@ -156,7 +166,7 @@ void Experience::update(const Position& pos, Move move, int score, int depth) {
 
     for (std::size_t n = 0; n < TableSize; ++n)
     {
-        ExperienceSlot& rec = table[idx];
+        ExpEntry& rec = table[idx];
         if (rec.move == 0)
         {
             rec.key   = key;

--- a/src/experience.h
+++ b/src/experience.h
@@ -11,7 +11,17 @@
 namespace Stockfish {
 
 #pragma pack(push, 1)
-struct ExperienceSlot {
+
+struct ExpHeader {
+    char          magic[26];
+    std::uint16_t version;
+    std::uint64_t seed;
+    std::uint16_t headerSize;
+    std::uint32_t tableBytes;
+    std::uint8_t  reserved[256 - 26 - 2 - 8 - 2 - 4];
+};
+
+struct ExpEntry {
     std::uint64_t key;
     std::uint16_t move;
     std::int16_t  score;
@@ -24,9 +34,11 @@ struct ExperienceSlot {
     std::int16_t  age;
     std::int16_t  pad;
 };
+
 #pragma pack(pop)
 
-static_assert(sizeof(ExperienceSlot) == 34, "ExperienceSlot must be 34 bytes");
+static_assert(sizeof(ExpHeader) == 256, "header size");
+static_assert(sizeof(ExpEntry) == 34, "ExpEntry must be 34 bytes");
 
 class Experience {
    public:
@@ -43,7 +55,7 @@ class Experience {
    private:
     static constexpr std::size_t TableSize = 1ULL << 16;  // must be power of two
     static_assert((TableSize & (TableSize - 1)) == 0, "TableSize must be power of two");
-    std::array<ExperienceSlot, TableSize> table{};
+    std::array<ExpEntry, TableSize> table{};
     bool                                  readOnly = false;
 };
 


### PR DESCRIPTION
## Summary
- Add 256-byte SugaR v2 `ExpHeader` and `ExpEntry` definitions.
- Ensure experience files are validated and created with full header and zero-filled table.
- Update helper script to generate compliant `.exp` files.

## Testing
- `make build -j2`
- `python3 scripts/generate_wordfish_exp.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9213622f48327b995fafabef2ee10