### PR TITLE
Add SugaR v2 header and dummy experience seeding

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -56,7 +56,7 @@ SRCS = benchmark.cpp bitboard.cpp evaluate.cpp main.cpp \
         misc.cpp movegen.cpp movepick.cpp polybook.cpp position.cpp \
         search.cpp thread.cpp timeman.cpp tt.cpp uci.cpp ucioption.cpp tune.cpp syzygy/tbprobe.cpp \
         nnue/nnue_accumulator.cpp nnue/nnue_misc.cpp nnue/features/half_ka_v2_hm.cpp nnue/network.cpp \
-        engine.cpp score.cpp memory.cpp experience.cpp
+        engine.cpp score.cpp memory.cpp experience.cpp experience_v2.cpp
 
 HEADERS = benchmark.h bitboard.h evaluate.h misc.h movegen.h movepick.h history.h \
 		nnue/nnue_misc.h nnue/features/half_ka_v2_hm.h nnue/layers/affine_transform.h \
@@ -65,7 +65,7 @@ HEADERS = benchmark.h bitboard.h evaluate.h misc.h movegen.h movepick.h history.
 		nnue/nnue_common.h nnue/nnue_feature_transformer.h nnue/simd.h position.h \
                 search.h syzygy/tbprobe.h thread.h thread_win32_osx.h timeman.h \
                 tt.h tune.h types.h uci.h ucioption.h perft.h nnue/network.h engine.h score.h numa.h memory.h \
-                experience.h
+                experience.h experience_v2.hpp
 
 OBJS = $(notdir $(SRCS:.cpp=.o))
 

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -39,6 +39,7 @@
 #include "polybook.h"
 #include "position.h"
 #include "experience.h"
+#include "experience_v2.hpp"
 #include "search.h"
 #include "syzygy/tbprobe.h"
 #include "types.h"
@@ -244,7 +245,15 @@ void Engine::search_clear() {
     Tablebases::release();
 
     if ((bool) options["Experience Enabled"] && !(bool) options["Experience Readonly"])
-        experience.save(options["Experience File"]);
+        {
+            if (experience.dirty())
+            {
+                experience.save(options["Experience File"]);
+                experience.clear_dirty();
+            }
+            else if (experience.empty())
+                seed_dummy_if_empty(options["Experience File"]);
+        }
 }
 
 void Engine::set_on_update_no_moves(std::function<void(const Engine::InfoShort&)>&& f) {

--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -145,6 +145,14 @@ void Experience::load(const std::string& file) {
         }
         else if (isV2)
         {
+            unsigned char pad[6];
+            in.read(reinterpret_cast<char*>(pad), sizeof(pad));
+            if (!in)
+                return;
+            std::array<unsigned char, 32> rpd4{};
+            in.read(reinterpret_cast<char*>(rpd4.data()), rpd4.size());
+            if (!in)
+                return;
             std::array<unsigned char, 62> hdr{};
             in.read(reinterpret_cast<char*>(hdr.data()), hdr.size());
             if (!in)
@@ -267,6 +275,14 @@ void Experience::save(const std::string& file) const {
 
     const std::string sig = "SugaR Experience version 2";  // 26 bytes
     buffer.append(sig);
+    buffer.resize(32, '\0');
+    static const unsigned char RPD4[32] = {
+        0x23,0x72,0x70,0x44,0x34,0x9C,0xE9,0xF6,
+        0xDC,0x04,0x01,0x00,0x11,0x00,0x02,0x00,
+        0x00,0x00,0x00,0x00,0x00,0x00,0x91,0xD5,
+        0xA4,0xC0,0x78,0xE2,0xC0,0x52,0xEF,0x02
+    };
+    buffer.append(reinterpret_cast<const char*>(RPD4), sizeof(RPD4));
     static const unsigned char kExpHeader62[] = {
         0x02,
         0x00,0x80,0xE2,0x63,0xA4,0x80,0x33,0x10,
@@ -294,7 +310,7 @@ void Experience::save(const std::string& file) const {
         wroteAny = true;
     }
 
-    const size_t headerLen = sig.size() + sizeof(kExpHeader62);  // 26 + 62 = 88
+    const size_t headerLen = 32 + sizeof(RPD4) + sizeof(kExpHeader62);
     if (buffer.size() < headerLen)
         return;
     const size_t bodyLen = buffer.size() - headerLen;

--- a/src/experience.h
+++ b/src/experience.h
@@ -48,6 +48,7 @@ class Experience {
                int minDepth, int maxMoves);
     void update(Position& pos, Move move, int score, int depth);
     void insert_entry(uint64_t key, uint16_t move, int value, int depth, int count);
+    bool empty() const { return table.empty(); }
 
     // Dirty / flush helpers
     void mark_dirty()        { dirty_.store(true, std::memory_order_relaxed); }

--- a/src/experience_v2.cpp
+++ b/src/experience_v2.cpp
@@ -1,0 +1,59 @@
+#include "experience_v2.hpp"
+#include "position.h"
+
+#include <cstring>
+
+namespace Stockfish {
+
+void write_sugar_v2_header(std::FILE* f) {
+    SugarV2Header h{};
+    const char* sig = "SugaR Experience version 2";
+    std::memcpy(h.signature, sig, std::strlen(sig));
+    static const unsigned char RPD4[32] = {
+        0x23, 0x72, 0x70, 0x44, 0x34, 0x9C, 0xE9, 0xF6,
+        0xDC, 0x04, 0x01, 0x00, 0x11, 0x00, 0x02, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x91, 0xD5,
+        0xA4, 0xC0, 0x78, 0xE2, 0xC0, 0x52, 0xEF, 0x02
+    };
+    std::memcpy(h.rpd4, RPD4, 32);
+    std::fwrite(&h, 1, sizeof(h), f);
+}
+
+#pragma pack(push,1)
+struct ExpEntry {
+    uint64_t key;
+    int32_t  depth;
+    int32_t  score;
+    int32_t  mov;
+    int32_t  perf;
+};
+#pragma pack(pop)
+
+static inline int32_t pack_book_move(int from, int to, int promo) {
+    return (to & 63) << 6 | (from & 63) | ((promo & 15) << 12);
+}
+
+void seed_dummy_if_empty(const std::string& path) {
+    std::FILE* f = std::fopen(path.c_str(), "ab");
+    if (!f)
+        return;
+
+    constexpr const char* StartFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+    StateInfo st;
+    Position pos;
+    pos.set(StartFEN, false, &st);
+    uint64_t key = pos.key();
+
+    ExpEntry e{};
+    e.key   = key;
+    e.depth = 8;
+    e.score = 0;
+    e.mov   = pack_book_move(12, 28, 0); // e2e4
+    e.perf  = 0;
+
+    std::fwrite(&e, 1, sizeof(e), f);
+    std::fclose(f);
+}
+
+} // namespace Stockfish
+

--- a/src/experience_v2.hpp
+++ b/src/experience_v2.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+
+namespace Stockfish {
+
+#pragma pack(push,1)
+struct SugarV2Header {
+    char signature[32];
+    unsigned char rpd4[32];
+};
+#pragma pack(pop)
+
+void write_sugar_v2_header(std::FILE* f);
+void seed_dummy_if_empty(const std::string& path);
+
+} // namespace Stockfish
+

--- a/src/experience_writer.cpp
+++ b/src/experience_writer.cpp
@@ -1,54 +1,40 @@
 #include "experience_format.h"
 #include "experience.h"
+#include "experience_v2.hpp"
 #include <cstring>
-#include <fstream>
 #include <random>
-
-static void write_header(std::ofstream& os) {
-    ExpHeaderV2 h{};
-    std::memset(h.signature, 0, sizeof(h.signature));
-    const char* sig = "SugaR Experience version 2";
-    std::memcpy(h.signature, sig, std::strlen(sig));
-    os.write(reinterpret_cast<const char*>(&h), sizeof(h));
-}
 
 static uint64_t rand64() {
     std::mt19937_64 rng{std::random_device{}()};
     return rng();
 }
 
-static void write_index_root(std::ofstream& os) {
+namespace Stockfish {
+
+void Experience::create_empty_file(const std::string& path) {
+    std::FILE* f = std::fopen(path.c_str(), "wb");
+    if (!f)
+        return;
+
+    write_sugar_v2_header(f); // 64-byte header
+
     ExpIndexRoot idx{};
     idx.magic        = 0x44707223u;  // LE: 23 72 70 44
     idx.salt_or_uuid = rand64();     // cualquier valor; persistente si quieres
     idx.record_size  = 0x0011;       // ajusta si cambias ExpDummyEntry
     idx.key_size     = 0x0002;       // tamaño de tu clave primaria
     idx.reserved0    = 0;
-    os.write(reinterpret_cast<const char*>(&idx), sizeof(idx));
-}
+    std::fwrite(&idx, 1, sizeof(idx), f);
 
-static void write_dummy_entry(std::ofstream& os) {
     ExpDummyEntry e{};
     e.zobrist = 0x9e3779b97f4a7c15ULL;  // constante dorada / cualquier hash
-    e.move    = 0x1208;                 // ejemplo: from e2->e4 si usas 6+6 bits (ajusta)
-    e.score   = 0;                      // neutro
-    e.depth   = 1;                      // mínima profundidad
-    e.count   = 1;                      // al menos 1
-    os.write(reinterpret_cast<const char*>(&e), sizeof(e));
-}
+    e.move    = 0x1208;                 // ejemplo e2e4
+    e.score   = 0;
+    e.depth   = 1;
+    e.count   = 1;
+    std::fwrite(&e, 1, sizeof(e), f);
 
-namespace Stockfish {
-
-void Experience::create_empty_file(const std::string& path) {
-    std::ofstream os(path, std::ios::binary | std::ios::trunc);
-    if (!os)
-        return;
-
-    write_header(os);       // 32 bytes exactos
-    write_index_root(os);   // bloque root (como Wordfish)
-    write_dummy_entry(os);  // siembra para que HypnoS muestre estadísticas
-
-    os.flush();
+    std::fclose(f);
 }
 
 }  // namespace Stockfish

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -36,6 +36,7 @@
 #include "memory.h"
 #include "movegen.h"
 #include "experience.h"
+#include "experience_v2.hpp"
 #include "position.h"
 #include "score.h"
 #include "search.h"
@@ -118,6 +119,8 @@ void UCIEngine::loop() {
                     experience.save(options["Experience File"]);
                     experience.clear_dirty();
                 }
+                else if (experience.empty())
+                    seed_dummy_if_empty(options["Experience File"]);
             }
         }
         else if (token == "quit")
@@ -128,8 +131,13 @@ void UCIEngine::loop() {
             if ((bool) options["Experience Enabled"] && !(bool) options["Experience Readonly"])
             {
                 std::lock_guard<std::mutex> lk(experience.mtx);
-                experience.save(options["Experience File"]);
-                experience.clear_dirty();
+                if (experience.dirty())
+                {
+                    experience.save(options["Experience File"]);
+                    experience.clear_dirty();
+                }
+                else if (experience.empty())
+                    seed_dummy_if_empty(options["Experience File"]);
             }
             break;
         }

--- a/tests/test_exp_gtest.cpp
+++ b/tests/test_exp_gtest.cpp
@@ -25,25 +25,23 @@ static_assert(sizeof(EntryV2) == 34, "EntryV2 must be 34 bytes");
 
 constexpr const char* kSig = "SugaR Experience version 2";
 
-// Cabecera v2 completa: versión+seed+bucket+entry + 2 metabloques (22B * 2) = 61B
-// Bytes idénticos a los de tu save():
+// Bloque #rpD4 de Revolution (32 bytes)
+static const unsigned char kRPD4[32] = {
+    0x23, 0x72, 0x70, 0x44, 0x34, 0x9C, 0xE9, 0xF6,
+    0xDC, 0x04, 0x01, 0x00, 0x11, 0x00, 0x02, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x91, 0xD5,
+    0xA4, 0xC0, 0x78, 0xE2, 0xC0, 0x52, 0xEF, 0x02
+};
+
+// Cabecera v2 completa: versión+seed+bucket+entry + 2 metabloques (22B * 2) = 62B
 static const unsigned char kHeaderExtra[] = {
-    0x02,                                                              // version
-    0x00, 0x80, 0xE2, 0x63, 0xA4, 0x80, 0x33, 0x10,                    // seed
-    0x06, 0x00, 0x00, 0x00,                                            // bucket_size = 6
-    0x22, 0x00, 0x00, 0x00,                                            // entry_size  = 34
-    // Meta #1
-    0x17, 0x00, 0x00, 0x00,                                            // hash_bits = 23
-    0x01, 0x00, 0x00, 0x00,                                            // reserved
-    0x02, 0x00,                                                        // endian_tag = 0x0002
-    0xE4, 0x6C, 0x3F, 0x41,                                            // k_factor = 11.978f
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,                    // counters = 0
-    // Meta #2 (duplicado)
-    0x17, 0x00, 0x00, 0x00,
-    0x01, 0x00, 0x00, 0x00,
-    0x02, 0x00,
-    0xE4, 0x6C, 0x3F, 0x41,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+    0x02,
+    0x00, 0x80, 0xE2, 0x63, 0xA4, 0x80, 0x33, 0x10,
+    0x06, 0x00, 0x00, 0x00,
+    0x22, 0x00, 0x00, 0x00,
+    0x17, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0xE4, 0x6C, 0x3F, 0x41, 0x8B, 0x26, 0x6D, 0x09, 0x00, 0x00, 0x19, 0x00,
+    0x17, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0xE4, 0x6C, 0x3F, 0x41, 0x8B, 0x26, 0xE7, 0x0B, 0x00, 0x00, 0x14, 0x00,
+    0x00, 0x00
 };
 
 // Utilidad: escribir archivo .exp con N entradas EntryV2
@@ -51,8 +49,11 @@ std::string WriteExpFile(const std::string& path, size_t nEntries) {
     std::ofstream os(path, std::ios::binary);
     if (!os) return {};
 
-    // firma + cabecera
+    // firma + padding + subheader + cabecera
     os.write(kSig, std::char_traits<char>::length(kSig));
+    static const char zeroPad[6] = {0};
+    os.write(zeroPad, sizeof(zeroPad));
+    os.write(reinterpret_cast<const char*>(kRPD4), sizeof(kRPD4));
     os.write(reinterpret_cast<const char*>(kHeaderExtra), sizeof(kHeaderExtra));
 
     // entradas (si las hay)
@@ -87,7 +88,7 @@ std::string WriteExpFile(const std::string& path, size_t nEntries) {
     if (std::string(buf.begin(), buf.end()) != sig)
         return ::testing::AssertionFailure() << "Firma inválida";
 
-    const std::size_t headerExtra = sizeof(kHeaderExtra); // 61
+    const std::size_t headerExtra = 6 + sizeof(kRPD4) + sizeof(kHeaderExtra); // 6 pad + 32 + 62 = 100
     if (size < static_cast<std::streamsize>(sig.size() + headerExtra))
         return ::testing::AssertionFailure() << "Cabecera incompleta";
 


### PR DESCRIPTION
## Summary
- implement 64-byte SugaR v2 header with required #rpD4 block
- align experience save/load to new header and seed dummy entry when file is empty
- hook dummy seeding into engine shutdown and tests

## Testing
- `make -C src build ARCH=x86-64`
- `./src/wordfish-2.0-dev-040925 bench`
- `g++ -std=c++17 tests/test_exp_gtest.cpp -lgtest -lpthread -o /tmp/test_exp && /tmp/test_exp` *(fails: gtest/gtest.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ab87fb3c832789b77e056f7e012d