### PR TITLE
Integrate Falcon NNUE into evaluation pipeline

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -30,6 +30,7 @@
 #include <vector>
 #include <iomanip>
 #include <random>
+#include <ctime>
 
 #include "evaluate.h"
 #include "misc.h"
@@ -374,16 +375,49 @@ void Engine::verify_networks() const {
     networks->big.verify(options["EvalFile"], onVerifyNetworks);
     networks->small.verify(options["EvalFileSmall"], onVerifyNetworks);
     networks->falcon.verify(options["FalconFile"], onVerifyNetworks);
+
+    if (onVerifyNetworks)
+    {
+        std::string status = networks->falcon.is_available() ? "active" : "inactive";
+        std::string requestedFile(options["FalconFile"]);
+        std::string fallbackFile(options["EvalFileSmall"]);
+        std::string origin = networks->falcon.loaded_from().empty() ? "(unknown)"
+                                                                   : networks->falcon.loaded_from();
+
+        std::time_t loadedAt = networks->falcon.loaded_time();
+        char        buffer[64]{};
+        if (loadedAt != 0)
+        {
+            std::tm tm{};
+#ifdef _WIN32
+            gmtime_s(&tm, &loadedAt);
+#else
+            gmtime_r(&loadedAt, &tm);
+#endif
+            std::strftime(buffer, sizeof(buffer), "%Y-%m-%d %H:%M:%SZ", &tm);
+        }
+
+        std::string when = loadedAt ? buffer : "never";
+
+        onVerifyNetworks("Falcon NNUE status: " + status + ", requested='" + requestedFile
+                          + "', source='" + origin + "', loaded=" + when
+                          + ", fallback='" + fallbackFile + "'");
+    }
 }
 
 void Engine::load_networks() {
-    networks.modify_and_replicate([this](NN::Networks& networks_) {
+    bool falconLoaded = true;
+    networks.modify_and_replicate([this, &falconLoaded](NN::Networks& networks_) {
         networks_.big.load(binaryDirectory, options["EvalFile"]);
         networks_.small.load(binaryDirectory, options["EvalFileSmall"]);
-        networks_.falcon.load(binaryDirectory, options["FalconFile"]);
+        falconLoaded = networks_.falcon.load(binaryDirectory, options["FalconFile"]);
     });
     threads.clear();
     threads.ensure_network_replicated();
+
+    if (!falconLoaded)
+        sync_cout << "Falcon network ('" << std::string(options["FalconFile"]) << "') unavailable;"
+                  << " falling back to EvalFileSmall." << sync_endl;
 }
 
 void Engine::load_big_network(const std::string& file) {
@@ -401,12 +435,17 @@ void Engine::load_small_network(const std::string& file) {
 }
 
 void Engine::load_falcon_network(const std::string& file) {
+    bool falconLoaded = true;
     networks.modify_and_replicate(
-      [this, &file](NN::Networks& networks_) {
-          networks_.falcon.load(binaryDirectory, file);
+      [this, &file, &falconLoaded](NN::Networks& networks_) {
+          falconLoaded = networks_.falcon.load(binaryDirectory, file);
       });
     threads.clear();
     threads.ensure_network_replicated();
+
+    if (!falconLoaded)
+        sync_cout << "Falcon network ('" << file << "') unavailable; falling back to EvalFileSmall."
+                  << sync_endl;
 }
 
 void Engine::save_network(const std::pair<std::optional<std::string>, std::string> files[2]) {

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -48,6 +48,29 @@ int Eval::simple_eval(const Position& pos) {
 
 bool Eval::use_smallnet(const Position& pos) { return std::abs(simple_eval(pos)) > 962; }
 
+namespace {
+
+bool should_use_falcon(const Position& pos, bool smallNetPreferred) {
+    const int totalPieces    = pos.count<ALL_PIECES>();
+    const int pawns          = pos.count<PAWN>();
+    const int majorPieces    = pos.count<ROOK>() + pos.count<QUEEN>();
+    const int minorPieces    = pos.count<BISHOP>() + pos.count<KNIGHT>();
+    const int materialImb    = std::abs(Eval::simple_eval(pos));
+    const bool deepEndgame   = totalPieces <= 7 || (pawns <= 4 && majorPieces <= 1);
+    const bool lightMaterial = (pawns <= 5 && totalPieces <= 12) || minorPieces <= 1;
+    const bool highImbalance = materialImb > 800 && (pawns <= 6 || majorPieces <= 1);
+
+    if (deepEndgame)
+        return true;
+
+    if (smallNetPreferred)
+        return highImbalance || lightMaterial;
+
+    return highImbalance && lightMaterial;
+}
+
+}  // namespace
+
 // Evaluate is the evaluator for the outer world. It returns a static evaluation
 // of the position from the point of view of the side to move.
 Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
@@ -58,16 +81,63 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
 
     assert(!pos.checkers());
 
-    bool smallNet           = use_smallnet(pos);
-    auto [psqt, positional] = smallNet ? networks.small.evaluate(pos, accumulators, &caches.small)
-                                       : networks.big.evaluate(pos, accumulators, &caches.big);
+    bool  smallNetCandidate = use_smallnet(pos);
+    bool  falconAvailable   = networks.falcon.is_available();
+    bool  useFalconNet      = falconAvailable && should_use_falcon(pos, smallNetCandidate);
+    bool  smallNet          = smallNetCandidate;
+    Value nnue              = VALUE_ZERO;
+    Value psqt              = VALUE_ZERO;
+    Value positional        = VALUE_ZERO;
 
-    Value nnue = (125 * psqt + 131 * positional) / 128;
+    if (useFalconNet)
+    {
+        auto& falconCache = caches.cache_for_falcon(networks.falcon);
+        auto  falconEval  = networks.falcon.evaluate(pos, accumulators, &falconCache);
+
+        auto& bigCache = caches.cache_for_big(networks.big);
+        auto  bigEval  = networks.big.evaluate(pos, accumulators, &bigCache);
+
+        Value falconPsqt, falconPositional;
+        Value bigPsqt, bigPositional;
+        std::tie(falconPsqt, falconPositional) = falconEval;
+        std::tie(bigPsqt, bigPositional)       = bigEval;
+
+        int imbalance     = std::min(1500, std::abs(simple_eval(pos)));
+        int scarcityBonus = std::max(0, 10 - pos.count<ALL_PIECES>());
+        int falconWeight  = 64 + imbalance * 32 / 1500 + scarcityBonus * 4;
+        falconWeight      = std::clamp(falconWeight, 48, 120);
+
+        psqt       = Value((falconWeight * falconPsqt + (128 - falconWeight) * bigPsqt) / 128);
+        positional = Value((falconWeight * falconPositional + (128 - falconWeight) * bigPositional)
+                           / 128);
+
+        Value falconScore = (125 * falconPsqt + 131 * falconPositional) / 128;
+        Value bigScore    = (125 * bigPsqt + 131 * bigPositional) / 128;
+        nnue              = Value((falconWeight * falconScore + (128 - falconWeight) * bigScore) / 128);
+        smallNet          = false;
+    }
+    else
+    {
+        if (smallNetCandidate)
+        {
+            auto& smallCache = caches.cache_for_small(networks.small);
+            std::tie(psqt, positional) = networks.small.evaluate(pos, accumulators, &smallCache);
+        }
+        else
+        {
+            auto& bigCache = caches.cache_for_big(networks.big);
+            std::tie(psqt, positional) = networks.big.evaluate(pos, accumulators, &bigCache);
+            smallNet                   = false;
+        }
+
+        nnue = (125 * psqt + 131 * positional) / 128;
+    }
 
     // Re-evaluate the position when higher eval accuracy is worth the time spent
-    if (smallNet && (std::abs(nnue) < 236))
+    if (!useFalconNet && smallNet && (std::abs(nnue) < 236))
     {
-        std::tie(psqt, positional) = networks.big.evaluate(pos, accumulators, &caches.big);
+        auto& bigCache = caches.cache_for_big(networks.big);
+        std::tie(psqt, positional) = networks.big.evaluate(pos, accumulators, &bigCache);
         nnue                       = (125 * psqt + 131 * positional) / 128;
         smallNet                   = false;
     }
@@ -107,7 +177,8 @@ std::string Eval::trace(Position& pos, const Eval::NNUE::Networks& networks) {
 
     ss << std::showpoint << std::showpos << std::fixed << std::setprecision(2) << std::setw(15);
 
-    auto [psqt, positional] = networks.big.evaluate(pos, accumulators, &caches->big);
+    auto& bigCache = caches->cache_for_big(networks.big);
+    auto [psqt, positional] = networks.big.evaluate(pos, accumulators, &bigCache);
     Value v                 = psqt + positional;
     v                       = pos.side_to_move() == WHITE ? v : -v;
     ss << "NNUE evaluation        " << 0.01 * UCIEngine::to_cp(v, pos) << " (white side)\n";

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -21,6 +21,7 @@
 #include <cassert>
 #include <cstdlib>
 #include <fstream>
+#include <ctime>
 #include <iostream>
 #include <memory>
 #include <optional>
@@ -149,7 +150,7 @@ Network<Arch, Transformer>::operator=(const Network<Arch, Transformer>& other) {
 }
 
 template<typename Arch, typename Transformer>
-void Network<Arch, Transformer>::load(const std::string& rootDirectory, std::string evalfilePath) {
+bool Network<Arch, Transformer>::load(const std::string& rootDirectory, std::string evalfilePath) {
 #if defined(DEFAULT_NNUE_DIRECTORY)
     std::vector<std::string> dirs = {"<internal>", "", rootDirectory,
                                      stringify(DEFAULT_NNUE_DIRECTORY)};
@@ -160,21 +161,65 @@ void Network<Arch, Transformer>::load(const std::string& rootDirectory, std::str
     if (evalfilePath.empty())
         evalfilePath = evalFile.defaultName;
 
+    auto previousWeights = weights_handle();
+    bool loadedNewWeights = false;
+    std::string resolvedPath;
+
     for (const auto& directory : dirs)
     {
-        if (evalFile.current != evalfilePath)
-        {
-            if (directory != "<internal>")
-            {
-                load_user_net(directory, evalfilePath);
-            }
+        if (evalFile.current == evalfilePath && available.load(std::memory_order_relaxed))
+            break;
 
-            if (directory == "<internal>" && evalfilePath == evalFile.defaultName)
-            {
-                load_internal();
-            }
+        bool loaded = false;
+
+        if (directory != "<internal>")
+        {
+            loaded = load_user_net(directory, evalfilePath);
+            if (loaded)
+                resolvedPath = directory.empty() ? evalfilePath : directory + evalfilePath;
+        }
+
+        if (!loaded && directory == "<internal>" && evalfilePath == evalFile.defaultName)
+        {
+            loaded = load_internal();
+            if (loaded)
+                resolvedPath = "<internal>";
+        }
+
+        if (loaded)
+        {
+            loadedNewWeights = true;
+            break;
         }
     }
+
+    auto currentWeights = weights_handle();
+
+    bool alreadyLoaded = evalFile.current == evalfilePath && bool(currentWeights);
+    bool success       = loadedNewWeights || alreadyLoaded;
+
+    if (success)
+    {
+        available.store(true, std::memory_order_relaxed);
+
+        if (loadedNewWeights && currentWeights && currentWeights != previousWeights)
+        {
+            versionCounter.fetch_add(1, std::memory_order_relaxed);
+            lastLoadedFrom = resolvedPath.empty() ? evalfilePath : resolvedPath;
+            lastLoadedTime.store(std::time(nullptr), std::memory_order_relaxed);
+        }
+
+        return true;
+    }
+
+    available.store(false, std::memory_order_relaxed);
+
+    if (embeddedType == EmbeddedNNUEType::FALCON)
+        std::atomic_store(&weights, WeightsPtr{});
+
+    evalFile.current.clear();
+
+    return false;
 }
 
 
@@ -224,6 +269,26 @@ Network<Arch, Transformer>::weights_handle() const {
     return std::atomic_load(&weights);
 }
 
+template<typename Arch, typename Transformer>
+std::uint64_t Network<Arch, Transformer>::version() const {
+    return versionCounter.load(std::memory_order_relaxed);
+}
+
+template<typename Arch, typename Transformer>
+bool Network<Arch, Transformer>::is_available() const {
+    return available.load(std::memory_order_relaxed) && bool(std::atomic_load(&weights));
+}
+
+template<typename Arch, typename Transformer>
+std::time_t Network<Arch, Transformer>::loaded_time() const {
+    return lastLoadedTime.load(std::memory_order_relaxed);
+}
+
+template<typename Arch, typename Transformer>
+const std::string& Network<Arch, Transformer>::loaded_from() const {
+    return lastLoadedFrom;
+}
+
 
 template<typename Arch, typename Transformer>
 NetworkOutput
@@ -259,8 +324,10 @@ void Network<Arch, Transformer>::verify(std::string                             
     if (evalfilePath.empty())
         evalfilePath = evalFile.defaultName;
 
-    if (evalFile.current != evalfilePath)
-    {
+    bool required = embeddedType != EmbeddedNNUEType::FALCON;
+    auto storage  = weights_handle();
+
+    auto abort_with_message = [&]() {
         if (f)
         {
             std::string msg1 =
@@ -280,21 +347,44 @@ void Network<Arch, Transformer>::verify(std::string                             
         }
 
         exit(EXIT_FAILURE);
-    }
+    };
 
-    if (f)
+    if ((!storage || evalFile.current != evalfilePath) && required)
+        abort_with_message();
+
+    if (!f)
+        return;
+
+    if (!storage || evalFile.current != evalfilePath)
     {
-        auto storage = weights_handle();
-        if (!storage)
-            return;
-
-        size_t size = sizeof(*storage->featureTransformer) + sizeof(Arch) * LayerStacks;
-        f("NNUE evaluation using " + evalfilePath + " (" + std::to_string(size / (1024 * 1024))
-          + "MiB, (" + std::to_string(storage->featureTransformer->InputDimensions) + ", "
-          + std::to_string(storage->network[0].TransformedFeatureDimensions) + ", "
-          + std::to_string(storage->network[0].FC_0_OUTPUTS) + ", "
-          + std::to_string(storage->network[0].FC_1_OUTPUTS) + ", 1))");
+        f("Falcon network inactive (requested '" + evalfilePath
+          + "'); falling back to EvalFileSmall outputs.");
+        return;
     }
+
+    size_t size = sizeof(*storage->featureTransformer) + sizeof(Arch) * LayerStacks;
+
+    std::time_t loadedAt = loaded_time();
+    char        buffer[64]{};
+    if (loadedAt != 0)
+    {
+        std::tm tm{};
+#ifdef _WIN32
+        gmtime_s(&tm, &loadedAt);
+#else
+        gmtime_r(&loadedAt, &tm);
+#endif
+        std::strftime(buffer, sizeof(buffer), "%Y-%m-%d %H:%M:%SZ", &tm);
+    }
+
+    std::string origin = loaded_from().empty() ? "(unknown)" : loaded_from();
+
+    f("NNUE evaluation using " + evalfilePath + " (" + std::to_string(size / (1024 * 1024))
+      + "MiB, (" + std::to_string(storage->featureTransformer->InputDimensions) + ", "
+      + std::to_string(storage->network[0].TransformedFeatureDimensions) + ", "
+      + std::to_string(storage->network[0].FC_0_OUTPUTS) + ", "
+      + std::to_string(storage->network[0].FC_1_OUTPUTS) + ", 1))\n"
+      + "    source: " + origin + "\n    loaded: " + (loadedAt ? buffer : "never"));
 }
 
 
@@ -334,21 +424,22 @@ Network<Arch, Transformer>::trace_evaluate(const Position&                      
 
 
 template<typename Arch, typename Transformer>
-void Network<Arch, Transformer>::load_user_net(const std::string& dir,
+bool Network<Arch, Transformer>::load_user_net(const std::string& dir,
                                                const std::string& evalfilePath) {
     std::ifstream stream(dir + evalfilePath, std::ios::binary);
     auto          description = load(stream);
 
-    if (description.has_value())
-    {
-        evalFile.current        = evalfilePath;
-        evalFile.netDescription = description.value();
-    }
+    if (!description.has_value())
+        return false;
+
+    evalFile.current        = evalfilePath;
+    evalFile.netDescription = description.value();
+    return true;
 }
 
 
 template<typename Arch, typename Transformer>
-void Network<Arch, Transformer>::load_internal() {
+bool Network<Arch, Transformer>::load_internal() {
     // C++ way to prepare a buffer for a memory stream
     class MemoryBuffer: public std::basic_streambuf<char> {
        public:
@@ -364,13 +455,14 @@ void Network<Arch, Transformer>::load_internal() {
                         size_t(embedded.size));
 
     std::istream stream(&buffer);
-    auto         description = load(stream);
+    auto description = load(stream);
 
-    if (description.has_value())
-    {
-        evalFile.current        = evalFile.defaultName;
-        evalFile.netDescription = description.value();
-    }
+    if (!description.has_value())
+        return false;
+
+    evalFile.current        = evalFile.defaultName;
+    evalFile.netDescription = description.value();
+    return true;
 }
 
 

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -29,6 +29,7 @@
 #include <string_view>
 #include <tuple>
 #include <utility>
+#include <ctime>
 
 #include "../memory.h"
 #include "../types.h"
@@ -67,7 +68,10 @@ class Network {
     Network(EvalFile file, EmbeddedNNUEType type) :
         weights(std::make_shared<Weights>()),
         evalFile(file),
-        embeddedType(type) {}
+        embeddedType(type),
+        versionCounter(0),
+        available(false),
+        lastLoadedTime(0) {}
 
     Network(const Network& other);
     Network(Network&& other) = default;
@@ -75,10 +79,14 @@ class Network {
     Network& operator=(const Network& other);
     Network& operator=(Network&& other) = default;
 
-    void load(const std::string& rootDirectory, std::string evalfilePath);
+    bool load(const std::string& rootDirectory, std::string evalfilePath);
     bool save(const std::optional<std::string>& filename) const;
 
     WeightsPtr weights_handle() const;
+    std::uint64_t version() const;
+    bool          is_available() const;
+    std::time_t   loaded_time() const;
+    const std::string& loaded_from() const;
 
     NetworkOutput evaluate(const Position&                         pos,
                            AccumulatorStack&                       accumulatorStack,
@@ -91,8 +99,8 @@ class Network {
                                  AccumulatorCaches::Cache<FTDimensions>* cache) const;
 
    private:
-    void load_user_net(const std::string&, const std::string&);
-    void load_internal();
+    bool load_user_net(const std::string&, const std::string&);
+    bool load_internal();
 
     WeightsPtr allocate_weights() const;
 
@@ -110,6 +118,11 @@ class Network {
 
     EvalFile         evalFile;
     EmbeddedNNUEType embeddedType;
+
+    std::atomic<std::uint64_t> versionCounter;
+    std::atomic<bool>          available;
+    std::atomic<std::time_t>   lastLoadedTime;
+    std::string                lastLoadedFrom;
 
     // Hash value of evaluation function structure
     static constexpr std::uint32_t hash = Transformer::get_hash_value() ^ Arch::get_hash_value();

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -102,15 +102,95 @@ struct AccumulatorCaches {
 
     template<typename Networks>
     void clear(const Networks& networks) {
-        big.clear(networks.big);
-        small.clear(networks.small);
-        falcon.clear(networks.falcon);
+        bigCache.cache.clear(networks.big);
+        bigCache.version = networks.big.version();
+
+        sharedSmall.reset();
+        sharedSmall.cache.clear(networks.small);
+        sharedSmall.owner        = SharedSmallCache::Owner::Small;
+        sharedSmall.smallVersion = networks.small.version();
+        sharedSmall.falconVersion = networks.falcon.version();
     }
 
-    Cache<TransformedFeatureDimensionsBig>   big;
-    Cache<TransformedFeatureDimensionsSmall> small;
-    // Falcon network uses the small-network dimensions
-    Cache<TransformedFeatureDimensionsSmall> falcon;
+    template<typename Network>
+    Cache<TransformedFeatureDimensionsBig>& cache_for_big(const Network& network) {
+        auto version = network.version();
+        if (bigCache.version != version)
+        {
+            bigCache.cache.clear(network);
+            bigCache.version = version;
+        }
+        return bigCache.cache;
+    }
+
+    template<typename Network>
+    Cache<TransformedFeatureDimensionsSmall>& cache_for_small(const Network& network) {
+        auto version = network.version();
+        if (sharedSmall.owner != SharedSmallCache::Owner::Small
+            || sharedSmall.smallVersion != version)
+        {
+            sharedSmall.cache.clear(network);
+            sharedSmall.owner        = SharedSmallCache::Owner::Small;
+            sharedSmall.smallVersion = version;
+        }
+        return sharedSmall.cache;
+    }
+
+    template<typename Network>
+    Cache<TransformedFeatureDimensionsSmall>& cache_for_falcon(const Network& network) {
+        if (!network.is_available())
+        {
+            sharedSmall.owner = SharedSmallCache::Owner::None;
+            return sharedSmall.cache;
+        }
+
+        auto version = network.version();
+        if (sharedSmall.owner != SharedSmallCache::Owner::Falcon
+            || sharedSmall.falconVersion != version)
+        {
+            sharedSmall.cache.clear(network);
+            sharedSmall.owner         = SharedSmallCache::Owner::Falcon;
+            sharedSmall.falconVersion = version;
+        }
+        return sharedSmall.cache;
+    }
+
+    void invalidate_big() { bigCache.version = 0; }
+
+    void invalidate_small() {
+        sharedSmall.smallVersion = 0;
+        if (sharedSmall.owner == SharedSmallCache::Owner::Small)
+            sharedSmall.owner = SharedSmallCache::Owner::None;
+    }
+
+    void invalidate_falcon() {
+        sharedSmall.falconVersion = 0;
+        if (sharedSmall.owner == SharedSmallCache::Owner::Falcon)
+            sharedSmall.owner = SharedSmallCache::Owner::None;
+    }
+
+    struct BigCacheState {
+        Cache<TransformedFeatureDimensionsBig> cache;
+        std::uint64_t                         version = 0;
+    };
+
+    struct SharedSmallCache {
+        enum class Owner { None, Small, Falcon };
+
+        void reset() {
+            owner         = Owner::None;
+            smallVersion  = 0;
+            falconVersion = 0;
+        }
+
+        Cache<TransformedFeatureDimensionsSmall> cache;
+        std::uint64_t                            smallVersion  = 0;
+        std::uint64_t                            falconVersion = 0;
+        Owner                                    owner         = Owner::None;
+    };
+
+    BigCacheState    bigCache;
+    SharedSmallCache sharedSmall;
 };
 
 

--- a/src/nnue/nnue_misc.cpp
+++ b/src/nnue/nnue_misc.cpp
@@ -124,7 +124,12 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
 
     // We estimate the value of each piece by doing a differential evaluation from
     // the current base eval, simulating the removal of the piece from its square.
-    auto [psqt, positional] = networks.falcon.evaluate(pos, accumulators, &caches.falcon);
+    auto& cacheToUse = networks.falcon.is_available()
+                         ? caches.cache_for_falcon(networks.falcon)
+                         : caches.cache_for_small(networks.small);
+    auto [psqt, positional] = networks.falcon.is_available()
+                                ? networks.falcon.evaluate(pos, accumulators, &cacheToUse)
+                                : networks.small.evaluate(pos, accumulators, &cacheToUse);
     Value base              = psqt + positional;
     base                    = pos.side_to_move() == WHITE ? base : -base;
 
@@ -140,8 +145,12 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
                 pos.remove_piece(sq);
 
                 accumulators.reset();
-                std::tie(psqt, positional) =
-                  networks.falcon.evaluate(pos, accumulators, &caches.falcon);
+                auto& loopCache = networks.falcon.is_available()
+                                     ? caches.cache_for_falcon(networks.falcon)
+                                     : caches.cache_for_small(networks.small);
+                std::tie(psqt, positional) = networks.falcon.is_available()
+                                               ? networks.falcon.evaluate(pos, accumulators, &loopCache)
+                                               : networks.small.evaluate(pos, accumulators, &loopCache);
                 Value eval                 = psqt + positional;
                 eval                       = pos.side_to_move() == WHITE ? eval : -eval;
                 v                          = base - eval;
@@ -158,7 +167,12 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
     ss << '\n';
 
     accumulators.reset();
-    auto t = networks.falcon.trace_evaluate(pos, accumulators, &caches.falcon);
+    auto& traceCache = networks.falcon.is_available()
+                         ? caches.cache_for_falcon(networks.falcon)
+                         : caches.cache_for_small(networks.small);
+    auto t = networks.falcon.is_available()
+                ? networks.falcon.trace_evaluate(pos, accumulators, &traceCache)
+                : networks.small.trace_evaluate(pos, accumulators, &traceCache);
 
     ss << " NNUE network contributions "
        << (pos.side_to_move() == WHITE ? "(White to move)" : "(Black to move)") << std::endl

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -223,6 +223,10 @@ Search::Worker::Worker(SharedState&                    sharedState,
     bigWeightsHandle         = netsForToken.big.weights_handle();
     smallWeightsHandle       = netsForToken.small.weights_handle();
     falconWeightsHandle      = netsForToken.falcon.weights_handle();
+    bigWeightsVersion        = netsForToken.big.version();
+    smallWeightsVersion      = netsForToken.small.version();
+    falconWeightsVersion     = netsForToken.falcon.version();
+    falconAvailable          = netsForToken.falcon.is_available();
     clear();
 }
 
@@ -233,15 +237,30 @@ void Search::Worker::ensure_network_replicated() {
     auto newSmall  = nets.small.weights_handle();
     auto newFalcon = nets.falcon.weights_handle();
 
-    if (newBig == bigWeightsHandle && newSmall == smallWeightsHandle
-        && newFalcon == falconWeightsHandle)
+    bool bigChanged = newBig != bigWeightsHandle || nets.big.version() != bigWeightsVersion;
+    bool smallChanged = newSmall != smallWeightsHandle || nets.small.version() != smallWeightsVersion;
+    bool falconStateChanged =
+      newFalcon != falconWeightsHandle || nets.falcon.version() != falconWeightsVersion
+      || nets.falcon.is_available() != falconAvailable;
+
+    if (!bigChanged && !smallChanged && !falconStateChanged)
         return;
 
     bigWeightsHandle    = std::move(newBig);
     smallWeightsHandle  = std::move(newSmall);
     falconWeightsHandle = std::move(newFalcon);
 
-    refreshTable.clear(nets);
+    if (bigChanged)
+        refreshTable.invalidate_big();
+    if (smallChanged)
+        refreshTable.invalidate_small();
+    if (falconStateChanged)
+        refreshTable.invalidate_falcon();
+
+    bigWeightsVersion    = nets.big.version();
+    smallWeightsVersion  = nets.small.version();
+    falconWeightsVersion = nets.falcon.version();
+    falconAvailable      = nets.falcon.is_available();
 }
 
 bool Search::Worker::experience_guidance_available() const { return experienceAvailable; }

--- a/src/search.h
+++ b/src/search.h
@@ -362,6 +362,10 @@ class Worker {
     Eval::NNUE::NetworkBig::WeightsPtr    bigWeightsHandle;
     Eval::NNUE::NetworkSmall::WeightsPtr  smallWeightsHandle;
     Eval::NNUE::NetworkFalcon::WeightsPtr falconWeightsHandle;
+    std::uint64_t                          bigWeightsVersion   = 0;
+    std::uint64_t                          smallWeightsVersion = 0;
+    std::uint64_t                          falconWeightsVersion = 0;
+    bool                                   falconAvailable     = false;
 
     bool experienceAvailable = false;
 


### PR DESCRIPTION
## Summary
- integrate the Falcon NNUE weights into the evaluation by heuristically selecting Falcon-heavy blends with the big net and falling back to the legacy small net when Falcon is unavailable
- share the small-network accumulator cache between small and Falcon networks with version-aware invalidation so only affected caches refresh when weights change
- track per-network weight versions/availability with richer telemetry and automatic fallback warnings when Falcon loading fails

## Testing
- make build -C src

------
https://chatgpt.com/codex/tasks/task_e_68d3f65d714c8327a470f631a1efae34