### PR TITLE
Serialize experience table access

### DIFF
--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <fstream>
 #include <iomanip>
+#include <mutex>
 #include <iostream>
 #include <iterator>
 #include <memory>
@@ -31,6 +32,7 @@ bool Experience::is_ready() const {
 
 void Experience::clear() {
     wait_until_loaded();
+    std::lock_guard<std::mutex> lock(tableMutex);
     table.clear();
 }
 
@@ -103,127 +105,132 @@ void Experience::load(const std::string& file) {
     in.clear();
     in.seekg(0, std::ios::beg);
 
-    table.clear();
-    binaryFormat     = isV1 || isV2 || isBL;
-    brainLearnFormat = isBL;
-
     std::size_t totalMoves     = 0;
     std::size_t duplicateMoves = 0;
+    std::size_t totalPositions = 0;
+    double      frag           = 0.0;
 
-    auto insert_entry = [&](uint64_t key, unsigned move, int score, int depth, int count) {
-        totalMoves++;
-        auto& vec = table[key];
-        bool  dup = false;
-        for (auto& e : vec)
-            if (e.move.raw() == move)
-            {
-                dup = true;
-                duplicateMoves++;
-                e.score = score;
-                e.depth = depth;
-                e.count += count;
-                break;
-            }
-        if (!dup)
-            vec.push_back({Move(static_cast<std::uint16_t>(move)), score, depth, count});
-    };
-
-    if (binaryFormat)
     {
-        if (isBL)
-        {
-            struct BinBL {
-                uint64_t key;
-                int32_t  depth;
-                int32_t  value;
-                uint16_t move;
-                uint16_t pad;
-                int32_t  perf;
-            };
-            BinBL e;
-            while (in.read(reinterpret_cast<char*>(&e), sizeof(e)))
-                insert_entry(e.key, e.move, e.value, e.depth, 1);
-        }
-        else
-        {
-            in.seekg(isV2 ? sigV2.size() : sigV1.size(), std::ios::beg);
+        std::lock_guard<std::mutex> lock(tableMutex);
+        table.clear();
+        binaryFormat     = isV1 || isV2 || isBL;
+        brainLearnFormat = isBL;
 
-            struct BinV1 {
-                uint64_t key;
-                uint32_t move;
-                int32_t  value;
-                int32_t  depth;
-                uint8_t  pad[4];
-            };
-            struct BinV2 {
-                uint64_t key;
-                uint32_t move;
-                int32_t  value;
-                int32_t  depth;
-                uint16_t count;
-                uint8_t  pad[2];
-            };
+        auto insert_entry = [&](uint64_t key, unsigned move, int score, int depth, int count) {
+            totalMoves++;
+            auto& vec = table[key];
+            bool  dup = false;
+            for (auto& e : vec)
+                if (e.move.raw() == move)
+                {
+                    dup = true;
+                    duplicateMoves++;
+                    e.score = score;
+                    e.depth = depth;
+                    e.count += count;
+                    break;
+                }
+            if (!dup)
+                vec.push_back({Move(static_cast<std::uint16_t>(move)), score, depth, count});
+        };
 
-            if (isV2)
+        if (binaryFormat)
+        {
+            if (isBL)
             {
-                BinV2 e;
-                while (in.read(reinterpret_cast<char*>(&e), sizeof(e)))
-                    insert_entry(e.key, e.move, e.value, e.depth, e.count);
-            }
-            else
-            {
-                BinV1 e;
+                struct BinBL {
+                    uint64_t key;
+                    int32_t  depth;
+                    int32_t  value;
+                    uint16_t move;
+                    uint16_t pad;
+                    int32_t  perf;
+                };
+                BinBL e;
                 while (in.read(reinterpret_cast<char*>(&e), sizeof(e)))
                     insert_entry(e.key, e.move, e.value, e.depth, 1);
             }
-        }
-    }
-    else
-    {
-        std::string line;
-        while (std::getline(in, line))
-        {
-            if (line.empty() || line[0] == '#')
-                continue;
+            else
+            {
+                in.seekg(isV2 ? sigV2.size() : sigV1.size(), std::ios::beg);
 
-            std::istringstream iss(line);
-            std::string        keyStr, moveStr;
-            int                score, depth, count;
+                struct BinV1 {
+                    uint64_t key;
+                    uint32_t move;
+                    int32_t  value;
+                    int32_t  depth;
+                    uint8_t  pad[4];
+                };
+                struct BinV2 {
+                    uint64_t key;
+                    uint32_t move;
+                    int32_t  value;
+                    int32_t  depth;
+                    uint16_t count;
+                    uint8_t  pad[2];
+                };
 
-            if (!(iss >> keyStr >> moveStr >> score >> depth >> count))
-                continue;
-
-            auto parse = [](const std::string& s, uint64_t& out) {
-                std::istringstream ss(s);
-                if (s.find_first_not_of("0123456789") == std::string::npos)
-                    ss >> out;
+                if (isV2)
+                {
+                    BinV2 e;
+                    while (in.read(reinterpret_cast<char*>(&e), sizeof(e)))
+                        insert_entry(e.key, e.move, e.value, e.depth, e.count);
+                }
                 else
-                    ss >> std::hex >> out;
-                return !ss.fail();
-            };
-
-            uint64_t key64, move64;
-            if (!parse(keyStr, key64) || !parse(moveStr, move64))
-                continue;
-            insert_entry(key64, static_cast<unsigned>(move64), score, depth, count);
+                {
+                    BinV1 e;
+                    while (in.read(reinterpret_cast<char*>(&e), sizeof(e)))
+                        insert_entry(e.key, e.move, e.value, e.depth, 1);
+                }
+            }
         }
-    }
+        else
+        {
+            std::string line;
+            while (std::getline(in, line))
+            {
+                if (line.empty() || line[0] == '#')
+                    continue;
 
-    std::size_t totalPositions = table.size();
-    double      frag           = totalPositions ? 100.0 * duplicateMoves / totalPositions : 0.0;
+                std::istringstream iss(line);
+                std::string        keyStr, moveStr;
+                int                score, depth, count;
+
+                if (!(iss >> keyStr >> moveStr >> score >> depth >> count))
+                    continue;
+
+                auto parse = [](const std::string& s, uint64_t& out) {
+                    std::istringstream ss(s);
+                    if (s.find_first_not_of("0123456789") == std::string::npos)
+                        ss >> out;
+                    else
+                        ss >> std::hex >> out;
+                    return !ss.fail();
+                };
+
+                uint64_t key64, move64;
+                if (!parse(keyStr, key64) || !parse(moveStr, move64))
+                    continue;
+                insert_entry(key64, static_cast<unsigned>(move64), score, depth, count);
+            }
+        }
+
+        totalPositions = table.size();
+        frag           = totalPositions ? 100.0 * duplicateMoves / totalPositions : 0.0;
+        binaryFormat   = true;
+    }
 
     sync_cout << "info string " << display << " -> Total moves: " << totalMoves
               << ". Total positions: " << totalPositions << ". Duplicate moves: " << duplicateMoves
               << ". Fragmentation: " << std::fixed << std::setprecision(2) << frag << "%)"
               << sync_endl;
 
-    binaryFormat = true;
-
     if (convertBin)
         save(path);
 }
 
 void Experience::load_async(const std::string& file) {
+    wait_until_loaded();
     loader = std::async(std::launch::async, [this, file] { load(file); });
 }
 
@@ -252,10 +259,18 @@ void Experience::save(const std::string& file) const {
         }
     }
 
+    std::unordered_map<Key, std::vector<ExperienceEntry>> tableCopy;
+    bool                                                  useBrainLearn = false;
+    {
+        std::lock_guard<std::mutex> lock(tableMutex);
+        tableCopy      = table;
+        useBrainLearn  = brainLearnFormat;
+    }
+
     std::string buffer;
     std::size_t totalMoves = 0;
 
-    if (brainLearnFormat)
+    if (useBrainLearn)
     {
         struct BinBL {
             uint64_t key;
@@ -265,7 +280,7 @@ void Experience::save(const std::string& file) const {
             uint16_t pad;
             int32_t  perf;
         };
-        for (const auto& [key, vec] : table)
+        for (const auto& [key, vec] : tableCopy)
             for (const auto& e : vec)
             {
                 BinBL be{key, e.depth, e.score, static_cast<uint16_t>(e.move.raw()), 0, e.count};
@@ -285,7 +300,7 @@ void Experience::save(const std::string& file) const {
             uint16_t count;
             uint8_t  pad[2];
         };
-        for (const auto& [key, vec] : table)
+        for (const auto& [key, vec] : tableCopy)
             for (const auto& e : vec)
             {
                 BinV2 be{key,
@@ -326,7 +341,7 @@ void Experience::save(const std::string& file) const {
         return;
     }
 
-    std::size_t totalPositions = table.size();
+    std::size_t totalPositions = tableCopy.size();
 
     sync_cout << "info string " << path << " <- Total moves: " << totalMoves
               << ". Total positions: " << totalPositions << sync_endl;
@@ -334,11 +349,14 @@ void Experience::save(const std::string& file) const {
 Move Experience::probe(Position& pos, int width, int evalImportance, int minDepth, int maxMoves) {
     if (!is_ready())
         return Move::none();
-    auto it = table.find(pos.key());
-    if (it == table.end())
-        return Move::none();
-
-    auto vec = it->second;
+    std::vector<ExperienceEntry> vec;
+    {
+        std::lock_guard<std::mutex> lock(tableMutex);
+        auto                        it = table.find(pos.key());
+        if (it == table.end())
+            return Move::none();
+        vec = it->second;
+    }
     if (vec.empty())
         return Move::none();
 
@@ -363,7 +381,8 @@ Move Experience::probe(Position& pos, int width, int evalImportance, int minDept
 void Experience::update(Position& pos, Move move, int score, int depth) {
     if (!is_ready())
         return;
-    auto& vec = table[pos.key()];
+    std::lock_guard<std::mutex> lock(tableMutex);
+    auto&                        vec = table[pos.key()];
     for (auto& e : vec)
         if (e.move == move)
         {
@@ -382,13 +401,22 @@ void Experience::update(Position& pos, Move move, int score, int depth) {
 void Experience::show(const Position& pos, int evalImportance, int maxMoves) const {
     if (!is_ready())
         return;
-    auto it = table.find(pos.key());
-    if (it == table.end())
+    std::vector<ExperienceEntry> vec;
+    bool                         found = false;
+    {
+        std::lock_guard<std::mutex> lock(tableMutex);
+        auto                        it = table.find(pos.key());
+        if (it != table.end())
+        {
+            vec   = it->second;
+            found = true;
+        }
+    }
+    if (!found)
     {
         sync_cout << "info string No experience available" << sync_endl;
         return;
     }
-    auto vec = it->second;
     std::sort(vec.begin(), vec.end(), [&](const ExperienceEntry& a, const ExperienceEntry& b) {
         return (a.score + evalImportance * a.depth) > (b.score + evalImportance * b.depth);
     });

--- a/src/experience.h
+++ b/src/experience.h
@@ -25,6 +25,7 @@
 #include <vector>
 #include <string>
 #include <future>
+#include <mutex>
 
 #include "position.h"
 #include "types.h"
@@ -55,6 +56,7 @@ class Experience {
     bool                                                  binaryFormat     = false;
     bool                                                  brainLearnFormat = true;
     std::future<void>                                     loader;
+    mutable std::mutex                                    tableMutex;
 };
 
 extern Experience experience;


### PR DESCRIPTION
## Summary
- block asynchronous experience loads until any previous load has finished
- protect the experience table with a mutex across loading, updating, probing, and display operations
- snapshot the table before saving to avoid concurrent mutations during file writes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cdf356291c8327bcccdb1489f51b93