### PR TITLE
Add index root writer function

### DIFF
--- a/src/experience_writer.cpp
+++ b/src/experience_writer.cpp
@@ -1,6 +1,7 @@
 #include "experience_format.h"
 #include <cstring>
 #include <fstream>
+#include <random>
 
 static void write_header(std::ofstream& os) {
     ExpHeaderV2 h{};
@@ -8,4 +9,19 @@ static void write_header(std::ofstream& os) {
     const char* sig = "SugaR Experience version 2";
     std::memcpy(h.signature, sig, std::strlen(sig));
     os.write(reinterpret_cast<const char*>(&h), sizeof(h));
+}
+
+static uint64_t rand64() {
+    std::mt19937_64 rng{std::random_device{}()};
+    return rng();
+}
+
+static void write_index_root(std::ofstream& os) {
+    ExpIndexRoot idx{};
+    idx.magic        = 0x44707223u;    // LE: 23 72 70 44
+    idx.salt_or_uuid = rand64();       // cualquier valor; persistente si quieres
+    idx.record_size  = 0x0011;         // ajusta si cambias ExpDummyEntry
+    idx.key_size     = 0x0002;         // tamaño de tu clave primaria
+    idx.reserved0    = 0;
+    os.write(reinterpret_cast<const char*>(&idx), sizeof(idx));
 }


### PR DESCRIPTION
## Summary
- allow experience writer to emit index root block with magic values and sizes

## Testing
- `g++ -std=c++17 -c src/experience_writer.cpp -o /tmp/experience_writer.o`
- `ls -l /tmp/experience_writer.o`


------
https://chatgpt.com/codex/tasks/task_e_68b95601c5bc8327be7b6f3badd40d79