### PR TITLE
Wait for experience loading before search

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -243,6 +243,13 @@ void UCIEngine::go(std::istringstream& is) {
 
     Search::LimitsType limits = parse_limits(is);
 
+    // Ensure the experience file has finished loading before starting a search.
+    // Some GUIs like Fritz or CuteChess may issue a "go" command immediately
+    // after "uci", while the experience file is still being loaded in a
+    // background thread. Waiting here avoids potential races that could
+    // terminate the engine unexpectedly.
+    experience.wait_until_loaded();
+
     if (limits.perft)
         perft(limits);
     else

--- a/tests/instrumented.py
+++ b/tests/instrumented.py
@@ -220,6 +220,12 @@ class TestInteractive(metaclass=OrderedClassMembers):
         self.stockfish.send_command("uci")
         self.stockfish.equals("uciok")
 
+    def test_uci_go_depth_1_without_position(self):
+        self.stockfish.send_command("uci")
+        self.stockfish.equals("uciok")
+        self.stockfish.send_command("go depth 1")
+        self.stockfish.starts_with("bestmove")
+
     def test_set_threads_option(self):
         self.stockfish.send_command(f"setoption name Threads value {get_threads()}")
 


### PR DESCRIPTION
## Summary
- ensure experience file finishes loading before handling `go` to avoid races in GUIs
- add regression test for issuing `go depth 1` immediately after `uci`

## Testing
- `make build -j`
- `printf "uci\ngo depth 1\nquit\n" | ./src/wordfish_dev_120925_v2.40_avx`

------
https://chatgpt.com/codex/tasks/task_e_68c557b810e883278310681230bf3e3b