### PR TITLE
Ensure experience file exists before loading

### DIFF
--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -5,8 +5,6 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
-#include <sstream>
-#include <cstring>
 #include <array>
 
 #include "misc.h"
@@ -52,11 +50,11 @@ void Experience::insert_entry(uint64_t key, uint16_t move, int value, int depth,
 }
 
 void Experience::load(const std::string& file) {
-    std::string path = file;
-    bool        convertBin   = false;
-    bool        binaryFormat = false;
-    bool        isBL         = false;
-    bool        isV2         = false;
+    std::string   path = file;
+    bool          convertBin   = false;
+    bool          binaryFormat = false;
+    bool          isBL         = false;
+    bool          isV2         = false;
 
     const std::string sigV2 = "SugaR Experience version 2";
 

--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -50,11 +50,11 @@ void Experience::insert_entry(uint64_t key, uint16_t move, int value, int depth,
 }
 
 void Experience::load(const std::string& file) {
-    std::string   path = file;
-    bool          convertBin   = false;
-    bool          binaryFormat = false;
-    bool          isBL         = false;
-    bool          isV2         = false;
+    std::string path = file;
+    bool convertBin = false;
+    bool binaryFormat = false;
+    bool isBL = false;
+    bool isV2 = false;
 
     const std::string sigV2 = "SugaR Experience version 2";
 
@@ -67,14 +67,14 @@ void Experience::load(const std::string& file) {
         if (ext == ".bin")
         {
             convertBin = true;
-            path       = path.substr(0, path.size() - 4) + ".exp";
+            path = path.substr(0, path.size() - 4) + ".exp";
             sync_cout << "info string '.bin' experience files are deprecated; converting to '"
                       << path << "'" << sync_endl;
         }
     }
 
     std::ifstream in(path, std::ios::binary);
-    std::string   display = path;
+    std::string display = path;
     if (path != file)
         display += " (from " + file + ")";
 

--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -52,12 +52,11 @@ void Experience::insert_entry(uint64_t key, uint16_t move, int value, int depth,
 }
 
 void Experience::load(const std::string& file) {
-    std::string   path = file;
-    std::ifstream in;
-    bool          convertBin   = false;
-    bool          binaryFormat = false;
-    bool          isBL         = false;
-    bool          isV2         = false;
+    std::string path = file;
+    bool        convertBin   = false;
+    bool        binaryFormat = false;
+    bool        isBL         = false;
+    bool        isV2         = false;
 
     const std::string sigV2 = "SugaR Experience version 2";
 
@@ -70,17 +69,14 @@ void Experience::load(const std::string& file) {
         if (ext == ".bin")
         {
             convertBin = true;
-            in.open(path, std::ios::binary);
-            path = path.substr(0, path.size() - 4) + ".exp";
+            path       = path.substr(0, path.size() - 4) + ".exp";
             sync_cout << "info string '.bin' experience files are deprecated; converting to '"
                       << path << "'" << sync_endl;
         }
     }
 
-    if (!convertBin)
-        in.open(path, std::ios::binary);
-
-    std::string display = path;
+    std::ifstream in(path, std::ios::binary);
+    std::string   display = path;
     if (path != file)
         display += " (from " + file + ")";
 

--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -11,6 +11,7 @@
 
 #include "misc.h"
 #include "rpd4.hpp"
+#include "experience_v2.hpp"  // seed_dummy_if_empty()
 
 namespace Stockfish {
 
@@ -83,10 +84,16 @@ void Experience::load(const std::string& file) {
     if (path != file)
         display += " (from " + file + ")";
 
-    if (!in)
-    {
-        sync_cout << "info string Could not open " << display << sync_endl;
-        return;
+    if (!in) {
+        // Si no existe o no abre, crea el exp mínimo (32B firma + 32B #rpD4 + 62B subheader)
+        seed_dummy_if_empty(path);
+
+        in.clear();
+        in.open(path, std::ios::binary);
+        if (!in) {
+            sync_cout << "info string Could not open " << display << sync_endl;
+            return;
+        }
     }
 
     // Detect format: check for SugaR Experience v2 signature


### PR DESCRIPTION
## Summary
- Delay opening experience file until after extension handling
- Seed minimal experience file when missing and reopen to load data

## Testing
- `cd src && make build ARCH=x86-64-sse41-popcnt -j2`

------
https://chatgpt.com/codex/tasks/task_e_68b9cb6dbf308327acb85ecb5925ec2b