### PR TITLE
Convert next TT value before cutoff check

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -903,13 +903,19 @@ Value Search::Worker::search(
                 pos.do_move(ttData.move, st);
                 Key nextPosKey                             = pos.key();
                 auto [ttHitNext, ttDataNext, ttWriterNext] = tt.probe(nextPosKey);
+                Value ttValueNext = ttHitNext
+                  ? value_from_tt(ttDataNext.value, ss->ply + 1, pos.rule50_count())
+                  : VALUE_NONE;
                 pos.undo_move(ttData.move);
 
                 // Check that the ttValue after the tt move would also trigger a cutoff
-                if (!is_valid(ttDataNext.value))
-                    return ttData.value;
-                if ((ttData.value >= beta) == (-ttDataNext.value >= beta))
-                    return ttData.value;
+                if (ttHitNext)
+                {
+                    if (!is_valid(ttValueNext))
+                        return ttData.value;
+                    if ((ttData.value >= beta) == (-ttValueNext >= beta))
+                        return ttData.value;
+                }
             }
             else
                 return ttData.value;


### PR DESCRIPTION
## Summary
- convert the probed child transposition table value before using it in the cutoff logic
- skip the cutoff verification when the second probe misses

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2147db8348327a72f0c355e470194