### PR TITLE
Refine version reporting and correction heuristics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Wordfish Chess Engine
 
-**Version 2.42**
+**Version 2.50**
 
-This build identifies as `Wordfish 2.42-190825`.
+This build identifies as `Wordfish 2.50 dev-210925`.
 
 <div align="center">
   <img src="[https://ijccrl.com/wp-content/uploads/2025/08/wordfish.png]" 

--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = wordfish_190825_v2.42.exe
+        EXE = wordfish_210925_v2.50.exe
 else
-        EXE = wordfish_190825_v2.42
+        EXE = wordfish_210925_v2.50
 endif
 
 ### Installation dir definitions
@@ -859,11 +859,11 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 # UCI "id name" string shown in GUIs.
 # Defaults:
-#   - ENGINE_NAME: "Wordfish 2.42-190825"
+#   - ENGINE_NAME: "Wordfish 2.50 dev-210925"
 #   - ENGINE_BUILD_DATE: optional build identifier
 # You can override on the command line:
-#   make ENGINE_NAME="Wordfish 2.42-190825" ENGINE_BUILD_DATE=20250907
-ENGINE_NAME        ?= Wordfish 2.42-190825
+#   make ENGINE_NAME="Wordfish 2.50 dev-210925" ENGINE_BUILD_DATE=20250907
+ENGINE_NAME        ?= Wordfish 2.50 dev-210925
 ENGINE_BUILD_DATE  ?=
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,11 +23,7 @@
 #include "tune.h"
 #include "bitboard.h"
 #include "position.h"
-
-#ifndef ENGINE_NAME
-    // override at build time with:  -DENGINE_NAME="\"Wordfish 2.42-190825\""
-    #define ENGINE_NAME "Wordfish 2.42-190825"
-#endif
+#include "version.h"
 
 using namespace Stockfish;
 
@@ -42,7 +38,7 @@ int main(int argc, char* argv[]) {
         // Clear, consistent banner (many GUIs echo this to their logs).
         // Send banner to stderr so it doesn't interfere with UCI handshake on
         // stdout when run from a terminal.
-        std::cerr << ENGINE_NAME
+        std::cerr << Stockfish::Version::string()
                   << " by Jorge Ruiz Centelles and the Stockfish developers (see AUTHORS file)"
                   << std::endl;
 

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -36,12 +36,7 @@
 #include <string_view>
 
 #include "types.h"
-#ifndef ENGINE_NAME
-    #define ENGINE_NAME "Wordfish 2.42-190825"
-#endif
-#ifndef ENGINE_BUILD_DATE
-    #define ENGINE_BUILD_DATE ""
-#endif
+#include "version.h"
 
 namespace Stockfish {
 
@@ -119,7 +114,7 @@ class Logger {
 
 
 // Returns the full name of the current Wordfish version.
-std::string engine_version_info() { return std::string(ENGINE_NAME); }
+std::string engine_version_info() { return Version::string(); }
 
 // Update author information
 std::string engine_info(bool to_uci) {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -27,6 +27,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <initializer_list>
+#include <iterator>
 #include <iostream>
 #include <list>
 #include <ratio>
@@ -68,13 +69,60 @@ namespace {
 constexpr int SEARCHEDLIST_CAPACITY = 32;
 using SearchedList                  = ValueList<Move, SEARCHEDLIST_CAPACITY>;
 
+int king_file_exposure_scale(const Position& pos, Color us) {
+    const Square kingSq  = pos.square<KING>(us);
+    const int    forward = us == WHITE ? 8 : -8;
+
+    bool friendlyShield = false;
+    bool enemyPressure  = false;
+
+    for (int idx = int(kingSq) + forward; idx >= 0 && idx < 64; idx += forward)
+    {
+        const Square sq = Square(idx);
+        const Piece  pc = pos.piece_on(sq);
+
+        if (pc == NO_PIECE)
+            continue;
+
+        if (color_of(pc) == us)
+        {
+            if (type_of(pc) == PAWN)
+                friendlyShield = true;
+            break;
+        }
+
+        if (type_of(pc) == ROOK || type_of(pc) == QUEEN)
+            enemyPressure = true;
+        break;
+    }
+
+    const Bitboard enemyRooksQueens = pos.pieces(~us, ROOK, QUEEN);
+
+    const auto check_pressure = [&](Square target) {
+        if (!is_ok(target))
+            return false;
+        return bool(pos.attackers_to(target, pos.pieces()) & enemyRooksQueens);
+    };
+
+    enemyPressure = enemyPressure || check_pressure(Square(int(kingSq) + forward))
+                    || check_pressure(Square(int(kingSq) + 2 * forward));
+
+    if (enemyPressure)
+        return friendlyShield ? 112 : 96;
+
+    return friendlyShield ? 140 : 128;
+}
+
 // (*Scalers):
 // The values with Scaler asterisks have proven non-linear scaling.
 // They are optimized to time controls of 180 + 1.8 and longer,
 // so changing them or adding conditions that are similar requires
 // tests at these types of time controls.
 
-int correction_value(const Worker& w, const Position& pos, const Stack* const ss) {
+int correction_value(const Worker& w,
+                     const Position& pos,
+                     const Stack* const ss,
+                     Depth            depth) {
     const Color us    = pos.side_to_move();
     const auto  m     = (ss - 1)->currentMove;
     const auto  pcv   = w.pawnCorrectionHistory[pawn_correction_history_index(pos)][us];
@@ -85,7 +133,22 @@ int correction_value(const Worker& w, const Position& pos, const Stack* const ss
       m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
                  : 0;
 
-    return 8867 * pcv + 8136 * micv + 10757 * (wnpcv + bnpcv) + 7232 * cntcv;
+    const int depthLeft     = std::max(int(depth), 0);
+    const int depthScale    = 128 - std::min(48, depthLeft * 4);
+    const int experienceAim = w.experienceAvailable ? 96 : 128;
+    const int blendedScale  = (depthScale * 3 + experienceAim) / 4;
+    const int exposureScale = king_file_exposure_scale(pos, us);
+
+    const int staticScale = std::clamp(blendedScale * exposureScale / 128, 72, 160);
+    const int continuationScale =
+      std::clamp(staticScale + 16, std::max(96, staticScale), 168);
+
+    const int64_t staticContribution =
+      8867LL * pcv + 8136LL * micv + 10757LL * (wnpcv + bnpcv);
+    const int64_t continuationContribution = 7232LL * cntcv;
+
+    return int((staticContribution * staticScale + continuationContribution * continuationScale)
+               / 128);
 }
 
 // Add correctionHistory value to raw staticEval and guarantee evaluation
@@ -106,16 +169,20 @@ void update_correction_history(const Position& pos,
 
     static constexpr int nonPawnWeight = 165;
 
-    workerThread.pawnCorrectionHistory[pawn_correction_history_index(pos)][us] << bonus;
-    workerThread.minorPieceCorrectionHistory[minor_piece_index(pos)][us] << bonus * 153 / 128;
+    const int exposureScale = king_file_exposure_scale(pos, us);
+    const int scaledBonus = (bonus * exposureScale + (bonus >= 0 ? 64 : -64)) / 128;
+
+    workerThread.pawnCorrectionHistory[pawn_correction_history_index(pos)][us] << scaledBonus;
+    workerThread.minorPieceCorrectionHistory[minor_piece_index(pos)][us]
+      << scaledBonus * 153 / 128;
     workerThread.nonPawnCorrectionHistory[non_pawn_index<WHITE>(pos)][WHITE][us]
-      << bonus * nonPawnWeight / 128;
+      << scaledBonus * nonPawnWeight / 128;
     workerThread.nonPawnCorrectionHistory[non_pawn_index<BLACK>(pos)][BLACK][us]
-      << bonus * nonPawnWeight / 128;
+      << scaledBonus * nonPawnWeight / 128;
 
     if (m.is_ok())
         (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-          << bonus * 153 / 128;
+          << scaledBonus * 153 / 128;
 }
 
 // Add a small random component to draw evaluations to avoid 3-fold blindness
@@ -192,8 +259,10 @@ void Search::Worker::start_searching() {
                             main_manager()->originalTimeAdjust);
     tt.new_search();
 
-    Move preferredMove = Move::none();
-    Move bookMove      = Move::none();
+    Move preferredMove   = Move::none();
+    Move bookMove        = Move::none();
+    bool experienceBook  = false;
+    bool experiencePrior = false;
 
     if (rootMoves.empty())
     {
@@ -208,18 +277,28 @@ void Search::Worker::start_searching() {
             if ((bool) options["Experience Enabled"])
             {
                 if ((bool) options["Experience Prior"])
+                {
                     preferredMove =
                       experience.probe(rootPos, (int) options["Experience Width"],
                                        (int) options["Experience Eval Weight"],
                                        (int) options["Experience Min Depth"],
                                        (int) options["Experience Max Moves"]);
+                    experiencePrior = preferredMove != Move::none();
+                }
 
                 if ((bool) options["Experience Book"])
-                    bookMove = experience.probe(rootPos,
-                                               (int) options["Experience Book Max Moves"],
-                                               (int) options["Experience Eval Weight"],
-                                               (int) options["Experience Book Min Depth"],
-                                               (int) options["Experience Book Max Moves"]);
+                {
+                    Move candidate = experience.probe(rootPos,
+                                                     (int) options["Experience Book Max Moves"],
+                                                     (int) options["Experience Eval Weight"],
+                                                     (int) options["Experience Book Min Depth"],
+                                                     (int) options["Experience Book Max Moves"]);
+                    if (candidate != Move::none())
+                    {
+                        bookMove       = candidate;
+                        experienceBook = true;
+                    }
+                }
             }
 
             if ((bool) options["Book1"]
@@ -233,6 +312,20 @@ void Search::Worker::start_searching() {
                 bookMove = polybook[1].probe(rootPos, (bool) options["Book2 BestBookMove"],
                                              (int) options["Book2 Width"]);
         }
+
+        const bool experienceGuidance = experiencePrior || experienceBook;
+
+        experienceAvailable = experienceGuidance;
+        for (size_t idx = 1; idx < threads.size(); ++idx)
+        {
+            auto threadIt  = std::next(threads.begin(), idx);
+            auto workerPtr = (*threadIt)->worker.get();
+            threads.run_on_thread(idx, [workerPtr, experienceGuidance]() {
+                workerPtr->experienceAvailable = experienceGuidance;
+            });
+        }
+        for (size_t idx = 1; idx < threads.size(); ++idx)
+            threads.wait_on_thread(idx);
 
         if (preferredMove != Move::none()
             && std::find(rootMoves.begin(), rootMoves.end(), preferredMove) != rootMoves.end())
@@ -379,6 +472,9 @@ void Search::Worker::iterative_deepening() {
     while (++rootDepth < MAX_PLY && !threads.stop
            && !(limits.depth && mainThread && rootDepth > limits.depth))
     {
+        if ((iterIdx++ & 3) == 0)
+            ensure_network_replicated();
+
         // Age out PV variability metric
         if (mainThread)
             totBestMoveChanges /= 2;
@@ -666,6 +762,8 @@ void Search::Worker::clear() {
         reductions[i] = int(2782 / 128.0 * std::log(i));
 
     refreshTable.clear(networks[numaAccessToken]);
+
+    experienceAvailable = false;
 }
 
 
@@ -871,7 +969,7 @@ Value Search::Worker::search(
 
     // Step 6. Static evaluation of the position
     Value      unadjustedStaticEval = VALUE_NONE;
-    const auto correctionValue      = correction_value(*this, pos, ss);
+    const auto correctionValue      = correction_value(*this, pos, ss, depth);
     if (ss->inCheck)
     {
         // Skip early pruning when in check
@@ -1637,7 +1735,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
         bestValue = futilityBase = -VALUE_INFINITE;
     else
     {
-        const auto correctionValue = correction_value(*this, pos, ss);
+        const auto correctionValue = correction_value(*this, pos, ss, depth);
 
         if (ss->ttHit)
         {

--- a/src/search.h
+++ b/src/search.h
@@ -362,6 +362,8 @@ class Worker {
     Eval::NNUE::NetworkSmall::WeightsPtr  smallWeightsHandle;
     Eval::NNUE::NetworkFalcon::WeightsPtr falconWeightsHandle;
 
+    bool experienceAvailable = false;
+
     friend class Stockfish::ThreadPool;
     friend class SearchManager;
 };

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -41,13 +41,7 @@
 #include "experience.h"
 #include "types.h"
 #include "ucioption.h"
-
-#ifndef ENGINE_NAME
-    #define ENGINE_NAME "Wordfish 2.42-190825"
-#endif
-#ifndef ENGINE_BUILD_DATE
-    #define ENGINE_BUILD_DATE ""
-#endif
+#include "version.h"
 
 namespace Stockfish {
 
@@ -127,7 +121,7 @@ void UCIEngine::loop() {
             // Force a stable, explicit UCI name so GUIs show "Wordfish 1.0"
             sync_cout_start();
             std::cout
-              << "id name " << ENGINE_NAME << "\n"
+              << "id name " << Version::string() << "\n"
               << "id author Jorge Ruiz Centelles and the Stockfish developers (see AUTHORS file)"
               << "\n"
               << engine.get_options() << std::endl;
@@ -463,7 +457,7 @@ void UCIEngine::benchmark(std::istream& args) {
     // clang-format off
 
     std::cerr << "==========================="
-              << "\nVersion                    :   << ENGINE_NAME"
+              << "\nVersion                    : " << Version::string()
               << compiler_info()
               << "Large pages                  : " << (has_large_pages() ? "yes" : "no")
               << "\nUser invocation            : " << BenchmarkCommand << " "

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -19,14 +19,6 @@
 */
 
 #include "ucioption.h"
-// --- Engine identity (fallbacks; Makefile can override) ---
-#ifndef ENGINE_NAME
-    #define ENGINE_NAME "Wordfish 2.42-190825"
-#endif
-#ifndef ENGINE_BUILD_DATE
-    #define ENGINE_BUILD_DATE ""  // build identifier
-#endif
-
 
 #include <algorithm>
 #include <cassert>
@@ -38,6 +30,7 @@
 #include <charconv>
 
 #include "misc.h"
+#include "version.h"
 
 namespace Stockfish {
 

--- a/src/version.h
+++ b/src/version.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+
+#ifndef ENGINE_NAME
+    #define ENGINE_NAME "Wordfish 2.50 dev-210925"
+#endif
+
+#ifndef ENGINE_BUILD_DATE
+    #define ENGINE_BUILD_DATE ""
+#endif
+
+namespace Stockfish::Version {
+
+inline constexpr std::string_view Name      = ENGINE_NAME;
+inline constexpr std::string_view BuildTag = ENGINE_BUILD_DATE;
+
+inline std::string string() {
+    if (BuildTag.empty())
+        return std::string(Name);
+
+    std::string result(Name);
+    result += ' ';
+    result.append(BuildTag);
+    return result;
+}
+
+}  // namespace Stockfish::Version
+


### PR DESCRIPTION
## Summary
- centralize the engine identity in a shared version header and use the new "Wordfish 2.50 dev-210925" label in the console, UCI handshake, benchmark output, and default Makefile configuration so builds without overrides report the same version string
- rescale correction-history contributions with depth-, experience-, and king-file exposure-aware factors before blending into static evaluation and stats updates
- broadcast experience availability to every worker and periodically refresh NNUE handles during iterative deepening to stay current with shared networks

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cff41f6cbc8327a17893de01aa391e