### PR TITLE
Rename engine to Wordfish 2.0 dev-060925 avx

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
-# Revolution authors
+# Wordfish authors
 Jorge Ruiz Centelles (JRCentelles)
 ChatGPT (OpenAI)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.0 dev-060925]
+### Changed
+- Renamed engine to Wordfish 2.0 dev-060925 avx.
+
+
 ## [1.0.1] - 2025-09-01
 ### Added
 - UCI option `Minimum Thinking Time` to enforce a minimum search duration per move.
@@ -11,10 +16,10 @@
 ## [1.0.0-dev 2708225]
 ### Changed
 - Simplified LMR logic to streamline search and improve speed.
-- Updated default engine name to "revolution device v.1.0.0" with build identifier 2708225.
+- Updated default engine name to "wordfish device v.1.0.0" with build identifier 2708225.
 
 ## [1.0] - 2025-08-27
 ### Added
-- Initial public release of Revolution v1.0.
+- Initial public release of Wordfish v1.0.
 - Iterative deepening now starts at depth 2 for faster and deeper analysis.
 - Updated engine name and author information.

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
-Revolution Chess Engine
+Wordfish Chess Engine
 Copyright (c) the Stockfish developers (see AUTHORS file)
 
-Revolution is a UCI chess engine derived from Stockfish. This distribution includes modifications and new code by Jorge Ruiz Centelles, with credit to ChatGPT, exploring new ideas.
+Wordfish is a UCI chess engine derived from Stockfish. This distribution includes modifications and new code by Jorge Ruiz Centelles, with credit to ChatGPT, exploring new ideas.
 
 
 Copyright (c) 2025 Jorge Ruiz Centelles
@@ -11,7 +11,7 @@ it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Revolution incorporates code from the following GPLv3 project:
+Wordfish incorporates code from the following GPLv3 project:
 
 - Stockfish <https://github.com/official-stockfish/Stockfish>
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
-# Revolution Chess Engine
+# Wordfish Chess Engine
 
-**Version 1.0**
+**Version 2.0**
+
+This build identifies as `wordfish 2.0 dev-060925 avx`.
 
 <div align="center">
-  <img src="[https://ijccrl.com/wp-content/uploads/2025/08/revolution.png]" 
-  <h3>Revolution</h3>
+  <img src="[https://ijccrl.com/wp-content/uploads/2025/08/wordfish.png]" 
+  <h3>Wordfish</h3>
   
   A free and open-source UCI chess engine combining classical algorithms with neural network innovations.
   <br>
-  <strong><a href="#">Explore Revolution Documentation »</a>
+  <strong><a href="#">Explore Wordfish Documentation »</a>
 
   <em>Author: This distribution includes modifications and new code by Jorge Ruiz Centelles, with credit to ChatGPT, exploring new ideas.</em>
   
@@ -16,13 +18,13 @@
 
 ## Overview
 
-**Revolution** is a free, open-source UCI chess engine derived from **Stockfish**. Jorge Ruiz Centelles, with credit to ChatGPT, modifies and extends the code to explore new concepts. The engine implements cutting-edge search algorithms combined with neural network evaluation. Derived from fundamental chess programming principles, Revolution analyzes positions through parallelized alpha-beta search enhanced with null-move pruning and late move reductions.
+**Wordfish** is a free, open-source UCI chess engine derived from **Stockfish**. Jorge Ruiz Centelles, with credit to ChatGPT, modifies and extends the code to explore new concepts. The engine implements cutting-edge search algorithms combined with neural network evaluation. Derived from fundamental chess programming principles, Wordfish analyzes positions through parallelized alpha-beta search enhanced with null-move pruning and late move reductions.
 
-As a UCI-compliant engine, Revolution operates through **standard chess interfaces** without an integrated graphical interface. Users must employ compatible chess GUIs (Arena, Scid vs PC, etc.) for board visualization and move input. Consult your GUI documentation for implementation details.
+As a UCI-compliant engine, Wordfish operates through **standard chess interfaces** without an integrated graphical interface. Users must employ compatible chess GUIs (Arena, Scid vs PC, etc.) for board visualization and move input. Consult your GUI documentation for implementation details.
 
 ## Technical Architecture
 
-Revolution's architecture features:
+Wordfish's architecture features:
 
 - Hybrid evaluation system combining classical heuristics with NNUE networks
 - SMP parallelization with YBWC (Young Brothers Wait Concept)
@@ -38,7 +40,7 @@ The distribution includes:
 - `COPYING.txt` ([GNU GPLv3 license][gpl-link])
 - `AUTHORS` (contributor acknowledgments)
 - `src/` (source code with platform-specific Makefiles)
-- Neural network weights (`revolution.nnue`)
+- Neural network weights (`wordfish.nnue`)
 
 ## Contributing
 
@@ -51,13 +53,13 @@ Contributions must adhere to:
 
 ### Testing Infrastructure
 Improvements require extensive testing:
-- Install the [Revolution Test Worker][worker-link]
-- Participate in active tests on [Revolution Test Suite][testsuite-link]
+- Install the [Wordfish Test Worker][worker-link]
+- Participate in active tests on [Wordfish Test Suite][testsuite-link]
 - Verify ELO gains through SPRT validation
 
 ### Community
 Technical discussions occur primarily through:
-- [Revolution Discord Server][discord-link]
+- [Wordfish Discord Server][discord-link]
 - [GitHub Discussions][discussions-link]
 - [Chess Programming Wiki][chesswiki-link]
 
@@ -78,7 +80,7 @@ Full compilation guides available in [documentation][doc-link].
 
 ## Syzygy Tablebases
 
-Revolution can probe [Syzygy](https://github.com/syzygy1) endgame tablebases when a
+Wordfish can probe [Syzygy](https://github.com/syzygy1) endgame tablebases when a
 directory is supplied via the `SyzygyPath` UCI option. The engine also exposes a
 `SyzygyPremap` boolean option. When set to `true`, `Tablebases::init` pre-maps all
 available WDL and DTZ tables during initialization, reducing probe latency at the
@@ -86,7 +88,7 @@ expense of additional startup time and memory usage.
 
 ## Experience Learning
 
-Revolution includes a simple text-based cache that stores root moves and evaluations from
+Wordfish includes a simple text-based cache that stores root moves and evaluations from
 previous games. Rather than forcing book moves, the cached information biases root move
 ordering during search. The following UCI options control this system:
 
@@ -119,7 +121,7 @@ setoption name Minimum Thinking Time value <milliseconds>
 
 ### Falcon Net
 
-Revolution can switch to an alternative neural network using the
+Wordfish can switch to an alternative neural network using the
 `FalconFile` option. To load the bundled `3.net` file, send:
 
 ```
@@ -128,12 +130,12 @@ setoption name FalconFile value 3.net
 
 ## License
 
-Revolution is distributed under the **[GNU General Public License v3][gpl-link]** (GPLv3).
+Wordfish is distributed under the **[GNU General Public License v3][gpl-link]** (GPLv3).
 It integrates source code from:
 
 - [Stockfish](https://github.com/official-stockfish/Stockfish)
 
-Because Stockfish is GPLv3, any distribution of Revolution must also comply with GPLv3.
+Because Stockfish is GPLv3, any distribution of Wordfish must also comply with GPLv3.
 For a summary of your obligations under GPLv3 see <https://www.gnu.org/licenses/quick-guide-gplv3.html>.
 When redistributing, you must:
 1. Include the original license text (`COPYING.txt`)
@@ -142,7 +144,7 @@ When redistributing, you must:
 
 ## Acknowledgements
 
-Revolution also benefits from:
+Wordfish also benefits from:
 - Neural networks trained on [Lichess open database][lichess-db]
 - Search techniques from [CCC testing community][ccc-link]
 - Positional analysis concepts from [CPW research][cpw-link]

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,6 +1,6 @@
 # Benchmarking Procedure
 
-This document outlines how to benchmark **Revolution** against other engines.
+This document outlines how to benchmark **Wordfish** against other engines.
 
 ## 1. Build the Engine
 ```bash

--- a/docs/preliminary_results.md
+++ b/docs/preliminary_results.md
@@ -3,7 +3,7 @@
 Small-scale matches (100 games, 40/0.4+0.4) were run using `scripts/match.sh`.
 The table below shows early Elo differences computed with [Ordo](https://github.com/michaelkeenan/ordo).
 
-| Engine          | Elo vs Revolution |
+| Engine          | Elo vs Wordfish |
 |-----------------|------------------|
 | Stockfish 16    | +280             |
 | Berserk 12      | +150             |

--- a/scripts/fishtest_local.sh
+++ b/scripts/fishtest_local.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# Launch a local fishtest worker for tuning Revolution.
+# Launch a local fishtest worker for tuning Wordfish.
 # Requires a fishtest repository cloned locally.
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE="$ROOT_DIR/src/revolution"
+ENGINE="$ROOT_DIR/src/wordfish"
 FISHTEST_DIR="${FISHTEST_DIR:-$HOME/fishtest}"
 
 if [ ! -x "$ENGINE" ]; then

--- a/scripts/match.sh
+++ b/scripts/match.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# Run automated matches between Revolution and another UCI engine using cutechess-cli.
+# Run automated matches between Wordfish and another UCI engine using cutechess-cli.
 # Usage: scripts/match.sh /path/to/opponent [games] [timecontrol]
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE="${ENGINE:-$ROOT_DIR/src/revolution}"
+ENGINE="${ENGINE:-$ROOT_DIR/src/wordfish}"
 OPPONENT="${1:?Opponent engine path required}"
 GAMES="${2:-10}"
 TC="${3:-40/0.4+0.4}"
@@ -15,7 +15,7 @@ if ! command -v cutechess-cli >/dev/null; then
 fi
 
 cutechess-cli \
-  -engine cmd="$ENGINE" name=Revolution \
+  -engine cmd="$ENGINE" name=Wordfish \
   -engine cmd="$OPPONENT" name=Opponent \
   -each proto=uci tc=$TC \
   -games $GAMES -concurrency 2 \

--- a/scripts/perft.sh
+++ b/scripts/perft.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# Run perft validation on the Revolution engine.
+# Run perft validation on the Wordfish engine.
 # Builds the engine if needed and executes the existing test suite.
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE="$ROOT_DIR/src/revolution"
+ENGINE="$ROOT_DIR/src/wordfish"
 TEST_DIR="$ROOT_DIR/tests"
 
 if [ ! -x "$ENGINE" ]; then

--- a/scripts/spsa.py
+++ b/scripts/spsa.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Simple SPSA tuner for the Revolution engine."""
+"""Simple SPSA tuner for the Wordfish engine."""
 import argparse
 import os
 import random
@@ -19,9 +19,9 @@ def run_bench(engine, name, value):
     raise RuntimeError("Unexpected bench output")
 
 def main():
-    p = argparse.ArgumentParser(description="SPSA tuning for Revolution")
+    p = argparse.ArgumentParser(description="SPSA tuning for Wordfish")
     p.add_argument("--param", nargs=4, metavar=("NAME", "START", "MIN", "MAX"), action='append', required=True)
-    p.add_argument("--engine", default="src/revolution")
+    p.add_argument("--engine", default="src/wordfish")
     p.add_argument("--iterations", type=int, default=10)
     args = p.parse_args()
 

--- a/sparsehash/dense_hash_map
+++ b/sparsehash/dense_hash_map
@@ -1,7 +1,7 @@
-#ifndef REVOLUTION_SPARSEHASH_DENSE_HASH_MAP_H
-#define REVOLUTION_SPARSEHASH_DENSE_HASH_MAP_H
+#ifndef WORDFISH_SPARSEHASH_DENSE_HASH_MAP_H
+#define WORDFISH_SPARSEHASH_DENSE_HASH_MAP_H
 
-// Placeholder dense_hash_map for the Revolution project.
+// Placeholder dense_hash_map for the Wordfish project.
 // Implementation intentionally minimal.
 
-#endif // REVOLUTION_SPARSEHASH_DENSE_HASH_MAP_H
+#endif // WORDFISH_SPARSEHASH_DENSE_HASH_MAP_H

--- a/sparsehash/dense_hash_set
+++ b/sparsehash/dense_hash_set
@@ -1,7 +1,7 @@
-#ifndef REVOLUTION_SPARSEHASH_DENSE_HASH_SET_H
-#define REVOLUTION_SPARSEHASH_DENSE_HASH_SET_H
+#ifndef WORDFISH_SPARSEHASH_DENSE_HASH_SET_H
+#define WORDFISH_SPARSEHASH_DENSE_HASH_SET_H
 
-// Placeholder dense_hash_set for the Revolution project.
+// Placeholder dense_hash_set for the Wordfish project.
 // Implementation intentionally minimal.
 
-#endif // REVOLUTION_SPARSEHASH_DENSE_HASH_SET_H
+#endif // WORDFISH_SPARSEHASH_DENSE_HASH_SET_H

--- a/sparsehash/sparse_hash_map
+++ b/sparsehash/sparse_hash_map
@@ -1,7 +1,7 @@
-#ifndef REVOLUTION_SPARSEHASH_SPARSE_HASH_MAP_H
-#define REVOLUTION_SPARSEHASH_SPARSE_HASH_MAP_H
+#ifndef WORDFISH_SPARSEHASH_SPARSE_HASH_MAP_H
+#define WORDFISH_SPARSEHASH_SPARSE_HASH_MAP_H
 
-// Placeholder sparse_hash_map for the Revolution project.
+// Placeholder sparse_hash_map for the Wordfish project.
 // Implementation intentionally minimal.
 
-#endif // REVOLUTION_SPARSEHASH_SPARSE_HASH_MAP_H
+#endif // WORDFISH_SPARSEHASH_SPARSE_HASH_MAP_H

--- a/sparsehash/sparse_hash_set
+++ b/sparsehash/sparse_hash_set
@@ -1,7 +1,7 @@
-#ifndef REVOLUTION_SPARSEHASH_SPARSE_HASH_SET_H
-#define REVOLUTION_SPARSEHASH_SPARSE_HASH_SET_H
+#ifndef WORDFISH_SPARSEHASH_SPARSE_HASH_SET_H
+#define WORDFISH_SPARSEHASH_SPARSE_HASH_SET_H
 
-// Placeholder sparse_hash_set for the Revolution project.
+// Placeholder sparse_hash_set for the Wordfish project.
 // Implementation intentionally minimal.
 
-#endif // REVOLUTION_SPARSEHASH_SPARSE_HASH_SET_H
+#endif // WORDFISH_SPARSEHASH_SPARSE_HASH_SET_H

--- a/sparsehash/sparsetable
+++ b/sparsehash/sparsetable
@@ -1,7 +1,7 @@
-#ifndef REVOLUTION_SPARSEHASH_SPARSETABLE_H
-#define REVOLUTION_SPARSEHASH_SPARSETABLE_H
+#ifndef WORDFISH_SPARSEHASH_SPARSETABLE_H
+#define WORDFISH_SPARSEHASH_SPARSETABLE_H
 
-// Placeholder sparsetable for the Revolution project.
+// Placeholder sparsetable for the Wordfish project.
 // Implementation intentionally minimal.
 
-#endif // REVOLUTION_SPARSEHASH_SPARSETABLE_H
+#endif // WORDFISH_SPARSEHASH_SPARSETABLE_H

--- a/sparsehash/template_util.h
+++ b/sparsehash/template_util.h
@@ -1,7 +1,7 @@
-#ifndef REVOLUTION_SPARSEHASH_TEMPLATE_UTIL_H
-#define REVOLUTION_SPARSEHASH_TEMPLATE_UTIL_H
+#ifndef WORDFISH_SPARSEHASH_TEMPLATE_UTIL_H
+#define WORDFISH_SPARSEHASH_TEMPLATE_UTIL_H
 
-// Utility templates for the Revolution project's sparsehash placeholders.
+// Utility templates for the Wordfish project's sparsehash placeholders.
 // Implementation intentionally minimal.
 
-#endif // REVOLUTION_SPARSEHASH_TEMPLATE_UTIL_H
+#endif // WORDFISH_SPARSEHASH_TEMPLATE_UTIL_H

--- a/sparsehash/type_traits.h
+++ b/sparsehash/type_traits.h
@@ -1,7 +1,7 @@
-#ifndef REVOLUTION_SPARSEHASH_TYPE_TRAITS_H
-#define REVOLUTION_SPARSEHASH_TYPE_TRAITS_H
+#ifndef WORDFISH_SPARSEHASH_TYPE_TRAITS_H
+#define WORDFISH_SPARSEHASH_TYPE_TRAITS_H
 
-// Type trait helpers for the Revolution project's sparsehash placeholders.
+// Type trait helpers for the Wordfish project's sparsehash placeholders.
 // Implementation intentionally minimal.
 
-#endif // REVOLUTION_SPARSEHASH_TYPE_TRAITS_H
+#endif // WORDFISH_SPARSEHASH_TYPE_TRAITS_H

--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = revolution_dev_010925_v1.0.1.exe
+        EXE = wordfish_dev_060925_v2.0.exe
 else
-        EXE = revolution_dev_010925_v1.0.1
+        EXE = wordfish_dev_060925_v2.0
 endif
 
 ### Installation dir definitions
@@ -859,11 +859,11 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 # UCI "id name" string shown in GUIs.
 # Defaults:
-#   - ENGINE_NAME: "revolution dev-1.0.1 050925 avx"
+#   - ENGINE_NAME: "wordfish 2.0 dev-060925 avx"
 #   - ENGINE_BUILD_DATE: optional build identifier
 # You can override on the command line:
-#   make ENGINE_NAME="revolution dev-1.0.1 050925 avx" ENGINE_BUILD_DATE=20250901
-ENGINE_NAME        ?= revolution dev-1.0.1 050925 avx
+#   make ENGINE_NAME="wordfish 2.0 dev-060925 avx" ENGINE_BUILD_DATE=20250901
+ENGINE_NAME        ?= wordfish 2.0 dev-060925 avx
 ENGINE_BUILD_DATE  ?=
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 

--- a/src/README_CHANGELOG.txt
+++ b/src/README_CHANGELOG.txt
@@ -1,4 +1,4 @@
-Revolution 1.0 dev 250827
+Wordfish 2.0 dev 060925
 - Initial fork from Stockfish.
 - Updated engine name and build system.
 - Added experience book system with persistent `.exp` file (legacy `.bin` files are converted automatically) and new UCI options.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,8 +25,8 @@
 #include "position.h"
 
 #ifndef ENGINE_NAME
-    // override at build time with:  -DENGINE_NAME="\"revolution dev-1.0.1 050925 avx\""
-    #define ENGINE_NAME "revolution dev-1.0.1 050925 avx"
+    // override at build time with:  -DENGINE_NAME="\"wordfish 2.0 dev-060925 avx\""
+    #define ENGINE_NAME "wordfish 2.0 dev-060925 avx"
 #endif
 
 using namespace Stockfish;

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -37,7 +37,7 @@
 
 #include "types.h"
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "revolution dev-1.0.1 050925 avx"
+    #define ENGINE_NAME "wordfish 2.0 dev-060925 avx"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""
@@ -118,7 +118,7 @@ class Logger {
 }  // namespace
 
 
-// Returns the full name of the current Revolution version.
+// Returns the full name of the current Wordfish version.
 std::string engine_version_info() { return std::string(ENGINE_NAME); }
 
 // Update author information

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -43,7 +43,7 @@
 #include "ucioption.h"
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "revolution dev-1.0.1 050925 avx"
+    #define ENGINE_NAME "wordfish 2.0 dev-060925 avx"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""
@@ -124,7 +124,7 @@ void UCIEngine::loop() {
 
         else if (token == "uci")
         {
-            // Force a stable, explicit UCI name so GUIs show "Revolution 1.0"
+            // Force a stable, explicit UCI name so GUIs show "Wordfish 1.0"
             sync_cout_start();
             std::cout << "id name " << ENGINE_NAME
                       << "\n"

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -21,7 +21,7 @@
 #include "ucioption.h"
 // --- Engine identity (fallbacks; Makefile can override) ---
 #ifndef ENGINE_NAME
-#define ENGINE_NAME "revolution dev-1.0.1 050925 avx"
+#define ENGINE_NAME "wordfish 2.0 dev-060925 avx"
 #endif
 #ifndef ENGINE_BUILD_DATE
 #define ENGINE_BUILD_DATE ""  // build identifier


### PR DESCRIPTION
## Summary
- Rename all remnants of Revolution to Wordfish
- Set default engine ID to `wordfish 2.0 dev-060925 avx`
- Update build scripts, docs, and helper scripts for the new name

## Testing
- `make build ARCH=x86-64`
- `echo -e "uci\nquit" | ./wordfish_dev_060925_v2.0 | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68bb622b399c832789f33ebb903094e0