### PR TITLE
Align experience header magic and metadata

### DIFF
--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -17,8 +17,8 @@ Experience experience;
 
 namespace {
 
-constexpr char         ExpMagic[] = "SugaR Experience version 2";
-constexpr std::uint64_t ExpSeed   = 0x06103380A463E280ULL;
+constexpr char          ExpMagic[] = "SugaR Experience version 2";
+constexpr std::uint64_t ExpSeed    = 0x06103380A463E280ULL;
 
 struct ProbeEntry {
     Move move;
@@ -62,6 +62,7 @@ void Experience::load(const std::filesystem::path& file, bool readonly) {
         header.seed       = ExpSeed;
         header.headerSize = sizeof(ExpHeader);
         header.tableBytes = tableBytes;
+        std::memset(header.reserved, 1, sizeof(header.reserved));
         out.write(reinterpret_cast<const char*>(&header), sizeof(header));
         ExpEntry zero{};
         for (std::size_t i = 0; i < TableSize; ++i)
@@ -86,9 +87,9 @@ void Experience::load(const std::filesystem::path& file, bool readonly) {
 
     ExpHeader header{};
     if (!in.read(reinterpret_cast<char*>(&header), sizeof(header))
-        || std::memcmp(header.magic, ExpMagic, sizeof(ExpMagic) - 1) != 0
-        || header.version != 2 || header.headerSize != sizeof(ExpHeader)
-        || header.tableBytes != tableBytes || size < header.headerSize + header.tableBytes)
+        || std::memcmp(header.magic, ExpMagic, sizeof(ExpMagic) - 1) != 0 || header.version != 2
+        || header.headerSize != sizeof(ExpHeader) || header.tableBytes != tableBytes
+        || size < header.headerSize + header.tableBytes)
     {
         sync_cout << "info string Experience: invalid or too small" << sync_endl;
         return;
@@ -115,6 +116,7 @@ void Experience::save(const std::filesystem::path& file) const {
     header.seed       = ExpSeed;
     header.headerSize = sizeof(ExpHeader);
     header.tableBytes = tableBytes;
+    std::memset(header.reserved, 1, sizeof(header.reserved));
     out.seekp(0);
     out.write(reinterpret_cast<const char*>(&header), sizeof(header));
     out.write(reinterpret_cast<const char*>(table.data()), table.size() * sizeof(ExpEntry));
@@ -182,7 +184,8 @@ void Experience::update(const Position& pos, Move move, int score, int depth) {
             int newDepth = depth;
             int total    = oldDepth + newDepth;
             if (total)
-                rec.score = static_cast<std::int16_t>((rec.score * oldDepth + score * newDepth) / total);
+                rec.score =
+                  static_cast<std::int16_t>((rec.score * oldDepth + score * newDepth) / total);
             rec.depth = static_cast<std::int16_t>(std::max(oldDepth, newDepth));
             if (rec.count < 32767)
                 rec.count++;

--- a/src/experience.h
+++ b/src/experience.h
@@ -13,12 +13,12 @@ namespace Stockfish {
 #pragma pack(push, 1)
 
 struct ExpHeader {
-    char          magic[26];
-    std::uint16_t version;
+    char          magic[32];
+    std::uint32_t version;
     std::uint64_t seed;
-    std::uint16_t headerSize;
+    std::uint32_t headerSize;
     std::uint32_t tableBytes;
-    std::uint8_t  reserved[256 - 26 - 2 - 8 - 2 - 4];
+    std::uint8_t  reserved[256 - 32 - 4 - 8 - 4 - 4];
 };
 
 struct ExpEntry {
@@ -56,7 +56,7 @@ class Experience {
     static constexpr std::size_t TableSize = 1ULL << 16;  // must be power of two
     static_assert((TableSize & (TableSize - 1)) == 0, "TableSize must be power of two");
     std::array<ExpEntry, TableSize> table{};
-    bool                                  readOnly = false;
+    bool                            readOnly = false;
 };
 
 extern Experience experience;


### PR DESCRIPTION
## Summary
- Expand ExpHeader.magic to 32 bytes so metadata begins at offset 0x20
- Store header fields as 32-bit values and fill reserved section with non-zero bytes for a fully populated v2 header

## Testing
- `make experience.o`

------
https://chatgpt.com/codex/tasks/task_e_68b92f19263483279e272794e1b69777