### PR TITLE
Add helper to write experience header

### DIFF
--- a/src/experience_writer.cpp
+++ b/src/experience_writer.cpp
@@ -1,0 +1,11 @@
+#include "experience_format.h"
+#include <cstring>
+#include <fstream>
+
+static void write_header(std::ofstream& os) {
+    ExpHeaderV2 h{};
+    std::memset(h.signature, 0, sizeof(h.signature));
+    const char* sig = "SugaR Experience version 2";
+    std::memcpy(h.signature, sig, std::strlen(sig));
+    os.write(reinterpret_cast<const char*>(&h), sizeof(h));
+}


### PR DESCRIPTION
## Summary
- add helper to emit a padded "SugaR Experience version 2" header

## Testing
- `g++ -std=c++20 -Isrc -c src/experience_writer.cpp -o /tmp/experience_writer.o`


------
https://chatgpt.com/codex/tasks/task_e_68b954d73d908327834d5095385fe8bf