### PR TITLE
Enable small NNUE for Falcon network

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,13 +128,13 @@ setoption name Minimum Thinking Time value <milliseconds>
 ### Falcon Net
 
 Wordfish can switch to an alternative neural network using the
-`FalconFile` option. If a `3.net` file is present in the engine
-directory it will be embedded automatically; otherwise the engine
-falls back to the standard networks. To load the `3.net` file when
-available, send:
+`FalconFile` option. If a `nn-c01dc0ffeede.nnue` file is present in the
+engine directory it will be embedded automatically; otherwise the engine
+falls back to the standard networks. To load the `nn-c01dc0ffeede.nnue`
+file when available, send:
 
 ```
-setoption name FalconFile value 3.net
+setoption name FalconFile value nn-c01dc0ffeede.nnue
 ```
 
 ## License

--- a/scripts/net.sh
+++ b/scripts/net.sh
@@ -14,7 +14,7 @@ fi
 get_nnue_filename() {
   # Extract the quoted filename from evaluate.h for the given macro name.
   # This works for both standard Stockfish nets (nn-xxxxxxxxxxxx.nnue)
-  # and any other custom filenames such as "3.net".
+  # and any other custom filenames such as "nn-c01dc0ffeede.nnue".
   grep "$1" evaluate.h | grep "#define" | sed 's/.*"\([^"]*\)".*/\1/'
 }
 
@@ -22,7 +22,7 @@ validate_network() {
   # If no sha256sum command is available, assume the file is always valid.
   if [ -n "$sha256sum" ] && [ -f "$1" ]; then
     # Only enforce the Stockfish naming scheme (nn-<hash>.nnue) when
-    # the filename matches that pattern. Custom nets like "3.net" are
+    # the filename matches that pattern. Custom nets like "nn-c01dc0ffeede.nnue" are
     # accepted without validation.
     if echo "$1" | grep -Eq '^nn-[a-z0-9]{12}\.nnue$'; then
       if [ "$1" != "nn-$($sha256sum "$1" | cut -c 1-12).nnue" ]; then
@@ -82,7 +82,8 @@ fetch_network() {
   return 1
 }
 
+falcon_name=$(get_nnue_filename FalconFileDefaultName)
 fetch_network EvalFileDefaultNameBig || exit 1
 fetch_network EvalFileDefaultNameSmall || exit 1
 fetch_network FalconFileDefaultName || \
-  echo "Falcon network (3.net) not found; continuing without it."
+  echo "Falcon network (${falcon_name}) not found; continuing without it."

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -35,7 +35,8 @@ namespace Eval {
 // in the Makefile/Fishtest.
 #define EvalFileDefaultNameBig "nn-1c0000000000.nnue"
 #define EvalFileDefaultNameSmall "nn-baff1ede1f90.nnue"
-#define FalconFileDefaultName "3.net"
+// Third embedded network (small-size) default filename
+#define FalconFileDefaultName "nn-c01dc0ffeede.nnue"
 
 namespace NNUE {
 struct Networks;

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -121,7 +121,8 @@ using BigNetworkArchitecture = NetworkArchitecture<TransformedFeatureDimensionsB
 
 using NetworkBig   = Network<BigNetworkArchitecture, BigFeatureTransformer>;
 using NetworkSmall = Network<SmallNetworkArchitecture, SmallFeatureTransformer>;
-using NetworkFalcon = Network<BigNetworkArchitecture, BigFeatureTransformer>;
+// Falcon network now uses the small-network architecture
+using NetworkFalcon = Network<SmallNetworkArchitecture, SmallFeatureTransformer>;
 
 
 struct Networks {

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -105,7 +105,8 @@ struct AccumulatorCaches {
 
     Cache<TransformedFeatureDimensionsBig>   big;
     Cache<TransformedFeatureDimensionsSmall> small;
-    Cache<TransformedFeatureDimensionsBig>   falcon;
+    // Falcon network uses the small-network dimensions
+    Cache<TransformedFeatureDimensionsSmall> falcon;
 };
 
 


### PR DESCRIPTION
## Summary
- Use an official Stockfish NNUE (`nn-c01dc0ffeede.nnue`) as the Falcon network
- Switch Falcon architecture and caches to the small-network layout
- Improve `net.sh` to fetch the third network and update docs

## Testing
- `bash ../scripts/net.sh` (from `src/`)
- `make build -j2 ARCH=x86-64`

------
https://chatgpt.com/codex/tasks/task_e_68c5223854348327a5a890bcafb8468d