### PR TITLE
Share NNUE weights across threads

### DIFF
--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -18,6 +18,7 @@
 
 #include "network.h"
 
+#include <cassert>
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
@@ -123,38 +124,26 @@ bool write_parameters(std::ostream& stream, T& reference) {
 }  // namespace Detail
 
 template<typename Arch, typename Transformer>
+Network<Arch, Transformer>::Weights::Weights() :
+    featureTransformer(make_unique_large_page<Transformer>()),
+    network(make_unique_aligned<Arch[]>(LayerStacks)) {}
+
+template<typename Arch, typename Transformer>
 Network<Arch, Transformer>::Network(const Network<Arch, Transformer>& other) :
+    weights(std::atomic_load(&other.weights)),
     evalFile(other.evalFile),
-    embeddedType(other.embeddedType) {
-
-    if (other.featureTransformer)
-        featureTransformer = make_unique_large_page<Transformer>(*other.featureTransformer);
-
-    network = make_unique_aligned<Arch[]>(LayerStacks);
-
-    if (!other.network)
-        return;
-
-    for (std::size_t i = 0; i < LayerStacks; ++i)
-        network[i] = other.network[i];
-}
+    embeddedType(other.embeddedType) {}
 
 template<typename Arch, typename Transformer>
 Network<Arch, Transformer>&
 Network<Arch, Transformer>::operator=(const Network<Arch, Transformer>& other) {
+    if (this == &other)
+        return *this;
+
     evalFile     = other.evalFile;
     embeddedType = other.embeddedType;
 
-    if (other.featureTransformer)
-        featureTransformer = make_unique_large_page<Transformer>(*other.featureTransformer);
-
-    network = make_unique_aligned<Arch[]>(LayerStacks);
-
-    if (!other.network)
-        return *this;
-
-    for (std::size_t i = 0; i < LayerStacks; ++i)
-        network[i] = other.network[i];
+    std::atomic_store(&weights, std::atomic_load(&other.weights));
 
     return *this;
 }
@@ -211,12 +200,28 @@ bool Network<Arch, Transformer>::save(const std::optional<std::string>& filename
     }
 
     std::ofstream stream(actualFilename, std::ios_base::binary);
-    bool          saved = save(stream, evalFile.current, evalFile.netDescription);
+    auto          storage = weights_handle();
+
+    if (!storage)
+    {
+        msg = "Failed to export a net";
+        sync_cout << msg << sync_endl;
+        return false;
+    }
+
+    bool saved = save(stream, evalFile.current, evalFile.netDescription, *storage);
 
     msg = saved ? "Network saved successfully to " + actualFilename : "Failed to export a net";
 
     sync_cout << msg << sync_endl;
     return saved;
+}
+
+
+template<typename Arch, typename Transformer>
+typename Network<Arch, Transformer>::WeightsPtr
+Network<Arch, Transformer>::weights_handle() const {
+    return std::atomic_load(&weights);
 }
 
 
@@ -233,10 +238,17 @@ Network<Arch, Transformer>::evaluate(const Position&                         pos
 
     ASSERT_ALIGNED(transformedFeatures, alignment);
 
+    auto storage = weights_handle();
+    if (!storage)
+    {
+        assert(storage && "NNUE weights not initialized");
+        return {Value(0), Value(0)};
+    }
+
     const int  bucket = (pos.count<ALL_PIECES>() - 1) / 4;
-    const auto psqt =
-      featureTransformer->transform(pos, accumulatorStack, cache, transformedFeatures, bucket);
-    const auto positional = network[bucket].propagate(transformedFeatures);
+    const auto psqt = storage->featureTransformer->transform(pos, accumulatorStack, cache,
+                                                             transformedFeatures, bucket);
+    const auto positional = storage->network[bucket].propagate(transformedFeatures);
     return {static_cast<Value>(psqt / OutputScale), static_cast<Value>(positional / OutputScale)};
 }
 
@@ -272,12 +284,16 @@ void Network<Arch, Transformer>::verify(std::string                             
 
     if (f)
     {
-        size_t size = sizeof(*featureTransformer) + sizeof(Arch) * LayerStacks;
+        auto storage = weights_handle();
+        if (!storage)
+            return;
+
+        size_t size = sizeof(*storage->featureTransformer) + sizeof(Arch) * LayerStacks;
         f("NNUE evaluation using " + evalfilePath + " (" + std::to_string(size / (1024 * 1024))
-          + "MiB, (" + std::to_string(featureTransformer->InputDimensions) + ", "
-          + std::to_string(network[0].TransformedFeatureDimensions) + ", "
-          + std::to_string(network[0].FC_0_OUTPUTS) + ", " + std::to_string(network[0].FC_1_OUTPUTS)
-          + ", 1))");
+          + "MiB, (" + std::to_string(storage->featureTransformer->InputDimensions) + ", "
+          + std::to_string(storage->network[0].TransformedFeatureDimensions) + ", "
+          + std::to_string(storage->network[0].FC_0_OUTPUTS) + ", "
+          + std::to_string(storage->network[0].FC_1_OUTPUTS) + ", 1))");
     }
 }
 
@@ -297,11 +313,17 @@ Network<Arch, Transformer>::trace_evaluate(const Position&                      
 
     NnueEvalTrace t{};
     t.correctBucket = (pos.count<ALL_PIECES>() - 1) / 4;
+    auto storage    = weights_handle();
+    if (!storage)
+    {
+        assert(storage && "NNUE weights not initialized");
+        return t;
+    }
     for (IndexType bucket = 0; bucket < LayerStacks; ++bucket)
     {
-        const auto materialist =
-          featureTransformer->transform(pos, accumulatorStack, cache, transformedFeatures, bucket);
-        const auto positional = network[bucket].propagate(transformedFeatures);
+        const auto materialist = storage->featureTransformer->transform(pos, accumulatorStack, cache,
+                                                                        transformedFeatures, bucket);
+        const auto positional = storage->network[bucket].propagate(transformedFeatures);
 
         t.psqt[bucket]       = static_cast<Value>(materialist / OutputScale);
         t.positional[bucket] = static_cast<Value>(positional / OutputScale);
@@ -353,29 +375,36 @@ void Network<Arch, Transformer>::load_internal() {
 
 
 template<typename Arch, typename Transformer>
-void Network<Arch, Transformer>::initialize() {
-    featureTransformer = make_unique_large_page<Transformer>();
-    network            = make_unique_aligned<Arch[]>(LayerStacks);
+typename Network<Arch, Transformer>::WeightsPtr
+Network<Arch, Transformer>::allocate_weights() const {
+    return std::make_shared<Weights>();
 }
 
 
 template<typename Arch, typename Transformer>
 bool Network<Arch, Transformer>::save(std::ostream&      stream,
                                       const std::string& name,
-                                      const std::string& netDescription) const {
+                                      const std::string& netDescription,
+                                      const Weights&     storage) const {
     if (name.empty() || name == "None")
         return false;
 
-    return write_parameters(stream, netDescription);
+    return write_parameters(stream, netDescription, storage);
 }
 
 
 template<typename Arch, typename Transformer>
 std::optional<std::string> Network<Arch, Transformer>::load(std::istream& stream) {
-    initialize();
     std::string description;
 
-    return read_parameters(stream, description) ? std::make_optional(description) : std::nullopt;
+    auto newWeights = allocate_weights();
+
+    if (!read_parameters(stream, description, *newWeights))
+        return std::nullopt;
+
+    std::atomic_store(&weights, std::move(newWeights));
+
+    return std::make_optional(description);
 }
 
 
@@ -412,17 +441,18 @@ bool Network<Arch, Transformer>::write_header(std::ostream&      stream,
 
 template<typename Arch, typename Transformer>
 bool Network<Arch, Transformer>::read_parameters(std::istream& stream,
-                                                 std::string&  netDescription) const {
+                                                 std::string&  netDescription,
+                                                 Weights&      storage) const {
     std::uint32_t hashValue;
     if (!read_header(stream, &hashValue, &netDescription))
         return false;
     if (hashValue != Network::hash)
         return false;
-    if (!Detail::read_parameters(stream, *featureTransformer))
+    if (!Detail::read_parameters(stream, *storage.featureTransformer))
         return false;
     for (std::size_t i = 0; i < LayerStacks; ++i)
     {
-        if (!Detail::read_parameters(stream, network[i]))
+        if (!Detail::read_parameters(stream, storage.network[i]))
             return false;
     }
     return stream && stream.peek() == std::ios::traits_type::eof();
@@ -431,14 +461,15 @@ bool Network<Arch, Transformer>::read_parameters(std::istream& stream,
 
 template<typename Arch, typename Transformer>
 bool Network<Arch, Transformer>::write_parameters(std::ostream&      stream,
-                                                  const std::string& netDescription) const {
+                                                  const std::string& netDescription,
+                                                  const Weights&     storage) const {
     if (!write_header(stream, Network::hash, netDescription))
         return false;
-    if (!Detail::write_parameters(stream, *featureTransformer))
+    if (!Detail::write_parameters(stream, *storage.featureTransformer))
         return false;
     for (std::size_t i = 0; i < LayerStacks; ++i)
     {
-        if (!Detail::write_parameters(stream, network[i]))
+        if (!Detail::write_parameters(stream, storage.network[i]))
             return false;
     }
     return bool(stream);

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -19,9 +19,11 @@
 #ifndef NETWORK_H_INCLUDED
 #define NETWORK_H_INCLUDED
 
+#include <atomic>
 #include <cstdint>
 #include <functional>
 #include <iostream>
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -55,7 +57,15 @@ class Network {
     static constexpr IndexType FTDimensions = Arch::TransformedFeatureDimensions;
 
    public:
+    struct Weights {
+        Weights();
+        LargePagePtr<Transformer> featureTransformer;
+        AlignedPtr<Arch[]>        network;
+    };
+    using WeightsPtr = std::shared_ptr<Weights>;
+
     Network(EvalFile file, EmbeddedNNUEType type) :
+        weights(std::make_shared<Weights>()),
         evalFile(file),
         embeddedType(type) {}
 
@@ -67,6 +77,8 @@ class Network {
 
     void load(const std::string& rootDirectory, std::string evalfilePath);
     bool save(const std::optional<std::string>& filename) const;
+
+    WeightsPtr weights_handle() const;
 
     NetworkOutput evaluate(const Position&                         pos,
                            AccumulatorStack&                       accumulatorStack,
@@ -82,22 +94,19 @@ class Network {
     void load_user_net(const std::string&, const std::string&);
     void load_internal();
 
-    void initialize();
+    WeightsPtr allocate_weights() const;
 
-    bool                       save(std::ostream&, const std::string&, const std::string&) const;
+    bool save(std::ostream&, const std::string&, const std::string&, const Weights&) const;
     std::optional<std::string> load(std::istream&);
 
     bool read_header(std::istream&, std::uint32_t*, std::string*) const;
     bool write_header(std::ostream&, std::uint32_t, const std::string&) const;
 
-    bool read_parameters(std::istream&, std::string&) const;
-    bool write_parameters(std::ostream&, const std::string&) const;
+    bool read_parameters(std::istream&, std::string&, Weights&) const;
+    bool write_parameters(std::ostream&, const std::string&, const Weights&) const;
 
     // Input feature converter
-    LargePagePtr<Transformer> featureTransformer;
-
-    // Evaluation function
-    AlignedPtr<Arch[]> network;
+    WeightsPtr weights;
 
     EvalFile         evalFile;
     EmbeddedNNUEType embeddedType;

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -22,6 +22,7 @@
 #define NNUE_ACCUMULATOR_H_INCLUDED
 
 #include <array>
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -86,9 +87,12 @@ struct AccumulatorCaches {
 
         template<typename Network>
         void clear(const Network& network) {
+            auto weights = network.weights_handle();
+            assert(weights);
+
             for (auto& entries1D : entries)
                 for (auto& entry : entries1D)
-                    entry.clear(network.featureTransformer->biases);
+                    entry.clear(weights->featureTransformer->biases);
         }
 
         std::array<Entry, COLOR_NB>& operator[](Square sq) { return entries[sq]; }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -152,13 +152,29 @@ Search::Worker::Worker(SharedState&                    sharedState,
     tt(sharedState.tt),
     networks(sharedState.networks),
     refreshTable(networks[token]) {
+    const auto& netsForToken = networks[token];
+    bigWeightsHandle         = netsForToken.big.weights_handle();
+    smallWeightsHandle       = netsForToken.small.weights_handle();
+    falconWeightsHandle      = netsForToken.falcon.weights_handle();
     clear();
 }
 
 void Search::Worker::ensure_network_replicated() {
-    // Access once to force lazy initialization.
-    // We do this because we want to avoid initialization during search.
-    (void) (networks[numaAccessToken]);
+    const auto& nets = networks[numaAccessToken];
+
+    auto newBig    = nets.big.weights_handle();
+    auto newSmall  = nets.small.weights_handle();
+    auto newFalcon = nets.falcon.weights_handle();
+
+    if (newBig == bigWeightsHandle && newSmall == smallWeightsHandle
+        && newFalcon == falconWeightsHandle)
+        return;
+
+    bigWeightsHandle    = std::move(newBig);
+    smallWeightsHandle  = std::move(newSmall);
+    falconWeightsHandle = std::move(newFalcon);
+
+    refreshTable.clear(nets);
 }
 
 void Search::Worker::start_searching() {

--- a/src/search.h
+++ b/src/search.h
@@ -358,6 +358,9 @@ class Worker {
     // Used by NNUE
     Eval::NNUE::AccumulatorStack  accumulatorStack;
     Eval::NNUE::AccumulatorCaches refreshTable;
+    Eval::NNUE::NetworkBig::WeightsPtr    bigWeightsHandle;
+    Eval::NNUE::NetworkSmall::WeightsPtr  smallWeightsHandle;
+    Eval::NNUE::NetworkFalcon::WeightsPtr falconWeightsHandle;
 
     friend class Stockfish::ThreadPool;
     friend class SearchManager;

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -102,7 +102,11 @@ void Thread::run_custom_job(std::function<void()> f) {
     cv.notify_one();
 }
 
-void Thread::ensure_network_replicated() { worker->ensure_network_replicated(); }
+void Thread::ensure_network_replicated() {
+    assert(worker != nullptr);
+    run_custom_job([this]() { worker->ensure_network_replicated(); });
+    wait_for_search_finished();
+}
 
 // Thread gets parked here, blocked on the condition variable
 // when the thread has no work to do.

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -1,4 +1,5 @@
 import subprocess
+import unittest
 from typing import List
 import os
 import collections
@@ -398,3 +399,141 @@ class Stockfish:
             return self.process.wait()
 
         return 0
+
+
+class TestNNUEThreadSafety(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.binary = cls._find_binary()
+        if cls.binary is None:
+            raise unittest.SkipTest("Stockfish binary not available")
+
+        cls.default_eval_file = cls._probe_option_default("EvalFile")
+
+    @staticmethod
+    def _find_binary():
+        candidates = []
+
+        env_path = os.environ.get("STOCKFISH_BINARY")
+        if env_path:
+            candidates.append(pathlib.Path(env_path))
+
+        candidates.extend(
+            [
+                PATH.parent / "stockfish",
+                PATH.parent / "build" / "stockfish",
+                PATH.parent / "src" / "stockfish",
+            ]
+        )
+
+        for candidate in candidates:
+            if candidate and os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+                return str(candidate)
+
+        return None
+
+    @classmethod
+    def _probe_option_default(cls, name: str):
+        runner = Stockfish([], cls.binary, args=["uci"], cli=True)
+
+        if not runner.process or runner.process.stdout is None:
+            return None
+
+        target = f"option name {name} "
+        for line in runner.process.stdout.splitlines():
+            if target in line and " default " in line:
+                return line.split("default", 1)[1].strip()
+
+        return None
+
+    def setUp(self):
+        self.engine = Stockfish([], self.binary)
+        self.engine.send_command("uci")
+        self.engine.expect("uciok")
+        self.engine.clear_output()
+
+        self.engine.setoption("Experience Enabled", "false")
+        self.engine.send_command("isready")
+        self.engine.expect("readyok")
+        self.engine.clear_output()
+
+    def tearDown(self):
+        if getattr(self, "engine", None):
+            try:
+                self.engine.quit()
+            finally:
+                self.engine.close()
+
+    def _run_search(self, threads: int, moves=None, depth: int = 3):
+        moves = moves or []
+
+        self.engine.setoption("Threads", str(threads))
+        self.engine.send_command("isready")
+        self.engine.expect("readyok")
+        self.engine.clear_output()
+
+        self.engine.send_command("ucinewgame")
+        position_cmd = "position startpos"
+        if moves:
+            position_cmd += " moves " + " ".join(moves)
+        self.engine.send_command(position_cmd)
+
+        self.engine.send_command(f"go depth {depth}")
+
+        result = {}
+
+        def parser(line: str):
+            tokens = line.split()
+            if len(tokens) >= 2 and tokens[0] == "info" and "score" in tokens:
+                try:
+                    score_index = tokens.index("score")
+                    score_type = tokens[score_index + 1]
+                    score_value = tokens[score_index + 2]
+                    if score_type in {"cp", "mate"}:
+                        result["score"] = (score_type, int(score_value))
+                except (ValueError, IndexError):
+                    pass
+
+            if tokens and tokens[0] == "bestmove":
+                result["bestmove"] = tokens[1] if len(tokens) > 1 else None
+                return True
+
+            return False
+
+        self.engine.check_output(parser)
+        self.engine.clear_output()
+
+        self.assertIn("bestmove", result)
+        return result["bestmove"], result.get("score")
+
+    def test_consistent_scores_across_threads(self):
+        moves = ["e2e4", "e7e5", "g1f3", "b8c6"]
+
+        single_thread = self._run_search(1, moves=moves, depth=4)
+        multi_thread = self._run_search(4, moves=moves, depth=4)
+
+        self.assertEqual(single_thread[0], multi_thread[0])
+
+        if single_thread[1] and multi_thread[1]:
+            self.assertEqual(single_thread[1][0], multi_thread[1][0])
+            self.assertLessEqual(abs(single_thread[1][1] - multi_thread[1][1]), 20)
+
+    def test_network_reload_preserves_evaluation(self):
+        if not self.default_eval_file:
+            self.skipTest("Default EvalFile option not available")
+
+        baseline = self._run_search(2, moves=["d2d4", "d7d5"], depth=3)
+
+        self.engine.setoption("EvalFile", self.default_eval_file)
+        self.engine.send_command("isready")
+        self.engine.expect("readyok")
+        self.engine.clear_output()
+
+        after_reload = self._run_search(2, moves=["d2d4", "d7d5"], depth=3)
+
+        self.assertIsNotNone(after_reload[0])
+
+        if baseline[1] and after_reload[1]:
+            self.assertEqual(baseline[1][0], after_reload[1][0])
+            self.assertLessEqual(abs(baseline[1][1] - after_reload[1][1]), 20)


### PR DESCRIPTION
## Summary
- refactor the NNUE network storage to share immutable weight buffers via `std::shared_ptr`
- update search threads to track shared weight handles and refresh caches when NNUE weights change
- add multithreaded regression tests that validate consistent behaviour after changing thread counts or reloading the network

## Testing
- `STOCKFISH_BINARY=src/wordfish_dev_120925_v2.40_avx pytest tests/testing.py -k NNUE`


------
https://chatgpt.com/codex/tasks/task_e_68c83af493688327afbca05606c283d8