### PR TITLE
Sanitize TT moves before use

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -867,6 +867,11 @@ Value Search::Worker::search(
     // Need further processing of the saved data
     ss->ttHit    = ttHit;
     ttData.move  = rootNode ? rootMoves[pvIdx].pv[0] : ttHit ? ttData.move : Move::none();
+    if (ttData.move)
+    {
+        if (!pos.pseudo_legal(ttData.move) || !pos.legal(ttData.move))
+            ttData.move = Move::none();
+    }
     ttData.value = ttHit ? value_from_tt(ttData.value, ss->ply, pos.rule50_count()) : VALUE_NONE;
     ss->ttPv     = excludedMove ? ss->ttPv : PvNode || (ttHit && ttData.is_pv);
     ttCapture    = ttData.move && pos.capture_stage(ttData.move);
@@ -1722,6 +1727,11 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
     // Need further processing of the saved data
     ss->ttHit    = ttHit;
     ttData.move  = ttHit ? ttData.move : Move::none();
+    if (ttData.move)
+    {
+        if (!pos.pseudo_legal(ttData.move) || !pos.legal(ttData.move))
+            ttData.move = Move::none();
+    }
     ttData.value = ttHit ? value_from_tt(ttData.value, ss->ply, pos.rule50_count()) : VALUE_NONE;
     pvHit        = ttHit && ttData.is_pv;
 


### PR DESCRIPTION
## Summary
- ensure TT moves are pseudo-legal and legal before using them in the main search
- propagate the same sanitization to qsearch so MovePicker never receives invalid TT moves
- recompute capture tracking from the sanitized move for consistent heuristics

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d214885a5c832799e80d784eef8292