### PR TITLE
Rename engine to Wordfish 2.0 dev 040925 and add options

### DIFF
--- a/sparsehash/dense_hash_map
+++ b/sparsehash/dense_hash_map
@@ -1,7 +1,7 @@
-#ifndef REVOLUTION_SPARSEHASH_DENSE_HASH_MAP_H
-#define REVOLUTION_SPARSEHASH_DENSE_HASH_MAP_H
+#ifndef WORDFISH_SPARSEHASH_DENSE_HASH_MAP_H
+#define WORDFISH_SPARSEHASH_DENSE_HASH_MAP_H
 
-// Placeholder dense_hash_map for the Revolution project.
+// Placeholder dense_hash_map for the Wordfish project.
 // Implementation intentionally minimal.
 
-#endif // REVOLUTION_SPARSEHASH_DENSE_HASH_MAP_H
+#endif // WORDFISH_SPARSEHASH_DENSE_HASH_MAP_H

--- a/sparsehash/dense_hash_set
+++ b/sparsehash/dense_hash_set
@@ -1,7 +1,7 @@
-#ifndef REVOLUTION_SPARSEHASH_DENSE_HASH_SET_H
-#define REVOLUTION_SPARSEHASH_DENSE_HASH_SET_H
+#ifndef WORDFISH_SPARSEHASH_DENSE_HASH_SET_H
+#define WORDFISH_SPARSEHASH_DENSE_HASH_SET_H
 
-// Placeholder dense_hash_set for the Revolution project.
+// Placeholder dense_hash_set for the Wordfish project.
 // Implementation intentionally minimal.
 
-#endif // REVOLUTION_SPARSEHASH_DENSE_HASH_SET_H
+#endif // WORDFISH_SPARSEHASH_DENSE_HASH_SET_H

--- a/sparsehash/sparse_hash_map
+++ b/sparsehash/sparse_hash_map
@@ -1,7 +1,7 @@
-#ifndef REVOLUTION_SPARSEHASH_SPARSE_HASH_MAP_H
-#define REVOLUTION_SPARSEHASH_SPARSE_HASH_MAP_H
+#ifndef WORDFISH_SPARSEHASH_SPARSE_HASH_MAP_H
+#define WORDFISH_SPARSEHASH_SPARSE_HASH_MAP_H
 
-// Placeholder sparse_hash_map for the Revolution project.
+// Placeholder sparse_hash_map for the Wordfish project.
 // Implementation intentionally minimal.
 
-#endif // REVOLUTION_SPARSEHASH_SPARSE_HASH_MAP_H
+#endif // WORDFISH_SPARSEHASH_SPARSE_HASH_MAP_H

--- a/sparsehash/sparse_hash_set
+++ b/sparsehash/sparse_hash_set
@@ -1,7 +1,7 @@
-#ifndef REVOLUTION_SPARSEHASH_SPARSE_HASH_SET_H
-#define REVOLUTION_SPARSEHASH_SPARSE_HASH_SET_H
+#ifndef WORDFISH_SPARSEHASH_SPARSE_HASH_SET_H
+#define WORDFISH_SPARSEHASH_SPARSE_HASH_SET_H
 
-// Placeholder sparse_hash_set for the Revolution project.
+// Placeholder sparse_hash_set for the Wordfish project.
 // Implementation intentionally minimal.
 
-#endif // REVOLUTION_SPARSEHASH_SPARSE_HASH_SET_H
+#endif // WORDFISH_SPARSEHASH_SPARSE_HASH_SET_H

--- a/sparsehash/sparsetable
+++ b/sparsehash/sparsetable
@@ -1,7 +1,7 @@
-#ifndef REVOLUTION_SPARSEHASH_SPARSETABLE_H
-#define REVOLUTION_SPARSEHASH_SPARSETABLE_H
+#ifndef WORDFISH_SPARSEHASH_SPARSETABLE_H
+#define WORDFISH_SPARSEHASH_SPARSETABLE_H
 
-// Placeholder sparsetable for the Revolution project.
+// Placeholder sparsetable for the Wordfish project.
 // Implementation intentionally minimal.
 
-#endif // REVOLUTION_SPARSEHASH_SPARSETABLE_H
+#endif // WORDFISH_SPARSEHASH_SPARSETABLE_H

--- a/sparsehash/template_util.h
+++ b/sparsehash/template_util.h
@@ -1,7 +1,7 @@
-#ifndef REVOLUTION_SPARSEHASH_TEMPLATE_UTIL_H
-#define REVOLUTION_SPARSEHASH_TEMPLATE_UTIL_H
+#ifndef WORDFISH_SPARSEHASH_TEMPLATE_UTIL_H
+#define WORDFISH_SPARSEHASH_TEMPLATE_UTIL_H
 
-// Utility templates for the Revolution project's sparsehash placeholders.
+// Utility templates for the Wordfish project's sparsehash placeholders.
 // Implementation intentionally minimal.
 
-#endif // REVOLUTION_SPARSEHASH_TEMPLATE_UTIL_H
+#endif // WORDFISH_SPARSEHASH_TEMPLATE_UTIL_H

--- a/sparsehash/type_traits.h
+++ b/sparsehash/type_traits.h
@@ -1,7 +1,7 @@
-#ifndef REVOLUTION_SPARSEHASH_TYPE_TRAITS_H
-#define REVOLUTION_SPARSEHASH_TYPE_TRAITS_H
+#ifndef WORDFISH_SPARSEHASH_TYPE_TRAITS_H
+#define WORDFISH_SPARSEHASH_TYPE_TRAITS_H
 
-// Type trait helpers for the Revolution project's sparsehash placeholders.
+// Type trait helpers for the Wordfish project's sparsehash placeholders.
 // Implementation intentionally minimal.
 
-#endif // REVOLUTION_SPARSEHASH_TYPE_TRAITS_H
+#endif // WORDFISH_SPARSEHASH_TYPE_TRAITS_H

--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = revolution.exe
+        EXE = wordfish-2.0-dev-040925.exe
 else
-        EXE = revolution
+        EXE = wordfish-2.0-dev-040925
 endif
 
 ### Installation dir definitions
@@ -842,12 +842,12 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 # UCI "id name" string shown in GUIs.
 # Defaults:
-#   - ENGINE_NAME: "Revolution 2.0.1 dev"
-#   - ENGINE_BUILD_DATE: 040825 (ddmmyy format)
+#   - ENGINE_NAME: "Wordfish 2.0 dev"
+#   - ENGINE_BUILD_DATE: 040925 (ddmmyy format)
 # You can override on the command line:
-#   make ENGINE_NAME="Revolution 2.0.1 dev" ENGINE_BUILD_DATE=040825
-ENGINE_NAME        ?= Revolution 2.0.1 dev
-ENGINE_BUILD_DATE  ?= 040825
+#   make ENGINE_NAME="Wordfish 2.0 dev" ENGINE_BUILD_DATE=040925
+ENGINE_NAME        ?= Wordfish 2.0 dev
+ENGINE_BUILD_DATE  ?= 040925
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 
 ### 3.9 Link Time Optimization

--- a/src/README_CHANGELOG.txt
+++ b/src/README_CHANGELOG.txt
@@ -1,10 +1,7 @@
-Revolution 2.0.1 dev 040825
-- Updated engine version to 2.0.1 dev with build date 040825.
+Wordfish 2.0 dev 040925
+- Renamed engine to Wordfish 2.0 dev with build date 040925.
 
-Revolution 2.0 040925
-- Renamed engine to Revolution 2.0 with build date 040925.
-
-Revolution 1.0 dev 250827
+Wordfish 1.0 dev 250827
 - Initial fork from Stockfish.
 - Updated engine name and build system.
 - Added experience book system with persistent `.exp` file (legacy `.bin` files are converted automatically) and new UCI options.

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -62,7 +62,8 @@ Engine::Engine(std::optional<std::string> path) :
       numaContext,
       NN::Networks(
         NN::NetworkBig({EvalFileDefaultNameBig, "None", ""}, NN::EmbeddedNNUEType::BIG),
-        NN::NetworkSmall({EvalFileDefaultNameSmall, "None", ""}, NN::EmbeddedNNUEType::SMALL))) {
+        NN::NetworkSmall({EvalFileDefaultNameSmall, "None", ""}, NN::EmbeddedNNUEType::SMALL),
+        NN::NetworkFalcon({EvalFileDefaultNameFalcon, "None", ""}, NN::EmbeddedNNUEType::BIG))) {
     pos.set(StartFEN, false, &states->back());
 
 
@@ -108,6 +109,8 @@ Engine::Engine(std::optional<std::string> path) :
     options.add("Move Overhead", Option(10, 0, 5000));
 
     options.add("nodestime", Option(0, 0, 10000));
+
+    options.add("Slow Mover", Option(100, 10, 1000));
 
     options.add("UCI_Chess960", Option(false));
 
@@ -169,7 +172,7 @@ Engine::Engine(std::optional<std::string> path) :
                     return std::nullopt;
                 }));
 
-    options.add("Experience File", Option("revolution.exp", [this](const Option& o) {
+    options.add("Experience File", Option("wordfish.exp", [this](const Option& o) {
                     if ((bool) options["Experience Enabled"])
                         experience.load(o);
                     return std::nullopt;
@@ -200,6 +203,12 @@ Engine::Engine(std::optional<std::string> path) :
     options.add(  //
       "EvalFileSmall", Option(EvalFileDefaultNameSmall, [this](const Option& o) {
           load_small_network(o);
+          return std::nullopt;
+      }));
+
+    options.add(  //
+      "EvalFileFalcon", Option(EvalFileDefaultNameFalcon, [this](const Option& o) {
+          load_falcon_network(o);
           return std::nullopt;
       }));
 
@@ -324,12 +333,14 @@ void Engine::set_ponderhit(bool b) { threads.main_manager()->ponder = b; }
 void Engine::verify_networks() const {
     networks->big.verify(options["EvalFile"], onVerifyNetworks);
     networks->small.verify(options["EvalFileSmall"], onVerifyNetworks);
+    networks->falcon.verify(options["EvalFileFalcon"], onVerifyNetworks);
 }
 
 void Engine::load_networks() {
     networks.modify_and_replicate([this](NN::Networks& networks_) {
         networks_.big.load(binaryDirectory, options["EvalFile"]);
         networks_.small.load(binaryDirectory, options["EvalFileSmall"]);
+        networks_.falcon.load(binaryDirectory, options["EvalFileFalcon"]);
     });
     threads.clear();
     threads.ensure_network_replicated();
@@ -345,6 +356,13 @@ void Engine::load_big_network(const std::string& file) {
 void Engine::load_small_network(const std::string& file) {
     networks.modify_and_replicate(
       [this, &file](NN::Networks& networks_) { networks_.small.load(binaryDirectory, file); });
+    threads.clear();
+    threads.ensure_network_replicated();
+}
+
+void Engine::load_falcon_network(const std::string& file) {
+    networks.modify_and_replicate(
+      [this, &file](NN::Networks& networks_) { networks_.falcon.load(binaryDirectory, file); });
     threads.clear();
     threads.ensure_network_replicated();
 }

--- a/src/engine.h
+++ b/src/engine.h
@@ -87,6 +87,7 @@ class Engine {
     void load_networks();
     void load_big_network(const std::string& file);
     void load_small_network(const std::string& file);
+    void load_falcon_network(const std::string& file);
     void save_network(const std::pair<std::optional<std::string>, std::string> files[2]);
 
     // utility functions

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -35,6 +35,7 @@ namespace Eval {
 // in the Makefile/Fishtest.
 #define EvalFileDefaultNameBig "nn-1c0000000000.nnue"
 #define EvalFileDefaultNameSmall "nn-37f18f62d772.nnue"
+#define EvalFileDefaultNameFalcon "nn-falcon.nnue"
 
 namespace NNUE {
 struct Networks;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,13 +25,13 @@
 #include "position.h"
 
 #ifndef ENGINE_BUILD_DATE
-    // ddmmyy; override at build time with:  -DENGINE_BUILD_DATE=040825
-    #define ENGINE_BUILD_DATE "040825"
+    // ddmmyy; override at build time with:  -DENGINE_BUILD_DATE=040925
+    #define ENGINE_BUILD_DATE "040925"
 #endif
 
 #ifndef ENGINE_NAME
-    // override at build time with:  -DENGINE_NAME="\"Revolution 2.0.1 dev\""
-    #define ENGINE_NAME "Revolution 2.0.1 dev"
+    // override at build time with:  -DENGINE_NAME="\"Wordfish 2.0 dev\""
+    #define ENGINE_NAME "Wordfish 2.0 dev"
 #endif
 
 using namespace Stockfish;

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -37,10 +37,10 @@
 
 #include "types.h"
 #ifndef ENGINE_BUILD_DATE
-    #define ENGINE_BUILD_DATE "040825"
+    #define ENGINE_BUILD_DATE "040925"
 #endif
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "Revolution 2.0.1 dev"
+    #define ENGINE_NAME "Wordfish 2.0 dev"
 #endif
 
 namespace Stockfish {
@@ -121,7 +121,7 @@ class Logger {
 }  // namespace
 
 
-// Returns the full name of the current Revolution version.
+// Returns the full name of the current Wordfish version.
 std::string engine_version_info() { return std::string(ENGINE_NAME " ") + version.data(); }
 
 // Update author information

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -120,15 +120,18 @@ using BigNetworkArchitecture = NetworkArchitecture<TransformedFeatureDimensionsB
 
 using NetworkBig   = Network<BigNetworkArchitecture, BigFeatureTransformer>;
 using NetworkSmall = Network<SmallNetworkArchitecture, SmallFeatureTransformer>;
+using NetworkFalcon = Network<BigNetworkArchitecture, BigFeatureTransformer>;
 
 
 struct Networks {
-    Networks(NetworkBig&& nB, NetworkSmall&& nS) :
+    Networks(NetworkBig&& nB, NetworkSmall&& nS, NetworkFalcon&& nF) :
         big(std::move(nB)),
-        small(std::move(nS)) {}
+        small(std::move(nS)),
+        falcon(std::move(nF)) {}
 
-    NetworkBig   big;
-    NetworkSmall small;
+    NetworkBig    big;
+    NetworkSmall  small;
+    NetworkFalcon falcon;
 };
 
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -108,6 +108,8 @@ void TimeManagement::init(Search::LimitsType& limits,
         if (originalTimeAdjust < 0)
             originalTimeAdjust = 0.3128 * std::log10(timeLeft) - 0.4354;
 
+        originalTimeAdjust *= double(options["Slow Mover"]) / 100.0;
+
         // Calculate time constants based on current time left.
         double logTimeInSec = std::log10(scaledTime / 1000.0);
         double optConstant  = std::min(0.0032116 + 0.000321123 * logTimeInSec, 0.00508017);

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -143,7 +143,7 @@ void UCIEngine::loop() {
 
         else if (token == "uci")
         {
-            // Force a stable, explicit UCI name so GUIs show "Revolution 2.0.1 dev <date>"
+            // Force a stable, explicit UCI name so GUIs show "Wordfish 2.0 dev <date>"
             sync_cout << "id name " << ENGINE_NAME << ' ' << ENGINE_BUILD_DATE << "\n"
                 << "id author Jorge Ruiz Centelles and the Stockfish developers (see AUTHORS file)" << "\n"
                 << engine.get_options() << sync_endl;

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -21,10 +21,10 @@
 #include "ucioption.h"
 // --- Engine identity (fallbacks; Makefile can override) ---
 #ifndef ENGINE_NAME
-#define ENGINE_NAME "Revolution 2.0.1 dev"
+#define ENGINE_NAME "Wordfish 2.0 dev"
 #endif
 #ifndef ENGINE_BUILD_DATE
-#define ENGINE_BUILD_DATE "040825"  // ddmmyy; overridden by Makefile if provided
+#define ENGINE_BUILD_DATE "040925"  // ddmmyy; overridden by Makefile if provided
 #endif
 
 


### PR DESCRIPTION
## Summary
- rename engine and executable to Wordfish 2.0 dev 040925
- change default experience file name to `wordfish.exp`
- add `Slow Mover` UCI option and optional Falcon neural network

## Testing
- `cd src && make build ARCH=x86-64 -j2`

------
https://chatgpt.com/codex/tasks/task_e_68b9a274a254832780c5e54102ea5dbb