### PR TITLE
Use free for polyhash destruction

### DIFF
--- a/src/polybook.cpp
+++ b/src/polybook.cpp
@@ -309,7 +309,10 @@ PolyBook::PolyBook() {
 
 PolyBook::~PolyBook() {
     if (polyhash != NULL)
-        delete[] polyhash;
+    {
+        free(polyhash);
+        polyhash = nullptr;
+    }
 }
 
 void PolyBook::init(const OptionsMap& options) {


### PR DESCRIPTION
## Summary
- free the `polyhash` buffer in the `PolyBook` destructor using `free`
- clear the pointer after releasing to avoid double frees

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdf33d2098832789279e51f48cfec5