### PR TITLE
Handle invalid spin option values

### DIFF
--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -35,6 +35,7 @@
 #include <iostream>
 #include <sstream>
 #include <utility>
+#include <charconv>
 
 #include "misc.h"
 
@@ -139,7 +140,15 @@ Option::Option(const char* v, const char* cur, OnChange f) :
 
 Option::operator int() const {
     assert(type == "check" || type == "spin");
-    return (type == "spin" ? std::stoi(currentValue) : currentValue == "true");
+
+    if (type == "check")
+        return currentValue == "true";
+
+    int iv = 0;
+    const char* begin = currentValue.c_str();
+    const char* end   = begin + currentValue.size();
+    auto res          = std::from_chars(begin, end, iv);
+    return res.ec == std::errc() ? iv : 0;
 }
 
 Option::operator std::string() const {
@@ -163,9 +172,18 @@ Option& Option::operator=(const std::string& v) {
     assert(!type.empty());
 
     if ((type != "button" && type != "string" && v.empty())
-        || (type == "check" && v != "true" && v != "false")
-        || (type == "spin" && (std::stof(v) < min || std::stof(v) > max)))
+        || (type == "check" && v != "true" && v != "false"))
         return *this;
+
+    if (type == "spin")
+    {
+        int         iv    = 0;
+        const char* begin = v.c_str();
+        const char* end   = begin + v.size();
+        auto        res   = std::from_chars(begin, end, iv);
+        if (res.ec != std::errc() || res.ptr != end || iv < min || iv > max)
+            return *this;
+    }
 
     if (type == "combo")
     {
@@ -212,8 +230,12 @@ std::ostream& operator<<(std::ostream& os, const OptionsMap& om) {
                 }
 
                 else if (o.type == "spin")
-                    os << " default " << int(stof(o.defaultValue)) << " min " << o.min << " max "
-                       << o.max;
+                {
+                    int dv = 0;
+                    std::from_chars(o.defaultValue.c_str(),
+                                     o.defaultValue.c_str() + o.defaultValue.size(), dv);
+                    os << " default " << dv << " min " << o.min << " max " << o.max;
+                }
 
                 break;
             }


### PR DESCRIPTION
## Summary
- convert spin option values with `std::from_chars` to avoid exceptions during UCI option parsing and printing

## Testing
- `bash tests/perft.sh src/wordfish_dev_120925_v2.40_avx`
- `./src/wordfish_dev_120925_v2.40_avx uci`


------
https://chatgpt.com/codex/tasks/task_e_68c550ddc2d88327aa2aa3a80069bfba