### PR TITLE
Add dynamic activity bonus for aggressive evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## [2.0.1 avx 070925]
+## [2.10 dev-090925 avx]
 ### Changed
-- Updated engine id name to "Wordfish v. 2.0.1 avx 070925".
+- Updated engine id name to "Wordfish v.2.10 dev-090925 avx".
 - Strengthened king safety evaluation and extended search on exposed enemy kings.
+- Introduced dynamic activity evaluation emphasizing mobility and initiative.
 
 ## [2.0 dev-060925]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.10 dev-090925 avx]
+### Changed
+- Updated engine id name to "Wordfish v2.10 dev-090925 avx".
+- Strengthened king safety evaluation and extended search on exposed enemy kings.
+
 ## [2.0 dev-060925]
 ### Changed
 - Renamed engine to Wordfish 2.0 dev-060925 avx.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## [2.10 dev-090925 avx]
+## [2.0.1 avx 070925]
 ### Changed
-- Updated engine id name to "Wordfish v2.10 dev-090925 avx".
+- Updated engine id name to "Wordfish v. 2.0.1 avx 070925".
 - Strengthened king safety evaluation and extended search on exposed enemy kings.
 
 ## [2.0 dev-060925]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [2.10 dev-090925 avx]
 ### Changed
-- Updated engine id name to "Wordfish v.2.10 dev-090925 avx".
+- Updated engine id name to "Wordfish v2.10 dev-090925 avx".
 - Strengthened king safety evaluation and extended search on exposed enemy kings.
 - Introduced dynamic activity evaluation emphasizing mobility and initiative.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Wordfish Chess Engine
 
-**Version 2.0.1**
+**Version 2.10**
 
-This build identifies as `Wordfish v. 2.0.1 avx 070925`.
+This build identifies as `Wordfish v.2.10 dev-090925 avx`.
 
 <div align="center">
   <img src="[https://ijccrl.com/wp-content/uploads/2025/08/wordfish.png]" 
@@ -31,6 +31,7 @@ Wordfish's architecture features:
 - Advanced pruning techniques (Reverse Futility Pruning, Late Move Pruning)
 - Efficient move ordering with history heuristics and killer moves
 - Aggressive king-safety heuristics extending search on exposed kings
+- Dynamic activity scoring to favor mobility and pressure near the enemy king
 - Optional root experience book storing previously played moves
 
 ## Files

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Wordfish Chess Engine
 
-**Version 2.0**
+**Version 2.10**
 
-This build identifies as `wordfish 2.0 dev-060925 avx`.
+This build identifies as `Wordfish v2.10 dev-090925 avx`.
 
 <div align="center">
   <img src="[https://ijccrl.com/wp-content/uploads/2025/08/wordfish.png]" 
@@ -30,6 +30,7 @@ Wordfish's architecture features:
 - SMP parallelization with YBWC (Young Brothers Wait Concept)
 - Advanced pruning techniques (Reverse Futility Pruning, Late Move Pruning)
 - Efficient move ordering with history heuristics and killer moves
+- Aggressive king-safety heuristics extending search on exposed kings
 - Optional root experience book storing previously played moves
 
 ## Files

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Wordfish Chess Engine
 
-**Version 2.10**
+**Version 2.0.1**
 
-This build identifies as `Wordfish v2.10 dev-090925 avx`.
+This build identifies as `Wordfish v. 2.0.1 avx 070925`.
 
 <div align="center">
   <img src="[https://ijccrl.com/wp-content/uploads/2025/08/wordfish.png]" 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Version 2.10**
 
-This build identifies as `Wordfish v.2.10 dev-090925 avx`.
+This build identifies as `Wordfish v2.10 dev-090925 avx`.
 
 <div align="center">
   <img src="[https://ijccrl.com/wp-content/uploads/2025/08/wordfish.png]" 

--- a/src/Makefile
+++ b/src/Makefile
@@ -38,10 +38,10 @@ else ifeq ($(COMP),mingw)
 endif
 
 ### Executable name
-ifeq ($(target_windows),yes)
-        EXE = wordfish_dev-090925_v2.10.exe
+ifeq (0 0target_windows),yes)
+        EXE = wordfish_dev_070925_v2.0.1.exe
 else
-        EXE = wordfish_dev-090925_v2.10
+        EXE = wordfish_dev_070925_v2.0.1
 endif
 
 ### Installation dir definitions
@@ -859,11 +859,11 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 # UCI "id name" string shown in GUIs.
 # Defaults:
-#   - ENGINE_NAME: "Wordfish v2.10 dev-090925 avx"
+#   - ENGINE_NAME: "Wordfish v. 2.0.1 avx 070925"
 #   - ENGINE_BUILD_DATE: optional build identifier
 # You can override on the command line:
-#   make ENGINE_NAME="Wordfish v2.10 dev-090925 avx" ENGINE_BUILD_DATE=20250909
-ENGINE_NAME        ?= Wordfish v2.10 dev-090925 avx
+#   make ENGINE_NAME="Wordfish v. 2.0.1 avx 070925" ENGINE_BUILD_DATE=20250907
+ENGINE_NAME        ?= Wordfish v. 2.0.1 avx 070925
 ENGINE_BUILD_DATE  ?=
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = wordfish_dev_060925_v2.0.exe
+        EXE = wordfish_dev-090925_v2.10.exe
 else
-        EXE = wordfish_dev_060925_v2.0
+        EXE = wordfish_dev-090925_v2.10
 endif
 
 ### Installation dir definitions
@@ -859,11 +859,11 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 # UCI "id name" string shown in GUIs.
 # Defaults:
-#   - ENGINE_NAME: "wordfish 2.0 dev-060925 avx"
+#   - ENGINE_NAME: "Wordfish v2.10 dev-090925 avx"
 #   - ENGINE_BUILD_DATE: optional build identifier
 # You can override on the command line:
-#   make ENGINE_NAME="wordfish 2.0 dev-060925 avx" ENGINE_BUILD_DATE=20250901
-ENGINE_NAME        ?= wordfish 2.0 dev-060925 avx
+#   make ENGINE_NAME="Wordfish v2.10 dev-090925 avx" ENGINE_BUILD_DATE=20250909
+ENGINE_NAME        ?= Wordfish v2.10 dev-090925 avx
 ENGINE_BUILD_DATE  ?=
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -38,10 +38,10 @@ else ifeq ($(COMP),mingw)
 endif
 
 ### Executable name
-ifeq (0 0target_windows),yes)
-        EXE = wordfish_dev_070925_v2.0.1.exe
+ifeq ($(target_windows),yes)
+        EXE = wordfish_dev-090925_v2.10.exe
 else
-        EXE = wordfish_dev_070925_v2.0.1
+        EXE = wordfish_dev-090925_v2.10
 endif
 
 ### Installation dir definitions
@@ -859,11 +859,11 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 # UCI "id name" string shown in GUIs.
 # Defaults:
-#   - ENGINE_NAME: "Wordfish v. 2.0.1 avx 070925"
+#   - ENGINE_NAME: "Wordfish v.2.10 dev-090925 avx"
 #   - ENGINE_BUILD_DATE: optional build identifier
 # You can override on the command line:
-#   make ENGINE_NAME="Wordfish v. 2.0.1 avx 070925" ENGINE_BUILD_DATE=20250907
-ENGINE_NAME        ?= Wordfish v. 2.0.1 avx 070925
+#   make ENGINE_NAME="Wordfish v.2.10 dev-090925 avx" ENGINE_BUILD_DATE=20250909
+ENGINE_NAME        ?= Wordfish v.2.10 dev-090925 avx
 ENGINE_BUILD_DATE  ?=
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -859,11 +859,11 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 # UCI "id name" string shown in GUIs.
 # Defaults:
-#   - ENGINE_NAME: "Wordfish v.2.10 dev-090925 avx"
+#   - ENGINE_NAME: "Wordfish v2.10 dev-090925 avx"
 #   - ENGINE_BUILD_DATE: optional build identifier
 # You can override on the command line:
-#   make ENGINE_NAME="Wordfish v.2.10 dev-090925 avx" ENGINE_BUILD_DATE=20250909
-ENGINE_NAME        ?= Wordfish v.2.10 dev-090925 avx
+#   make ENGINE_NAME="Wordfish v2.10 dev-090925 avx" ENGINE_BUILD_DATE=20250909
+ENGINE_NAME        ?= Wordfish v2.10 dev-090925 avx
 ENGINE_BUILD_DATE  ?=
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 

--- a/src/README_CHANGELOG.txt
+++ b/src/README_CHANGELOG.txt
@@ -1,7 +1,8 @@
-Wordfish v. 2.0.1 avx 070925
+Wordfish v.2.10 dev-090925 avx
 - Initial fork from Stockfish.
 - Updated engine name and build system.
 - Added experience book system with persistent `.exp` file (legacy `.bin` files are converted automatically) and new UCI options.
 - Iterative deepening now begins at depth 2 for faster, deeper search.
 - Strengthened king safety evaluation and search extensions for exposed kings.
+- Introduced dynamic activity evaluation to reward mobility and pressure on the enemy king.
 - Updated version strings and AUTHORS for first public release.

--- a/src/README_CHANGELOG.txt
+++ b/src/README_CHANGELOG.txt
@@ -1,4 +1,4 @@
-Wordfish v2.10 dev-090925 avx
+Wordfish v. 2.0.1 avx 070925
 - Initial fork from Stockfish.
 - Updated engine name and build system.
 - Added experience book system with persistent `.exp` file (legacy `.bin` files are converted automatically) and new UCI options.

--- a/src/README_CHANGELOG.txt
+++ b/src/README_CHANGELOG.txt
@@ -1,4 +1,4 @@
-Wordfish v.2.10 dev-090925 avx
+Wordfish v2.10 dev-090925 avx
 - Initial fork from Stockfish.
 - Updated engine name and build system.
 - Added experience book system with persistent `.exp` file (legacy `.bin` files are converted automatically) and new UCI options.

--- a/src/README_CHANGELOG.txt
+++ b/src/README_CHANGELOG.txt
@@ -1,6 +1,7 @@
-Wordfish 2.0 dev 060925
+Wordfish v2.10 dev-090925 avx
 - Initial fork from Stockfish.
 - Updated engine name and build system.
 - Added experience book system with persistent `.exp` file (legacy `.bin` files are converted automatically) and new UCI options.
 - Iterative deepening now begins at depth 2 for faster, deeper search.
+- Strengthened king safety evaluation and search extensions for exposed kings.
 - Updated version strings and AUTHORS for first public release.

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -125,6 +125,65 @@ Value adaptive_style_bonus(const Position& pos, Value current) {
     return Value(bonus);
 }
 
+// Compute a bonus favouring dynamic piece activity and king pressure. The goal
+// is to reward mobility and coordinated attacks so that sacrificial play with
+// strong initiative is penalized less by the static evaluation.
+Value dynamic_activity_bonus(const Position& pos) {
+    auto activity_score = [&](Color side) {
+        Color    us        = side;
+        Color    them      = ~us;
+        Square   enemyKing = pos.square<KING>(them);
+        Bitboard kingRing  = attacks_bb<KING>(enemyKing) | square_bb(enemyKing);
+
+        int mobility = popcount(pos.attacks_by<KNIGHT>(us)) + popcount(pos.attacks_by<BISHOP>(us))
+                     + popcount(pos.attacks_by<ROOK>(us)) + popcount(pos.attacks_by<QUEEN>(us));
+
+        int ringAttacks = popcount(pos.attacks_by<KNIGHT>(us) & kingRing)
+                        + popcount(pos.attacks_by<BISHOP>(us) & kingRing)
+                        + popcount(pos.attacks_by<ROOK>(us) & kingRing)
+                        + popcount(pos.attacks_by<QUEEN>(us) & kingRing)
+                        + popcount(pos.attacks_by<PAWN>(us) & kingRing);
+
+        int directAttackers = popcount(pos.attackers_to(enemyKing) & pos.pieces(us));
+
+        int score = mobility + ringAttacks * 8 + directAttackers * 16;
+
+        int material = pos.non_pawn_material(us) - pos.non_pawn_material(them)
+                     + PawnValue * (pos.count<PAWN>(us) - pos.count<PAWN>(them));
+
+        if (material < 0)
+            score += (-material) * ringAttacks / 64;
+
+        return score;
+    };
+
+    int usScore   = activity_score(pos.side_to_move());
+    int themScore = activity_score(~pos.side_to_move());
+
+    return Value(usScore - themScore);
+}
+
+// Evaluate the opponent king's safety aggressively, rewarding exposed kings
+// and active attackers even at the cost of material. Weak pawn cover and
+// direct pressure yield a higher bonus for the side to move.
+Value aggressive_king_safety_bonus(const Position& pos) {
+    auto danger_score = [&](Color side) {
+        Color  us    = side;
+        Color  them  = ~us;
+        Square ksq   = pos.square<KING>(them);
+        Bitboard ring = attacks_bb<KING>(ksq) | square_bb(ksq);
+        int pawnCover = popcount(pos.pieces(them, PAWN) & ring);
+        int attackers = popcount(pos.attackers_to(ksq) & pos.pieces(us));
+
+        return attackers * 16 + (3 - pawnCover) * 32;
+    };
+
+    int usScore   = danger_score(pos.side_to_move());
+    int themScore = danger_score(~pos.side_to_move());
+
+    return Value(usScore - themScore);
+}
+
 }  // namespace
 
 namespace Eval {
@@ -243,6 +302,10 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
 
     // Damp down the evaluation linearly when shuffling
     v -= v * pos.rule50_count() / 212;
+
+    // Encourage dynamic play: reward mobility and attacks on the enemy king
+    v += dynamic_activity_bonus(pos);
+    v += aggressive_king_safety_bonus(pos);
 
     // Guarantee evaluation does not hit the tablebase range
     v = std::clamp(v, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,8 +25,8 @@
 #include "position.h"
 
 #ifndef ENGINE_NAME
-    // override at build time with:  -DENGINE_NAME="\"Wordfish v. 2.0.1 avx 070925\""
-    #define ENGINE_NAME "Wordfish v. 2.0.1 avx 070925"
+    // override at build time with:  -DENGINE_NAME="\"Wordfish v.2.10 dev-090925 avx\""
+    #define ENGINE_NAME "Wordfish v.2.10 dev-090925 avx"
 #endif
 
 using namespace Stockfish;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,8 +25,8 @@
 #include "position.h"
 
 #ifndef ENGINE_NAME
-    // override at build time with:  -DENGINE_NAME="\"wordfish 2.0 dev-060925 avx\""
-    #define ENGINE_NAME "wordfish 2.0 dev-060925 avx"
+    // override at build time with:  -DENGINE_NAME="\"Wordfish v2.10 dev-090925 avx\""
+    #define ENGINE_NAME "Wordfish v2.10 dev-090925 avx"
 #endif
 
 using namespace Stockfish;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,8 +25,8 @@
 #include "position.h"
 
 #ifndef ENGINE_NAME
-    // override at build time with:  -DENGINE_NAME="\"Wordfish v.2.10 dev-090925 avx\""
-    #define ENGINE_NAME "Wordfish v.2.10 dev-090925 avx"
+    // override at build time with:  -DENGINE_NAME="\"Wordfish v2.10 dev-090925 avx\""
+    #define ENGINE_NAME "Wordfish v2.10 dev-090925 avx"
 #endif
 
 using namespace Stockfish;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,8 +25,8 @@
 #include "position.h"
 
 #ifndef ENGINE_NAME
-    // override at build time with:  -DENGINE_NAME="\"Wordfish v2.10 dev-090925 avx\""
-    #define ENGINE_NAME "Wordfish v2.10 dev-090925 avx"
+    // override at build time with:  -DENGINE_NAME="\"Wordfish v. 2.0.1 avx 070925\""
+    #define ENGINE_NAME "Wordfish v. 2.0.1 avx 070925"
 #endif
 
 using namespace Stockfish;

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -37,7 +37,7 @@
 
 #include "types.h"
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "Wordfish v2.10 dev-090925 avx"
+    #define ENGINE_NAME "Wordfish v. 2.0.1 avx 070925"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -37,7 +37,7 @@
 
 #include "types.h"
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "Wordfish v. 2.0.1 avx 070925"
+    #define ENGINE_NAME "Wordfish v.2.10 dev-090925 avx"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -37,7 +37,7 @@
 
 #include "types.h"
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "wordfish 2.0 dev-060925 avx"
+    #define ENGINE_NAME "Wordfish v2.10 dev-090925 avx"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -37,7 +37,7 @@
 
 #include "types.h"
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "Wordfish v.2.10 dev-090925 avx"
+    #define ENGINE_NAME "Wordfish v2.10 dev-090925 avx"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1248,6 +1248,20 @@ moves_loop:  // When in check, search starts here
                 extension = -2;
         }
 
+        // Extend search when checking a poorly shielded king, even for
+        // sacrificial attempts. This favors aggressive lines that expose
+        // the opponent king.
+        if (!rootNode && givesCheck)
+        {
+            Square   kingSq   = pos.square<KING>(~us);
+            Bitboard kingRing = attacks_bb<KING>(kingSq);
+            int      cover    = popcount(pos.pieces(~us, PAWN) & kingRing);
+            bool     sacrifice = !pos.see_ge(move, 0);
+
+            if (cover <= 1 || (cover <= 2 && sacrifice))
+                extension = std::max<Depth>(extension, 1);
+        }
+
         // Step 16. Make the move
         do_move(pos, move, st, givesCheck, ss);
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -43,7 +43,7 @@
 #include "ucioption.h"
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "Wordfish v2.10 dev-090925 avx"
+    #define ENGINE_NAME "Wordfish v. 2.0.1 avx 070925"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -43,7 +43,7 @@
 #include "ucioption.h"
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "Wordfish v.2.10 dev-090925 avx"
+    #define ENGINE_NAME "Wordfish v2.10 dev-090925 avx"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -43,7 +43,7 @@
 #include "ucioption.h"
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "Wordfish v. 2.0.1 avx 070925"
+    #define ENGINE_NAME "Wordfish v.2.10 dev-090925 avx"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -43,7 +43,7 @@
 #include "ucioption.h"
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "wordfish 2.0 dev-060925 avx"
+    #define ENGINE_NAME "Wordfish v2.10 dev-090925 avx"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -21,7 +21,7 @@
 #include "ucioption.h"
 // --- Engine identity (fallbacks; Makefile can override) ---
 #ifndef ENGINE_NAME
-#define ENGINE_NAME "Wordfish v.2.10 dev-090925 avx"
+#define ENGINE_NAME "Wordfish v2.10 dev-090925 avx"
 #endif
 #ifndef ENGINE_BUILD_DATE
 #define ENGINE_BUILD_DATE ""  // build identifier

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -21,7 +21,7 @@
 #include "ucioption.h"
 // --- Engine identity (fallbacks; Makefile can override) ---
 #ifndef ENGINE_NAME
-#define ENGINE_NAME "wordfish 2.0 dev-060925 avx"
+#define ENGINE_NAME "Wordfish v2.10 dev-090925 avx"
 #endif
 #ifndef ENGINE_BUILD_DATE
 #define ENGINE_BUILD_DATE ""  // build identifier

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -21,7 +21,7 @@
 #include "ucioption.h"
 // --- Engine identity (fallbacks; Makefile can override) ---
 #ifndef ENGINE_NAME
-#define ENGINE_NAME "Wordfish v2.10 dev-090925 avx"
+#define ENGINE_NAME "Wordfish v. 2.0.1 avx 070925"
 #endif
 #ifndef ENGINE_BUILD_DATE
 #define ENGINE_BUILD_DATE ""  // build identifier

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -21,7 +21,7 @@
 #include "ucioption.h"
 // --- Engine identity (fallbacks; Makefile can override) ---
 #ifndef ENGINE_NAME
-#define ENGINE_NAME "Wordfish v. 2.0.1 avx 070925"
+#define ENGINE_NAME "Wordfish v.2.10 dev-090925 avx"
 #endif
 #ifndef ENGINE_BUILD_DATE
 #define ENGINE_BUILD_DATE ""  // build identifier


### PR DESCRIPTION
## Summary
- reward mobility and coordinated king attacks with new `dynamic_activity_bonus`
- apply activity and king-safety bonuses in evaluation to prioritize exposed enemy kings
- extend search when checking poorly defended kings for aggressive follow-ups
- rename engine id to `Wordfish v2.10 dev-090925 avx` for clearer build identification

## Testing
- `make -C src build`
- `bash tests/perft.sh src/wordfish_dev-090925_v2.10`


------
https://chatgpt.com/codex/tasks/task_e_68bdce07c10c8327aa5bd57019d99e5a