### PR TITLE
Handle optional Falcon NNUE

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,10 @@ setoption name Minimum Thinking Time value <milliseconds>
 ### Falcon Net
 
 Wordfish can switch to an alternative neural network using the
-`FalconFile` option. To load the bundled `3.net` file, send:
+`FalconFile` option. If a `3.net` file is present in the engine
+directory it will be embedded automatically; otherwise the engine
+falls back to the standard networks. To load the `3.net` file when
+available, send:
 
 ```
 setoption name FalconFile value 3.net

--- a/scripts/net.sh
+++ b/scripts/net.sh
@@ -82,6 +82,7 @@ fetch_network() {
   return 1
 }
 
-fetch_network EvalFileDefaultNameBig && \
-fetch_network EvalFileDefaultNameSmall && \
-fetch_network FalconFileDefaultName
+fetch_network EvalFileDefaultNameBig || exit 1
+fetch_network EvalFileDefaultNameSmall || exit 1
+fetch_network FalconFileDefaultName || \
+  echo "Falcon network (3.net) not found; continuing without it."

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -48,7 +48,13 @@
 #if !defined(_MSC_VER) && !defined(NNUE_EMBEDDING_OFF)
 INCBIN(EmbeddedNNUEBig, EvalFileDefaultNameBig);
 INCBIN(EmbeddedNNUESmall, EvalFileDefaultNameSmall);
+#  if __has_include(FalconFileDefaultName)
 INCBIN(EmbeddedNNUEFalcon, FalconFileDefaultName);
+#  else
+const unsigned char        gEmbeddedNNUEFalconData[1] = {0x0};
+const unsigned char* const gEmbeddedNNUEFalconEnd     = &gEmbeddedNNUEFalconData[1];
+const unsigned int         gEmbeddedNNUEFalconSize    = 1;
+#  endif
 #else
 const unsigned char        gEmbeddedNNUEBigData[1]   = {0x0};
 const unsigned char* const gEmbeddedNNUEBigEnd       = &gEmbeddedNNUEBigData[1];


### PR DESCRIPTION
## Summary
- Embed the Falcon NNUE only when 3.net is present, falling back gracefully otherwise
- Make net.sh treat 3.net as optional and continue without it
- Document optional Falcon network usage in README

## Testing
- `make net`
- `make -j2 ARCH=x86-64-avx build COMP=clang EXTRA_CXXFLAGS="-fuse-ld=lld"`


------
https://chatgpt.com/codex/tasks/task_e_68c4a22e1ef48327a1897197dbcec176