### PR TITLE
Refine king safety metrics and fast time management

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -107,10 +107,17 @@ StyleIndicators gather_indicators(const Position& pos) {
     Square          enemyKing = pos.square<KING>(~pos.side_to_move());
     Square          ownKing   = pos.square<KING>(pos.side_to_move());
 
-    ind.pressure      = popcount(pos.attackers_to(enemyKing));
-    ind.shield        = popcount(pos.attackers_to(ownKing));
+    Color   us   = pos.side_to_move();
+    Color   them = ~us;
+    Bitboard atkEnemyKing = pos.attackers_to(enemyKing);
+    Bitboard atkOwnKing   = pos.attackers_to(ownKing);
+
+    ind.pressure = popcount(atkEnemyKing & pos.pieces(us));
+    ind.shield   = popcount(atkOwnKing & pos.pieces(us))
+                 - popcount(atkOwnKing & pos.pieces(them));
+
     Bitboard centerBB = square_bb(SQ_D4) | square_bb(SQ_E4) | square_bb(SQ_D5) | square_bb(SQ_E5);
-    ind.center        = popcount(pos.pieces(pos.side_to_move()) & centerBB);
+    ind.center        = popcount(pos.pieces(us) & centerBB);
     return ind;
 }
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -136,6 +136,14 @@ void TimeManagement::init(Search::LimitsType& limits,
     maximumTime =
       TimePoint(std::min(0.825179 * limits.time[us] - moveOverhead, maxScale * optimumTime)) - 10;
 
+    // In very fast time controls (e.g. bullet), cap thinking time to avoid
+    // losing on time due to overly deep searches.
+    if (limits.time[us] < 60000)
+    {
+        optimumTime = std::min(optimumTime, TimePoint(limits.time[us] / 40));
+        maximumTime = std::min(maximumTime, TimePoint(limits.time[us] / 20));
+    }
+
     if (options["Ponder"])
         optimumTime += optimumTime / 4;
 


### PR DESCRIPTION
## Summary
- Correct king pressure/shield indicators to distinguish friendly defenders from enemy attackers
- Add safeguard to cap thinking time in sub-minute controls to avoid time forfeits

## Testing
- `bash tests/perft.sh src/wordfish_dev_120925_v2.40_avx`

------
https://chatgpt.com/codex/tasks/task_e_68c54701143083279b12ce7d1ba19519