### PR TITLE
Add helper to create empty experience file

### DIFF
--- a/src/experience.h
+++ b/src/experience.h
@@ -4,6 +4,7 @@
 #include <array>
 #include <cstdint>
 #include <filesystem>
+#include <string>
 
 #include "position.h"
 #include "types.h"
@@ -45,6 +46,7 @@ class Experience {
     void clear();
     void load(const std::filesystem::path& file, bool readonly);
     void save(const std::filesystem::path& file) const;
+    void create_empty_file(const std::string& path);
     Move probe(const Position&      pos,
                [[maybe_unused]] int width,
                int                  evalImportance,

--- a/src/experience_writer.cpp
+++ b/src/experience_writer.cpp
@@ -1,4 +1,5 @@
 #include "experience_format.h"
+#include "experience.h"
 #include <cstring>
 #include <fstream>
 #include <random>
@@ -18,20 +19,36 @@ static uint64_t rand64() {
 
 static void write_index_root(std::ofstream& os) {
     ExpIndexRoot idx{};
-    idx.magic        = 0x44707223u;    // LE: 23 72 70 44
-    idx.salt_or_uuid = rand64();       // cualquier valor; persistente si quieres
-    idx.record_size  = 0x0011;         // ajusta si cambias ExpDummyEntry
-    idx.key_size     = 0x0002;         // tamaño de tu clave primaria
+    idx.magic        = 0x44707223u;  // LE: 23 72 70 44
+    idx.salt_or_uuid = rand64();     // cualquier valor; persistente si quieres
+    idx.record_size  = 0x0011;       // ajusta si cambias ExpDummyEntry
+    idx.key_size     = 0x0002;       // tamaño de tu clave primaria
     idx.reserved0    = 0;
     os.write(reinterpret_cast<const char*>(&idx), sizeof(idx));
 }
 
 static void write_dummy_entry(std::ofstream& os) {
     ExpDummyEntry e{};
-    e.zobrist = 0x9e3779b97f4a7c15ULL; // constante dorada / cualquier hash
-    e.move    = 0x1208;                // ejemplo: from e2->e4 si usas 6+6 bits (ajusta)
-    e.score   = 0;                     // neutro
-    e.depth   = 1;                     // mínima profundidad
-    e.count   = 1;                     // al menos 1
+    e.zobrist = 0x9e3779b97f4a7c15ULL;  // constante dorada / cualquier hash
+    e.move    = 0x1208;                 // ejemplo: from e2->e4 si usas 6+6 bits (ajusta)
+    e.score   = 0;                      // neutro
+    e.depth   = 1;                      // mínima profundidad
+    e.count   = 1;                      // al menos 1
     os.write(reinterpret_cast<const char*>(&e), sizeof(e));
 }
+
+namespace Stockfish {
+
+void Experience::create_empty_file(const std::string& path) {
+    std::ofstream os(path, std::ios::binary | std::ios::trunc);
+    if (!os)
+        return;
+
+    write_header(os);       // 32 bytes exactos
+    write_index_root(os);   // bloque root (como Revolution)
+    write_dummy_entry(os);  // siembra para que HypnoS muestre estadísticas
+
+    os.flush();
+}
+
+}  // namespace Stockfish


### PR DESCRIPTION
## Summary
- expose `Experience::create_empty_file` to write header, index root and dummy entry
- include `<string>` in experience interface for new function

## Testing
- `g++ -std=c++17 -Isrc -c src/experience_writer.cpp`
- `cd src && make build -j2`


------
https://chatgpt.com/codex/tasks/task_e_68b957fa825083278a184f5f2f71e4ca