### PR TITLE
Refactor TT probe handling

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -226,6 +226,30 @@ Search::Worker::Worker(SharedState&                    sharedState,
     clear();
 }
 
+TTLookupResult
+Search::Worker::probe_tt(Position& pos, Stack* ss, Key posKey, Move overrideMove) {
+
+    auto [ttHit, ttData, ttWriter] = tt.probe(posKey);
+
+    ss->ttHit = ttHit;
+
+    Move ttMove = overrideMove ? overrideMove : ttHit ? ttData.move : Move::none();
+
+    if (ttMove && (!ttMove.is_ok() || !pos.pseudo_legal(ttMove)))
+        ttMove = Move::none();
+
+    const Value ttValue = ttHit ? value_from_tt(ttData.value, ss->ply, pos.rule50_count())
+                                : VALUE_NONE;
+
+    ttData.move  = ttMove;
+    ttData.value = ttValue;
+
+    const bool pvHit    = ttHit && ttData.is_pv;
+    const bool isCapture = ttMove && pos.capture_stage(ttMove);
+
+    return TTLookupResult{ttHit, ttData, ttWriter, ttMove, ttValue, pvHit, isCapture};
+}
+
 void Search::Worker::ensure_network_replicated() {
     const auto& nets = networks[numaAccessToken];
 
@@ -862,14 +886,14 @@ Value Search::Worker::search(
 
     // Step 4. Transposition table lookup
     excludedMove                   = ss->excludedMove;
-    posKey                         = pos.key();
-    auto [ttHit, ttData, ttWriter] = tt.probe(posKey);
-    // Need further processing of the saved data
-    ss->ttHit    = ttHit;
-    ttData.move  = rootNode ? rootMoves[pvIdx].pv[0] : ttHit ? ttData.move : Move::none();
-    ttData.value = ttHit ? value_from_tt(ttData.value, ss->ply, pos.rule50_count()) : VALUE_NONE;
-    ss->ttPv     = excludedMove ? ss->ttPv : PvNode || (ttHit && ttData.is_pv);
-    ttCapture    = ttData.move && pos.capture_stage(ttData.move);
+    posKey = pos.key();
+    TTLookupResult ttResult =
+      probe_tt(pos, ss, posKey, rootNode ? rootMoves[pvIdx].pv[0] : Move::none());
+    const bool ttHit = ttResult.hit;
+    auto& ttData   = ttResult.data;
+    auto& ttWriter = ttResult.writer;
+    ss->ttPv       = excludedMove ? ss->ttPv : PvNode || ttResult.pvHit;
+    ttCapture      = ttResult.isCapture;
 
     // At this point, if excluded, skip straight to step 6, static eval. However,
     // to save indentation, we list the condition in all code between here and there.
@@ -1717,13 +1741,12 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
     assert(0 <= ss->ply && ss->ply < MAX_PLY);
 
     // Step 3. Transposition table lookup
-    posKey                         = pos.key();
-    auto [ttHit, ttData, ttWriter] = tt.probe(posKey);
-    // Need further processing of the saved data
-    ss->ttHit    = ttHit;
-    ttData.move  = ttHit ? ttData.move : Move::none();
-    ttData.value = ttHit ? value_from_tt(ttData.value, ss->ply, pos.rule50_count()) : VALUE_NONE;
-    pvHit        = ttHit && ttData.is_pv;
+    posKey = pos.key();
+    TTLookupResult ttResult = probe_tt(pos, ss, posKey);
+    const bool     ttHit    = ttResult.hit;
+    auto&          ttData   = ttResult.data;
+    auto&          ttWriter = ttResult.writer;
+    pvHit = ttResult.pvHit;
 
     // At non-PV nodes we check for an early TT cutoff
     if (!PvNode && ttData.depth >= DEPTH_QS

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -235,7 +235,8 @@ Search::Worker::probe_tt(Position& pos, Stack* ss, Key posKey, Move overrideMove
 
     Move ttMove = overrideMove ? overrideMove : ttHit ? ttData.move : Move::none();
 
-    if (ttMove && (!ttMove.is_ok() || !pos.pseudo_legal(ttMove)))
+    if (ttMove
+        && (!ttMove.is_ok() || !pos.pseudo_legal(ttMove) || !pos.legal(ttMove)))
         ttMove = Move::none();
 
     const Value ttValue = ttHit ? value_from_tt(ttData.value, ss->ply, pos.rule50_count())

--- a/src/search.h
+++ b/src/search.h
@@ -40,6 +40,7 @@
 #include "score.h"
 #include "syzygy/tbprobe.h"
 #include "timeman.h"
+#include "tt.h"
 #include "types.h"
 
 namespace Stockfish {
@@ -56,6 +57,16 @@ class ThreadPool;
 class OptionsMap;
 
 namespace Search {
+
+struct TTLookupResult {
+    bool     hit;
+    TTData   data;
+    TTWriter writer;
+    Move     move;
+    Value    value;
+    bool     pvHit;
+    bool     isCapture;
+};
 
 // Stack struct keeps track of the information we need to remember from nodes
 // shallower and deeper in the tree during the search. Each search thread has
@@ -312,6 +323,11 @@ class Worker {
     // Quiescence search function, which is called by the main search
     template<NodeType nodeType>
     Value qsearch(Position& pos, Stack* ss, Value alpha, Value beta);
+
+    TTLookupResult probe_tt(Position& pos,
+                            Stack*     ss,
+                            Key        posKey,
+                            Move       overrideMove = Move::none());
 
     Depth reduction(bool i, Depth d, int mn, int delta) const;
 


### PR DESCRIPTION
## Summary
- add a TTLookupResult helper struct and Worker::probe_tt to centralize TT lookups and move sanitization
- refactor search() and qsearch() to reuse the shared TT probing logic and rely on sanitized move data

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d214c476088327b9a3eb58037cbf56