### PR TITLE
Adjust capture reductions and bump to 2.42-190825

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## [2.41 dev-150925]
+## [2.42-190825]
 ### Changed
-- Updated engine id name to "Wordfish 2.41 dev-150925".
+- Updated engine id name to "Wordfish 2.42-190825".
 
 ## [2.40 120925 avx]
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Wordfish Chess Engine
 
-**Version 2.41**
+**Version 2.42**
 
-This build identifies as `Wordfish 2.41 dev-150925`.
+This build identifies as `Wordfish 2.42-190825`.
 
 <div align="center">
   <img src="[https://ijccrl.com/wp-content/uploads/2025/08/wordfish.png]" 

--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = wordfish_dev_150925_v2.41_dev.exe
+        EXE = wordfish_190825_v2.42.exe
 else
-        EXE = wordfish_dev_150925_v2.41_dev
+        EXE = wordfish_190825_v2.42
 endif
 
 ### Installation dir definitions
@@ -859,11 +859,11 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 # UCI "id name" string shown in GUIs.
 # Defaults:
-#   - ENGINE_NAME: "Wordfish 2.41 dev-150925"
+#   - ENGINE_NAME: "Wordfish 2.42-190825"
 #   - ENGINE_BUILD_DATE: optional build identifier
 # You can override on the command line:
-#   make ENGINE_NAME="Wordfish 2.41 dev-150925" ENGINE_BUILD_DATE=20250907
-ENGINE_NAME        ?= Wordfish 2.41 dev-150925
+#   make ENGINE_NAME="Wordfish 2.42-190825" ENGINE_BUILD_DATE=20250907
+ENGINE_NAME        ?= Wordfish 2.42-190825
 ENGINE_BUILD_DATE  ?=
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,8 +25,8 @@
 #include "position.h"
 
 #ifndef ENGINE_NAME
-    // override at build time with:  -DENGINE_NAME="\"Wordfish 2.41 dev-150925\""
-    #define ENGINE_NAME "Wordfish 2.41 dev-150925"
+    // override at build time with:  -DENGINE_NAME="\"Wordfish 2.42-190825\""
+    #define ENGINE_NAME "Wordfish 2.42-190825"
 #endif
 
 using namespace Stockfish;

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -37,7 +37,7 @@
 
 #include "types.h"
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "Wordfish 2.41 dev-150925"
+    #define ENGINE_NAME "Wordfish 2.42-190825"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1107,6 +1107,8 @@ moves_loop:  // When in check, search starts here
         movedPiece = pos.moved_piece(move);
         givesCheck = pos.gives_check(move);
 
+        const bool negativeSee = capture && !pos.see_ge(move, VALUE_ZERO);
+
         (ss + 1)->quietMoveStreak = (!capture && !givesCheck) ? (ss->quietMoveStreak + 1) : 0;
 
         // Calculate new depth for this move
@@ -1279,6 +1281,8 @@ moves_loop:  // When in check, search starts here
         // These reduction adjustments have no proven non-linear scaling
 
         r += 650;  // Base reduction offset to compensate for other tweaks
+        if (negativeSee)
+            r = std::max<int>(0, r - 1024);
         r -= moveCount * 69;
         r -= std::abs(correctionValue) / 27160;
 
@@ -1317,6 +1321,9 @@ moves_loop:  // When in check, search starts here
             // Apply a simple reduction limited between one ply and the remaining depth
             Depth d = std::max(1, newDepth - r / 1024);
 
+            if (negativeSee)
+                d = std::max(d, newDepth - 1);
+
             ss->reduction = newDepth - d;
             value         = -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha, d, true);
             ss->reduction = 0;
@@ -1337,9 +1344,12 @@ moves_loop:  // When in check, search starts here
             const int threshold2 = depth <= 4 ? 3500 : 4600;
 
             // Note that if expected reduction is high, we reduce search depth here
+            int depthReduction = (r > threshold1) + (r > threshold2 && newDepth > 2);
+            if (negativeSee)
+                depthReduction = std::min(depthReduction, 1);
+
             value = -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha,
-                                   newDepth - (r > threshold1) - (r > threshold2 && newDepth > 2),
-                                   !cutNode);
+                                   newDepth - depthReduction, !cutNode);
         }
 
         // For PV nodes only, do a full PV search on the first move or after a fail high,

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -43,7 +43,7 @@
 #include "ucioption.h"
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "Wordfish 2.41 dev-150925"
+    #define ENGINE_NAME "Wordfish 2.42-190825"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -21,7 +21,7 @@
 #include "ucioption.h"
 // --- Engine identity (fallbacks; Makefile can override) ---
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "Wordfish 2.41 dev-150925"
+    #define ENGINE_NAME "Wordfish 2.42-190825"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""  // build identifier


### PR DESCRIPTION
## Summary
- relax the LMR reductions for SEE-negative captures so sacrificial defences such as 47...Bg7 stay in the search
- update all version strings and build artefact names to Wordfish 2.42-190825

## Testing
- `make build ARCH=x86-64-sse41-popcnt`
- Verified `bestmove f8g7` from the reported position via manual UCI session

------
https://chatgpt.com/codex/tasks/task_e_68cbe8fa3ed88327aca7e0edd5eae45a