### PR TITLE
Update engine identity to Wordfish 2.41 dev-150925

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.41 dev-150925]
+### Changed
+- Updated engine id name to "Wordfish 2.41 dev-150925".
+
 ## [2.40 120925 avx]
 ### Changed
 - Updated engine id name to "Wordfish v. 2.40 120925 avx".

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Wordfish Chess Engine
 
-**Version 2.40**
+**Version 2.41**
 
-This build identifies as `Wordfish v. 2.40 120925 avx`.
+This build identifies as `Wordfish 2.41 dev-150925`.
 
 <div align="center">
   <img src="[https://ijccrl.com/wp-content/uploads/2025/08/wordfish.png]" 

--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = wordfish_dev_120925_v2.40_avx.exe
+        EXE = wordfish_dev_150925_v2.41_dev.exe
 else
-        EXE = wordfish_dev_120925_v2.40_avx
+        EXE = wordfish_dev_150925_v2.41_dev
 endif
 
 ### Installation dir definitions
@@ -859,11 +859,11 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 # UCI "id name" string shown in GUIs.
 # Defaults:
-#   - ENGINE_NAME: "Wordfish v. 2.40 120925 avx"
+#   - ENGINE_NAME: "Wordfish 2.41 dev-150925"
 #   - ENGINE_BUILD_DATE: optional build identifier
 # You can override on the command line:
-#   make ENGINE_NAME="Wordfish v. 2.40 120925 avx" ENGINE_BUILD_DATE=20250907
-ENGINE_NAME        ?= Wordfish v. 2.40 120925 avx
+#   make ENGINE_NAME="Wordfish 2.41 dev-150925" ENGINE_BUILD_DATE=20250907
+ENGINE_NAME        ?= Wordfish 2.41 dev-150925
 ENGINE_BUILD_DATE  ?=
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,8 +25,8 @@
 #include "position.h"
 
 #ifndef ENGINE_NAME
-    // override at build time with:  -DENGINE_NAME="\"Wordfish v. 2.40 120925 avx\""
-    #define ENGINE_NAME "Wordfish v. 2.40 120925 avx"
+    // override at build time with:  -DENGINE_NAME="\"Wordfish 2.41 dev-150925\""
+    #define ENGINE_NAME "Wordfish 2.41 dev-150925"
 #endif
 
 using namespace Stockfish;

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -37,7 +37,7 @@
 
 #include "types.h"
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "Wordfish v. 2.40 120925 avx"
+    #define ENGINE_NAME "Wordfish 2.41 dev-150925"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -43,7 +43,7 @@
 #include "ucioption.h"
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "Wordfish v. 2.40 120925 avx"
+    #define ENGINE_NAME "Wordfish 2.41 dev-150925"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -21,7 +21,7 @@
 #include "ucioption.h"
 // --- Engine identity (fallbacks; Makefile can override) ---
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "Wordfish v. 2.40 120925 avx"
+    #define ENGINE_NAME "Wordfish 2.41 dev-150925"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""  // build identifier


### PR DESCRIPTION
## Summary
- set the default ENGINE_NAME to "Wordfish 2.41 dev-150925" across the source and build configuration so UCI consoles and GUIs display the new identifier
- refresh README and changelog entries to document the updated engine name

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8474066908327b48e4066e56aa1e5