### PR TITLE
Enable small NNUE for Falcon network and fix NNUE path resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,13 +128,13 @@ setoption name Minimum Thinking Time value <milliseconds>
 ### Falcon Net
 
 Wordfish can switch to an alternative neural network using the
-`FalconFile` option. If a `3.net` file is present in the engine
-directory it will be embedded automatically; otherwise the engine
-falls back to the standard networks. To load the `3.net` file when
-available, send:
+`FalconFile` option. If a `nn-c01dc0ffeede.nnue` file is present in the
+engine directory it will be embedded automatically; otherwise the engine
+falls back to the standard networks. To load the `nn-c01dc0ffeede.nnue`
+file when available, send:
 
 ```
-setoption name FalconFile value 3.net
+setoption name FalconFile value nn-c01dc0ffeede.nnue
 ```
 
 ## License

--- a/scripts/net.sh
+++ b/scripts/net.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Always operate from the source directory so the networks are placed
+# alongside the engine binary. This allows the script to be invoked from
+# anywhere (repo root, src/, etc.).
+SCRIPT_DIR="$(cd -- "$(dirname "$0")" && pwd)"
+cd "${SCRIPT_DIR}/../src" || exit 1
+
 wget_or_curl=$( (command -v wget > /dev/null 2>&1 && echo "wget -qO-") || \
                 (command -v curl > /dev/null 2>&1 && echo "curl -skL"))
 
@@ -14,7 +20,7 @@ fi
 get_nnue_filename() {
   # Extract the quoted filename from evaluate.h for the given macro name.
   # This works for both standard Stockfish nets (nn-xxxxxxxxxxxx.nnue)
-  # and any other custom filenames such as "3.net".
+  # and any other custom filenames such as "nn-c01dc0ffeede.nnue".
   grep "$1" evaluate.h | grep "#define" | sed 's/.*"\([^"]*\)".*/\1/'
 }
 
@@ -22,7 +28,7 @@ validate_network() {
   # If no sha256sum command is available, assume the file is always valid.
   if [ -n "$sha256sum" ] && [ -f "$1" ]; then
     # Only enforce the Stockfish naming scheme (nn-<hash>.nnue) when
-    # the filename matches that pattern. Custom nets like "3.net" are
+    # the filename matches that pattern. Custom nets like "nn-c01dc0ffeede.nnue" are
     # accepted without validation.
     if echo "$1" | grep -Eq '^nn-[a-z0-9]{12}\.nnue$'; then
       if [ "$1" != "nn-$($sha256sum "$1" | cut -c 1-12).nnue" ]; then
@@ -82,7 +88,8 @@ fetch_network() {
   return 1
 }
 
+falcon_name=$(get_nnue_filename FalconFileDefaultName)
 fetch_network EvalFileDefaultNameBig || exit 1
 fetch_network EvalFileDefaultNameSmall || exit 1
 fetch_network FalconFileDefaultName || \
-  echo "Falcon network (3.net) not found; continuing without it."
+  echo "Falcon network (${falcon_name}) not found; continuing without it."

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -27,6 +27,7 @@
 #include <memory>
 #include <sstream>
 #include <tuple>
+#include <limits>
 
 #include "nnue/network.h"
 #include "nnue/nnue_misc.h"
@@ -165,7 +166,9 @@ Value dynamic_activity_bonus(const Position& pos) {
     int usScore   = activity_score(pos.side_to_move());
     int themScore = activity_score(~pos.side_to_move());
 
-    return Value(usScore - themScore);
+    // Scale the difference so this bonus only nudges the NNUE evaluation
+    // instead of overpowering it and flipping the score's sign.
+    return Value((usScore - themScore) / 128);
 }
 
 }  // namespace
@@ -206,7 +209,7 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
         e.key            = posKey;
         e.have_small     = 0;
         e.have_falcon    = 0;
-        e.last_optimism  = 0;
+        e.last_optimism  = std::numeric_limits<int>::min();
         // `v` can remain stale until we compute and overwrite it.
     }
     else
@@ -349,7 +352,7 @@ std::string Eval::trace(Position& pos, const Eval::NNUE::Networks& networks) {
             e.key            = posKey;
             e.have_small     = 0;
             e.have_falcon    = 0;
-            e.last_optimism  = 0;
+            e.last_optimism  = std::numeric_limits<int>::min();
         }
         e.psqt_falcon       = psqt;
         e.positional_falcon = positional;

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -35,7 +35,8 @@ namespace Eval {
 // in the Makefile/Fishtest.
 #define EvalFileDefaultNameBig "nn-1c0000000000.nnue"
 #define EvalFileDefaultNameSmall "nn-baff1ede1f90.nnue"
-#define FalconFileDefaultName "3.net"
+// Third embedded network (small-size) default filename
+#define FalconFileDefaultName "nn-c01dc0ffeede.nnue"
 
 namespace NNUE {
 struct Networks;

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -416,9 +416,14 @@ void prefetch(const void* addr) {
 
 #ifdef _WIN32
     #include <direct.h>
+    #include <windows.h>
     #define GETCWD _getcwd
 #else
     #include <unistd.h>
+    #include <limits.h>
+#    if defined(__APPLE__)
+        #include <mach-o/dyld.h>
+#    endif
     #define GETCWD getcwd
 #endif
 
@@ -456,8 +461,32 @@ std::string CommandLine::get_binary_directory(std::string argv0) {
     if (!_get_pgmptr(&pgmptr) && pgmptr != nullptr && *pgmptr)
         argv0 = pgmptr;
     #endif
+    if (argv0.find('\\') == std::string::npos && argv0.find('/') == std::string::npos)
+    {
+        char buffer[MAX_PATH];
+        if (GetModuleFileName(nullptr, buffer, MAX_PATH))
+            argv0 = buffer;
+    }
 #else
     pathSeparator = "/";
+    if (argv0.find('/') == std::string::npos)
+    {
+#if defined(__APPLE__)
+        uint32_t size = 0;
+        _NSGetExecutablePath(nullptr, &size);
+        std::string path(size, '\0');
+        if (_NSGetExecutablePath(path.data(), &size) == 0)
+            argv0 = path.c_str();
+#else
+        std::array<char, 4096> buffer{};
+        ssize_t len = readlink("/proc/self/exe", buffer.data(), buffer.size() - 1);
+        if (len > 0)
+        {
+            buffer[len] = '\0';
+            argv0 = buffer.data();
+        }
+#endif
+    }
 #endif
 
     // Extract the working directory

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -121,7 +121,8 @@ using BigNetworkArchitecture = NetworkArchitecture<TransformedFeatureDimensionsB
 
 using NetworkBig   = Network<BigNetworkArchitecture, BigFeatureTransformer>;
 using NetworkSmall = Network<SmallNetworkArchitecture, SmallFeatureTransformer>;
-using NetworkFalcon = Network<BigNetworkArchitecture, BigFeatureTransformer>;
+// Falcon network now uses the small-network architecture
+using NetworkFalcon = Network<SmallNetworkArchitecture, SmallFeatureTransformer>;
 
 
 struct Networks {

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -105,7 +105,8 @@ struct AccumulatorCaches {
 
     Cache<TransformedFeatureDimensionsBig>   big;
     Cache<TransformedFeatureDimensionsSmall> small;
-    Cache<TransformedFeatureDimensionsBig>   falcon;
+    // Falcon network uses the small-network dimensions
+    Cache<TransformedFeatureDimensionsSmall> falcon;
 };
 
 


### PR DESCRIPTION
## Summary
- Scale dynamic activity bonus so it only nudges NNUE scores instead of reversing them
- Reset evaluation cache with a sentinel value to avoid stale results when positions change

## Testing
- `./scripts/net.sh`
- `cd src && make build -j2 ARCH=x86-64`
- `(cd /tmp && PATH=/workspace/Wordfish/src:$PATH wordfish_dev_120925_v2.40_avx <<<'uci
isready
position startpos
go depth 1
quit
')`


------
https://chatgpt.com/codex/tasks/task_e_68c5223854348327a5a890bcafb8468d