### PR TITLE
Use header size constant in experience handler

### DIFF
--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -43,7 +43,7 @@ inline void write_u64(std::ostream& os, std::uint64_t v) {
 }
 
 inline void write_signature32(std::ostream& os) {
-    char sig[32]{};
+    char sig[kHdrSize]{};
     std::memcpy(sig, "SugaR Experience version 2", 27);
     os.write(sig, sizeof(sig));
 }
@@ -51,8 +51,8 @@ inline void write_signature32(std::ostream& os) {
 inline bool is_compact_exp(std::istream& in) {
     in.clear();
     in.seekg(0, std::ios::beg);
-    char sig[32]{};
-    if (!in.read(sig, 32))
+    char sig[kHdrSize]{};
+    if (!in.read(sig, kHdrSize))
         return false;
     if (std::memcmp(sig, "SugaR Experience version 2", 27) != 0)
         return false;


### PR DESCRIPTION
## Summary
- Replace magic numbers with the `kHdrSize` constant when writing and reading experience signatures.

## Testing
- `make -C src build`
- `bash tests/perft.sh` *(fails: exit code 127 - expect: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b971950928832789baea22b2730e59