### PR TITLE
Rename engine to Wordfish 2.0 dev

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
-# Revolution authors
+# Wordfish authors
 Jorge Ruiz Centelles (JRCentelles)
 ChatGPT (OpenAI)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,11 @@
 # Changelog
 
-## [2.0.1-dev] - 2025-08-04
+## [2.0-dev] - 2025-09-04
 ### Changed
-- Bump engine version to Revolution 2.0.1 dev with build date 040825.
-
-## [2.0] - 2025-09-04
-### Changed
-- Renamed engine to Revolution 2.0 with build date 040925 for GUI identification.
+- Bump engine version to Wordfish 2.0 dev with build date 040925.
 
 ## [1.0] - 2025-08-27
 ### Added
-- Initial public release of Revolution v1.0.
+- Initial public release of Wordfish v1.0.
 - Iterative deepening now starts at depth 2 for faster and deeper analysis.
 - Updated engine name and author information.

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
-Revolution Chess Engine
+Wordfish Chess Engine
 Copyright (c)  Stockfish developers (see AUTHORS file)
 
-Revolution is a UCI chess engine derived from Stockfish. This distribution includes modifications and new code by Jorge Ruiz Centelles, with credit to ChatGPT, exploring new ideas.
+Wordfish is a UCI chess engine derived from Stockfish. This distribution includes modifications and new code by Jorge Ruiz Centelles, with credit to ChatGPT, exploring new ideas.
 
 
 Copyright (c) 2024 Jorge Ruiz Centelles
@@ -12,7 +12,7 @@ the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
 
-Revolution incorporates code from the following GPLv3 project:
+Wordfish incorporates code from the following GPLv3 project:
 
 - Stockfish <https://github.com/official-stockfish/Stockfish>
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Revolution Chess Engine
+# Wordfish Chess Engine
 
 **Version 2.0**
 
 <div align="center">
-  <img src="[https://ijccrl.com/wp-content/uploads/2025/08/revolution.png]" 
-  <h3>Revolution</h3>
+  <img src="[https://ijccrl.com/wp-content/uploads/2025/08/wordfish.png]" 
+  <h3>Wordfish</h3>
   
   A free and open-source UCI chess engine combining classical algorithms with neural network innovations.
   <br>
-  <strong><a href="#">Explore Revolution Documentation »</a>
+  <strong><a href="#">Explore Wordfish Documentation »</a>
 
   <em>Author: This distribution includes modifications and new code by Jorge Ruiz Centelles, with credit to ChatGPT, exploring new ideas.</em>
   
@@ -16,13 +16,13 @@
 
 ## Overview
 
-**Revolution** is a free, open-source UCI chess engine derived from **Stockfish**. Jorge Ruiz Centelles, with credit to ChatGPT, modifies and extends the code to explore new concepts. The engine implements cutting-edge search algorithms combined with neural network evaluation. Derived from fundamental chess programming principles, Revolution analyzes positions through parallelized alpha-beta search enhanced with null-move pruning and late move reductions.
+**Wordfish** is a free, open-source UCI chess engine derived from **Stockfish**. Jorge Ruiz Centelles, with credit to ChatGPT, modifies and extends the code to explore new concepts. The engine implements cutting-edge search algorithms combined with neural network evaluation. Derived from fundamental chess programming principles, Wordfish analyzes positions through parallelized alpha-beta search enhanced with null-move pruning and late move reductions.
 
-As a UCI-compliant engine, Revolution operates through **standard chess interfaces** without an integrated graphical interface. Users must employ compatible chess GUIs (Arena, Scid vs PC, etc.) for board visualization and move input. Consult your GUI documentation for implementation details.
+As a UCI-compliant engine, Wordfish operates through **standard chess interfaces** without an integrated graphical interface. Users must employ compatible chess GUIs (Arena, Scid vs PC, etc.) for board visualization and move input. Consult your GUI documentation for implementation details.
 
 ## Technical Architecture
 
-Revolution's architecture features:
+Wordfish's architecture features:
 
 - Hybrid evaluation system combining classical heuristics with NNUE networks
 - SMP parallelization with YBWC (Young Brothers Wait Concept)
@@ -38,7 +38,7 @@ The distribution includes:
 - `COPYING.txt` ([GNU GPLv3 license][gpl-link])
 - `AUTHORS` (contributor acknowledgments)
 - `src/` (source code with platform-specific Makefiles)
-- Neural network weights (`revolution.nnue`)
+- Neural network weights (`wordfish.nnue`)
 
 ## Contributing
 
@@ -51,13 +51,13 @@ Contributions must adhere to:
 
 ### Testing Infrastructure
 Improvements require extensive testing:
-- Install the [Revolution Test Worker][worker-link]
-- Participate in active tests on [Revolution Test Suite][testsuite-link]
+- Install the [Wordfish Test Worker][worker-link]
+- Participate in active tests on [Wordfish Test Suite][testsuite-link]
 - Verify ELO gains through SPRT validation
 
 ### Community
 Technical discussions occur primarily through:
-- [Revolution Discord Server][discord-link]
+- [Wordfish Discord Server][discord-link]
 - [GitHub Discussions][discussions-link]
 - [Chess Programming Wiki][chesswiki-link]
 
@@ -78,7 +78,7 @@ Full compilation guides available in [documentation][doc-link].
 
 ## Syzygy Tablebases
 
-Revolution can probe [Syzygy](https://github.com/syzygy1) endgame tablebases when a
+Wordfish can probe [Syzygy](https://github.com/syzygy1) endgame tablebases when a
 directory is supplied via the `SyzygyPath` UCI option. The engine also exposes a
 `SyzygyPremap` boolean option. When set to `true`, `Tablebases::init` pre-maps all
 available WDL and DTZ tables during initialization, reducing probe latency at the
@@ -86,13 +86,13 @@ expense of additional startup time and memory usage.
 
 ## Experience Book
 
-Revolution includes a simple text-based cache that stores root moves from
+Wordfish includes a simple text-based cache that stores root moves from
 previous games. It functions as a lightweight opening book and does not
 influence the internal search beyond the root. The following UCI options
 control this system:
 
 - `Experience Enabled`: enables or disables the experience feature (default `true`).
-- `Experience File`: name of the file where the experience data is stored (default `revolution.exp`; legacy `.bin` files are converted automatically).
+- `Experience File`: name of the file where the experience data is stored (default `wordfish.exp`; legacy `.bin` files are converted automatically).
 - `Experience Readonly`: if `true`, no changes are written to the file.
 - `Experience Book`: uses the experience data as an opening book.
 - `Experience Book Width`: number of principal moves to consider (1–20).
@@ -104,12 +104,12 @@ The file is loaded at engine startup and updated after each game if `Experience 
 
 ## License
 
-Revolution is distributed under the **[GNU General Public License v3][gpl-link]** (GPLv3).
+Wordfish is distributed under the **[GNU General Public License v3][gpl-link]** (GPLv3).
 It integrates source code from:
 
 - [Stockfish](https://github.com/official-stockfish/Stockfish)
 
-Because Stockfish is GPLv3, any distribution of Revolution must also comply with GPLv3.
+Because Stockfish is GPLv3, any distribution of Wordfish must also comply with GPLv3.
 For a summary of your obligations under GPLv3 see <https://www.gnu.org/licenses/quick-guide-gplv3.html>.
 When redistributing, you must:
 1. Include the original license text (`COPYING.txt`)
@@ -118,7 +118,7 @@ When redistributing, you must:
 
 ## Acknowledgements
 
-Revolution also benefits from:
+Wordfish also benefits from:
 - Neural networks trained on [Lichess open database][lichess-db]
 - Search techniques from [CCC testing community][ccc-link]
 - Positional analysis concepts from [CPW research][cpw-link]

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,6 +1,6 @@
 # Benchmarking Procedure
 
-This document outlines how to benchmark **Revolution** against other engines.
+This document outlines how to benchmark **Wordfish** against other engines.
 
 ## 1. Build the Engine
 ```bash

--- a/docs/preliminary_results.md
+++ b/docs/preliminary_results.md
@@ -3,7 +3,7 @@
 Small-scale matches (100 games, 40/0.4+0.4) were run using `scripts/match.sh`.
 The table below shows early Elo differences computed with [Ordo](https://github.com/michaelkeenan/ordo).
 
-| Engine          | Elo vs Revolution |
+| Engine          | Elo vs Wordfish |
 |-----------------|------------------|
 | Stockfish 16    | +280             |
 | Berserk 12      | +150             |

--- a/scripts/fishtest_local.sh
+++ b/scripts/fishtest_local.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# Launch a local fishtest worker for tuning Revolution.
+# Launch a local fishtest worker for tuning Wordfish.
 # Requires a fishtest repository cloned locally.
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE="$ROOT_DIR/src/revolution"
+ENGINE="$ROOT_DIR/src/wordfish"
 FISHTEST_DIR="${FISHTEST_DIR:-$HOME/fishtest}"
 
 if [ ! -x "$ENGINE" ]; then

--- a/scripts/generate_wordfish_exp.py
+++ b/scripts/generate_wordfish_exp.py
@@ -3,7 +3,7 @@
 
 The generated file contains the full 256-byte "SugaR Experience version 2"
 header followed by a zero-filled table of 65,536 entries in the v2 layout (34
-bytes per entry).  This matches the format used by Revolution and allows
+bytes per entry).  This matches the format used by Wordfish and allows
 external tools such as HypnoS to recognise the file even before any experience
 data is stored.
 """

--- a/scripts/match.sh
+++ b/scripts/match.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# Run automated matches between Revolution and another UCI engine using cutechess-cli.
+# Run automated matches between Wordfish and another UCI engine using cutechess-cli.
 # Usage: scripts/match.sh /path/to/opponent [games] [timecontrol]
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE="${ENGINE:-$ROOT_DIR/src/revolution}"
+ENGINE="${ENGINE:-$ROOT_DIR/src/wordfish}"
 OPPONENT="${1:?Opponent engine path required}"
 GAMES="${2:-10}"
 TC="${3:-40/0.4+0.4}"
@@ -15,7 +15,7 @@ if ! command -v cutechess-cli >/dev/null; then
 fi
 
 cutechess-cli \
-  -engine cmd="$ENGINE" name=Revolution \
+  -engine cmd="$ENGINE" name=Wordfish \
   -engine cmd="$OPPONENT" name=Opponent \
   -each proto=uci tc=$TC \
   -games $GAMES -concurrency 2 \

--- a/scripts/perft.sh
+++ b/scripts/perft.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# Run perft validation on the Revolution engine.
+# Run perft validation on the Wordfish engine.
 # Builds the engine if needed and executes the existing test suite.
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE="$ROOT_DIR/src/revolution"
+ENGINE="$ROOT_DIR/src/wordfish"
 TEST_DIR="$ROOT_DIR/tests"
 
 if [ ! -x "$ENGINE" ]; then

--- a/scripts/spsa.py
+++ b/scripts/spsa.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Simple SPSA tuner for the Revolution engine."""
+"""Simple SPSA tuner for the Wordfish engine."""
 import argparse
 import os
 import random
@@ -19,9 +19,9 @@ def run_bench(engine, name, value):
     raise RuntimeError("Unexpected bench output")
 
 def main():
-    p = argparse.ArgumentParser(description="SPSA tuning for Revolution")
+    p = argparse.ArgumentParser(description="SPSA tuning for Wordfish")
     p.add_argument("--param", nargs=4, metavar=("NAME", "START", "MIN", "MAX"), action='append', required=True)
-    p.add_argument("--engine", default="src/revolution")
+    p.add_argument("--engine", default="src/wordfish")
     p.add_argument("--iterations", type=int, default=10)
     args = p.parse_args()
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = revolution.exe
+        EXE = wordfish.exe
 else
-        EXE = revolution
+        EXE = wordfish
 endif
 
 ### Installation dir definitions
@@ -842,12 +842,12 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 # UCI "id name" string shown in GUIs.
 # Defaults:
-#   - ENGINE_NAME: "Revolution 2.0.1 dev"
-#   - ENGINE_BUILD_DATE: 040825 (ddmmyy format)
+#   - ENGINE_NAME: "Wordfish 2.0 dev"
+#   - ENGINE_BUILD_DATE: 040925 (ddmmyy format)
 # You can override on the command line:
-#   make ENGINE_NAME="Revolution 2.0.1 dev" ENGINE_BUILD_DATE=040825
-ENGINE_NAME        ?= Revolution 2.0.1 dev
-ENGINE_BUILD_DATE  ?= 040825
+#   make ENGINE_NAME="Wordfish 2.0 dev" ENGINE_BUILD_DATE=040925
+ENGINE_NAME        ?= Wordfish 2.0 dev
+ENGINE_BUILD_DATE  ?= 040925
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 
 ### 3.9 Link Time Optimization

--- a/src/README_CHANGELOG.txt
+++ b/src/README_CHANGELOG.txt
@@ -1,10 +1,7 @@
-Revolution 2.0.1 dev 040825
-- Updated engine version to 2.0.1 dev with build date 040825.
+Wordfish 2.0 dev 040925
+- Renamed engine to Wordfish 2.0 dev with build date 040925.
 
-Revolution 2.0 040925
-- Renamed engine to Revolution 2.0 with build date 040925.
-
-Revolution 1.0 dev 250827
+Wordfish 1.0 dev 250827
 - Initial fork from Stockfish.
 - Updated engine name and build system.
 - Added experience book system with persistent `.exp` file (legacy `.bin` files are converted automatically) and new UCI options.

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -169,7 +169,7 @@ Engine::Engine(std::optional<std::string> path) :
                     return std::nullopt;
                 }));
 
-    options.add("Experience File", Option("revolution.exp", [this](const Option& o) {
+    options.add("Experience File", Option("wordfish.exp", [this](const Option& o) {
                     if ((bool) options["Experience Enabled"])
                         experience.load(o);
                     return std::nullopt;

--- a/src/experience_format.h
+++ b/src/experience_format.h
@@ -11,7 +11,7 @@ struct ExpHeaderV2 {
 
 struct ExpIndexRoot {
     // Bytes inmediatamente después de la cabecera.
-    // Campos deducidos por comparación con Revolution.
+    // Campos deducidos por comparación con Wordfish.
     // No uses tipos dependientes de plataforma (nada de time_t).
     uint32_t magic;        // 0x44707223 (LE)  // 'Dp r#' en hex al revés
     uint64_t salt_or_uuid; // semilla aleatoria/uuid (puede ser rand64)
@@ -40,4 +40,4 @@ static_assert(sizeof(ExpHeaderV2) == 32, "Header must be 32 bytes");
 static_assert(sizeof(ExpIndexRoot) == 32, "Index root must be 32 bytes");
 static_assert(sizeof(ExpDummyEntry) == 17, "Dummy entry must be 17 bytes");
 
-// Nota sobre record_size y key_size: En Revolution el bloque que sigue a la cabecera contiene estas parejas como 0x0011 y 0x0002 (vistas en LE como bytes 11 00 y 02 00). Si tu layout final difiere, actualiza ambos para reflejar el tamaño real de tus registros y de la clave.
+// Nota sobre record_size y key_size: En Wordfish el bloque que sigue a la cabecera contiene estas parejas como 0x0011 y 0x0002 (vistas en LE como bytes 11 00 y 02 00). Si tu layout final difiere, actualiza ambos para reflejar el tamaño real de tus registros y de la clave.

--- a/src/experience_writer.cpp
+++ b/src/experience_writer.cpp
@@ -45,7 +45,7 @@ void Experience::create_empty_file(const std::string& path) {
         return;
 
     write_header(os);       // 32 bytes exactos
-    write_index_root(os);   // bloque root (como Revolution)
+    write_index_root(os);   // bloque root (como Wordfish)
     write_dummy_entry(os);  // siembra para que HypnoS muestre estadísticas
 
     os.flush();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,13 +25,13 @@
 #include "position.h"
 
 #ifndef ENGINE_BUILD_DATE
-    // ddmmyy; override at build time with:  -DENGINE_BUILD_DATE=040825
-    #define ENGINE_BUILD_DATE "040825"
+    // ddmmyy; override at build time with:  -DENGINE_BUILD_DATE=040925
+    #define ENGINE_BUILD_DATE "040925"
 #endif
 
 #ifndef ENGINE_NAME
-    // override at build time with:  -DENGINE_NAME="\"Revolution 2.0.1 dev\""
-    #define ENGINE_NAME "Revolution 2.0.1 dev"
+    // override at build time with:  -DENGINE_NAME="\"Wordfish 2.0 dev\""
+    #define ENGINE_NAME "Wordfish 2.0 dev"
 #endif
 
 using namespace Stockfish;

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -37,10 +37,10 @@
 
 #include "types.h"
 #ifndef ENGINE_BUILD_DATE
-    #define ENGINE_BUILD_DATE "040825"
+    #define ENGINE_BUILD_DATE "040925"
 #endif
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "Revolution 2.0.1 dev"
+    #define ENGINE_NAME "Wordfish 2.0 dev"
 #endif
 
 namespace Stockfish {
@@ -121,7 +121,7 @@ class Logger {
 }  // namespace
 
 
-// Returns the full name of the current Revolution version.
+// Returns the full name of the current Wordfish version.
 std::string engine_version_info() { return std::string(ENGINE_NAME " ") + version.data(); }
 
 // Update author information

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -143,7 +143,7 @@ void UCIEngine::loop() {
 
         else if (token == "uci")
         {
-            // Force a stable, explicit UCI name so GUIs show "Revolution 2.0.1 dev <date>"
+            // Force a stable, explicit UCI name so GUIs show "Wordfish 2.0 dev <date>"
             sync_cout << "id name " << ENGINE_NAME << ' ' << ENGINE_BUILD_DATE << "\n"
                 << "id author Jorge Ruiz Centelles and the Stockfish developers (see AUTHORS file)" << "\n"
                 << engine.get_options() << sync_endl;

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -21,10 +21,10 @@
 #include "ucioption.h"
 // --- Engine identity (fallbacks; Makefile can override) ---
 #ifndef ENGINE_NAME
-#define ENGINE_NAME "Revolution 2.0.1 dev"
+#define ENGINE_NAME "Wordfish 2.0 dev"
 #endif
 #ifndef ENGINE_BUILD_DATE
-#define ENGINE_BUILD_DATE "040825"  // ddmmyy; overridden by Makefile if provided
+#define ENGINE_BUILD_DATE "040925"  // ddmmyy; overridden by Makefile if provided
 #endif
 
 


### PR DESCRIPTION
## Summary
- Rename engine and documentation from Revolution to Wordfish 2.0 dev with build date 040925
- Default experience book renamed to `wordfish.exp`
- Add placeholder `sparsehash` directory

## Testing
- `make -C src -j2 build ARCH=x86-64`
- `bash tests/perft.sh src/wordfish` *(fails: exit code 127)*

------
https://chatgpt.com/codex/tasks/task_e_68b99ed1242883278f572f9f2f98f384