### PR TITLE
Fix compact experience skeleton layout

### DIFF
--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -42,30 +42,24 @@ bool is_compact_file(std::ifstream& in) {
 void write_compact_skeleton(const std::filesystem::path& file) {
     std::fstream out(file, std::ios::binary | std::ios::out | std::ios::trunc);
 
-    // Firma de 32 bytes (padded)
-    char sig[32] = {};
-    std::memcpy(sig, "SugaR Experience version 2", 27);
-    out.write(sig, sizeof(sig));
+    // Cabecera de 32 bytes con la firma del formato
+    ExpHeaderV2 header{};
+    std::memset(header.signature, 0, sizeof(header.signature));
+    std::memcpy(header.signature, "SugaR Experience version 2", 27);
+    out.write(reinterpret_cast<const char*>(&header), sizeof(header));
 
-    // Bloque índice raíz mínimo
-    const std::uint32_t magic = kIndexMagic;
-    out.write(reinterpret_cast<const char*>(&magic), sizeof(magic));
+    // Índice raíz mínimo (equivalente a ExpIndexRoot)
+    ExpIndexRoot idx{};
+    idx.magic        = kIndexMagic;
+    idx.salt_or_uuid = 0;  // campo libre
+    idx.record_size  = kRecordSize;
+    idx.key_size     = kKeySize;
+    idx.reserved0    = 0;
+    out.write(reinterpret_cast<const char*>(&idx), sizeof(idx));
 
-    // Relleno genérico / campos reservados (dejamos 8 bytes a cero como timestamp/seed)
-    std::uint64_t zero64 = 0;
-    out.write(reinterpret_cast<const char*>(&zero64), sizeof(zero64));
-
-    // Tamaños de registro y clave
-    out.write(reinterpret_cast<const char*>(&kRecordSize), sizeof(kRecordSize));
-    out.write(reinterpret_cast<const char*>(&kKeySize), sizeof(kKeySize));
-
-    // Más reservado a cero para no romper lectores estrictos
-    out.write(reinterpret_cast<const char*>(&zero64), sizeof(zero64));
-    out.write(reinterpret_cast<const char*>(&zero64), sizeof(zero64));
-
-    // Añade una “dummy” de 17 bytes a cero (evita recuento=0)
-    char dummy[0x11] = {};
-    out.write(dummy, sizeof(dummy));
+    // Registro "dummy" para que el archivo no aparezca vacío
+    ExpDummyEntry dummy{};
+    out.write(reinterpret_cast<const char*>(&dummy), sizeof(dummy));
 
     out.flush();
 }

--- a/src/experience_format.h
+++ b/src/experience_format.h
@@ -28,11 +28,14 @@ struct ExpDummyEntry {
     int16_t  score;    // eval acumulada
     uint8_t  depth;    // profundidad media
     uint8_t  count;    // ocurrencias
+    // campo de relleno para alcanzar los 17 bytes que espera record_size
+    uint8_t  pad[3]{};
     // ajusta si tu formato guarda más campos; mantén pack(1)
 };
 
 #pragma pack(pop)
 
 static_assert(sizeof(ExpHeaderV2) == 32, "Header must be 32 bytes");
+static_assert(sizeof(ExpDummyEntry) == 17, "Dummy entry must be 17 bytes");
 
 // Nota sobre record_size y key_size: En Revolution el bloque que sigue a la cabecera contiene estas parejas como 0x0011 y 0x0002 (vistas en LE como bytes 11 00 y 02 00). Si tu layout final difiere, actualiza ambos para reflejar el tamaño real de tus registros y de la clave.


### PR DESCRIPTION
## Summary
- Write compact experience file using structured header and index root
- Ensure dummy entry matches 17-byte record size

## Testing
- `make experience.o`
- Generated sample file and inspected header bytes

------
https://chatgpt.com/codex/tasks/task_e_68b967828bf88327b874ea7664f72d06