### PR TITLE
Emphasize sacrificial attacks and update engine ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.30 110925]
+### Changed
+- Updated engine id name to "Wordfish v. 2.30 110925".
+- Increased evaluation weight for successful sacrificial attacks.
+
 ## [2.0.1 avx 070925]
 ### Changed
 - Updated engine id name to "Wordfish v. 2.0.1 avx 070925".

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Wordfish Chess Engine
 
-**Version 2.0.1**
+**Version 2.30**
 
-This build identifies as `Wordfish v. 2.0.1 avx 070925`.
+This build identifies as `Wordfish v. 2.30 110925`.
 
 <div align="center">
   <img src="[https://ijccrl.com/wp-content/uploads/2025/08/wordfish.png]" 

--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = wordfish_dev_070925_v2.0.1.exe
+        EXE = wordfish_dev_110925_v2.30.exe
 else
-        EXE = wordfish_dev_070925_v2.0.1
+        EXE = wordfish_dev_110925_v2.30
 endif
 
 ### Installation dir definitions
@@ -859,11 +859,11 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 # UCI "id name" string shown in GUIs.
 # Defaults:
-#   - ENGINE_NAME: "Wordfish v. 2.0.1 avx 070925"
+#   - ENGINE_NAME: "Wordfish v. 2.30 110925"
 #   - ENGINE_BUILD_DATE: optional build identifier
 # You can override on the command line:
-#   make ENGINE_NAME="Wordfish v. 2.0.1 avx 070925" ENGINE_BUILD_DATE=20250907
-ENGINE_NAME        ?= Wordfish v. 2.0.1 avx 070925
+#   make ENGINE_NAME="Wordfish v. 2.30 110925" ENGINE_BUILD_DATE=20250907
+ENGINE_NAME        ?= Wordfish v. 2.30 110925
 ENGINE_BUILD_DATE  ?=
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -152,7 +152,12 @@ Value dynamic_activity_bonus(const Position& pos) {
                      + PawnValue * (pos.count<PAWN>(us) - pos.count<PAWN>(them));
 
         if (material < 0)
-            score += (-material) * ringAttacks / 64;
+        {
+            // When behind in material, reward aggressive king attacks so
+            // promising sacrifices are evaluated more optimistically.
+            int sacr = -material;
+            score += sacr * (ringAttacks * 12 + directAttackers * 24) / 64;
+        }
 
         return score;
     };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,8 +25,8 @@
 #include "position.h"
 
 #ifndef ENGINE_NAME
-    // override at build time with:  -DENGINE_NAME="\"Wordfish v. 2.0.1 avx 070925\""
-    #define ENGINE_NAME "Wordfish v. 2.0.1 avx 070925"
+    // override at build time with:  -DENGINE_NAME="\"Wordfish v. 2.30 110925\""
+    #define ENGINE_NAME "Wordfish v. 2.30 110925"
 #endif
 
 using namespace Stockfish;

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -37,7 +37,7 @@
 
 #include "types.h"
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "Wordfish v. 2.0.1 avx 070925"
+    #define ENGINE_NAME "Wordfish v. 2.30 110925"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -43,7 +43,7 @@
 #include "ucioption.h"
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "Wordfish v. 2.0.1 avx 070925"
+    #define ENGINE_NAME "Wordfish v. 2.30 110925"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""
@@ -126,11 +126,11 @@ void UCIEngine::loop() {
         {
             // Force a stable, explicit UCI name so GUIs show "Wordfish 1.0"
             sync_cout_start();
-            std::cout << "id name " << ENGINE_NAME
-                      << "\n"
-                      << "id author Jorge Ruiz Centelles and the Stockfish developers (see AUTHORS file)"
-                      << "\n"
-                      << engine.get_options() << std::endl;
+            std::cout
+              << "id name " << ENGINE_NAME << "\n"
+              << "id author Jorge Ruiz Centelles and the Stockfish developers (see AUTHORS file)"
+              << "\n"
+              << engine.get_options() << std::endl;
             sync_cout_end();
 
             sync_cout << "uciok" << sync_endl;
@@ -168,9 +168,8 @@ void UCIEngine::loop() {
         else if (token == "eval")
             engine.trace_eval();
         else if (token == "showexp")
-            experience.show(engine.position(),
-                             (int) engine.get_options()["Experience Eval Weight"],
-                             (int) engine.get_options()["Experience Book Max Moves"]);
+            experience.show(engine.position(), (int) engine.get_options()["Experience Eval Weight"],
+                            (int) engine.get_options()["Experience Book Max Moves"]);
         else if (token == "compiler")
             sync_cout << compiler_info() << sync_endl;
         else if (token == "export_net")

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -21,10 +21,10 @@
 #include "ucioption.h"
 // --- Engine identity (fallbacks; Makefile can override) ---
 #ifndef ENGINE_NAME
-#define ENGINE_NAME "Wordfish v. 2.0.1 avx 070925"
+    #define ENGINE_NAME "Wordfish v. 2.30 110925"
 #endif
 #ifndef ENGINE_BUILD_DATE
-#define ENGINE_BUILD_DATE ""  // build identifier
+    #define ENGINE_BUILD_DATE ""  // build identifier
 #endif
 
 


### PR DESCRIPTION
## Summary
- strengthen NNUE evaluation by adding a sacrifice-aware bonus when behind on material
- bump engine identification to `Wordfish v. 2.30 110925` throughout code, docs, and build scripts

## Testing
- `make build ARCH=x86-64-sse41-popcnt`
- `bash tests/perft.sh ./src/wordfish_dev_110925_v2.30`


------
https://chatgpt.com/codex/tasks/task_e_68c2ecf51e94832783750709ed91b8b3