### PR TITLE
Handle custom NNUE network names in download script

### DIFF
--- a/scripts/net.sh
+++ b/scripts/net.sh
@@ -12,15 +12,23 @@ if [ -z "$sha256sum" ]; then
 fi
 
 get_nnue_filename() {
-  grep "$1" evaluate.h | grep "#define" | sed "s/.*\(nn-[a-z0-9]\{12\}.nnue\).*/\1/"
+  # Extract the quoted filename from evaluate.h for the given macro name.
+  # This works for both standard Stockfish nets (nn-xxxxxxxxxxxx.nnue)
+  # and any other custom filenames such as "3.net".
+  grep "$1" evaluate.h | grep "#define" | sed 's/.*"\([^"]*\)".*/\1/'
 }
 
 validate_network() {
   # If no sha256sum command is available, assume the file is always valid.
   if [ -n "$sha256sum" ] && [ -f "$1" ]; then
-    if [ "$1" != "nn-$($sha256sum "$1" | cut -c 1-12).nnue" ]; then
-      rm -f "$1"
-      return 1
+    # Only enforce the Stockfish naming scheme (nn-<hash>.nnue) when
+    # the filename matches that pattern. Custom nets like "3.net" are
+    # accepted without validation.
+    if echo "$1" | grep -Eq '^nn-[a-z0-9]{12}\.nnue$'; then
+      if [ "$1" != "nn-$($sha256sum "$1" | cut -c 1-12).nnue" ]; then
+        rm -f "$1"
+        return 1
+      fi
     fi
   fi
 }
@@ -61,6 +69,8 @@ fetch_network() {
       fi
     else
       echo "Failed to download from $url"
+      # Ensure no leftover partial file prevents trying other URLs.
+      rm -f "$_filename"
     fi
     if [ -f "$_filename" ]; then
       return


### PR DESCRIPTION
## Summary
- Allow `scripts/net.sh` to extract arbitrary NNUE filenames, including non-`nn-<hash>.nnue` nets like `3.net`
- Skip hash validation for custom nets and remove incomplete files after failed downloads

## Testing
- `bash ../scripts/net.sh` *(fails: Failed to download 3.net)*
- `bash tests/perft.sh` *(fails: exit code 127 for missing engine)*

------
https://chatgpt.com/codex/tasks/task_e_68c49fd19ed88327b8eed5a1e44bcf21