### PR TITLE
Refactor NNUE network metadata and caches

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -381,8 +381,8 @@ void Engine::verify_networks() const {
         std::string status = networks->falcon.is_available() ? "active" : "inactive";
         std::string requestedFile(options["FalconFile"]);
         std::string fallbackFile(options["EvalFileSmall"]);
-        std::string origin = networks->falcon.loaded_from().empty() ? "(unknown)"
-                                                                   : networks->falcon.loaded_from();
+        std::string originValue = networks->falcon.loaded_from();
+        std::string origin      = originValue.empty() ? "(unknown)" : originValue;
 
         std::time_t loadedAt = networks->falcon.loaded_time();
         char        buffer[64]{};

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -26,6 +26,7 @@
 #include <memory>
 #include <optional>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #define INCBIN_SILENCE_BITCODE_WARNING
@@ -133,13 +134,13 @@ template<typename Arch, typename Transformer>
 Network<Arch, Transformer>::Network(const Network<Arch, Transformer>& other) :
     weights(std::atomic_load(&other.weights)),
     evalFile(other.evalFile),
-    embeddedType(other.embeddedType) {
+    embeddedType(other.embeddedType),
+    lastLoadedFromPtr(std::atomic_load(&other.lastLoadedFromPtr)) {
     versionCounter.store(other.versionCounter.load(std::memory_order_relaxed),
                          std::memory_order_relaxed);
     available.store(other.available.load(std::memory_order_relaxed), std::memory_order_relaxed);
     lastLoadedTime.store(other.lastLoadedTime.load(std::memory_order_relaxed),
                          std::memory_order_relaxed);
-    lastLoadedFrom = other.lastLoadedFrom;
 }
 
 template<typename Arch, typename Transformer>
@@ -156,7 +157,7 @@ Network<Arch, Transformer>::operator=(const Network<Arch, Transformer>& other) {
     available.store(other.available.load(std::memory_order_relaxed), std::memory_order_relaxed);
     lastLoadedTime.store(other.lastLoadedTime.load(std::memory_order_relaxed),
                          std::memory_order_relaxed);
-    lastLoadedFrom = other.lastLoadedFrom;
+    std::atomic_store(&lastLoadedFromPtr, std::atomic_load(&other.lastLoadedFromPtr));
 
     std::atomic_store(&weights, std::atomic_load(&other.weights));
 
@@ -219,8 +220,7 @@ bool Network<Arch, Transformer>::load(const std::string& rootDirectory, std::str
         if (loadedNewWeights && currentWeights && currentWeights != previousWeights)
         {
             versionCounter.fetch_add(1, std::memory_order_relaxed);
-            lastLoadedFrom = resolvedPath.empty() ? evalfilePath : resolvedPath;
-            lastLoadedTime.store(std::time(nullptr), std::memory_order_relaxed);
+            record_load(resolvedPath, evalfilePath);
         }
 
         return true;
@@ -232,6 +232,7 @@ bool Network<Arch, Transformer>::load(const std::string& rootDirectory, std::str
         std::atomic_store(&weights, WeightsPtr{});
 
     evalFile.current.clear();
+    clear_loaded_metadata();
 
     return false;
 }
@@ -299,8 +300,50 @@ std::time_t Network<Arch, Transformer>::loaded_time() const {
 }
 
 template<typename Arch, typename Transformer>
-const std::string& Network<Arch, Transformer>::loaded_from() const {
-    return lastLoadedFrom;
+std::string Network<Arch, Transformer>::loaded_from() const {
+    auto path = std::atomic_load(&lastLoadedFromPtr);
+    return path ? *path : std::string();
+}
+
+template<typename Arch, typename Transformer>
+typename Network<Arch, Transformer>::StateSnapshot
+Network<Arch, Transformer>::snapshot() const {
+    StateSnapshot state{};
+    state.weights   = weights_handle();
+    state.version   = versionCounter.load(std::memory_order_relaxed);
+    state.available = available.load(std::memory_order_relaxed) && bool(state.weights);
+    state.loadedAt  = lastLoadedTime.load(std::memory_order_relaxed);
+
+    if (auto path = std::atomic_load(&lastLoadedFromPtr))
+        state.loadedFrom = *path;
+
+    state.currentFile = evalFile.current;
+    state.description = evalFile.netDescription;
+
+    return state;
+}
+
+template<typename Arch, typename Transformer>
+void Network<Arch, Transformer>::set_loaded_from(std::string value) {
+    std::shared_ptr<const std::string> newPtr;
+    if (!value.empty())
+        newPtr = std::make_shared<std::string>(std::move(value));
+
+    std::atomic_store(&lastLoadedFromPtr, std::move(newPtr));
+}
+
+template<typename Arch, typename Transformer>
+void Network<Arch, Transformer>::record_load(const std::string& resolvedPath,
+                                             const std::string& evalfilePath) {
+    const std::string origin = resolvedPath.empty() ? evalfilePath : resolvedPath;
+    set_loaded_from(origin);
+    lastLoadedTime.store(std::time(nullptr), std::memory_order_relaxed);
+}
+
+template<typename Arch, typename Transformer>
+void Network<Arch, Transformer>::clear_loaded_metadata() {
+    set_loaded_from(std::string{});
+    lastLoadedTime.store(0, std::memory_order_relaxed);
 }
 
 
@@ -339,7 +382,7 @@ void Network<Arch, Transformer>::verify(std::string                             
         evalfilePath = evalFile.defaultName;
 
     bool required = embeddedType != EmbeddedNNUEType::FALCON;
-    auto storage  = weights_handle();
+    auto state    = snapshot();
 
     auto abort_with_message = [&]() {
         if (f)
@@ -363,22 +406,22 @@ void Network<Arch, Transformer>::verify(std::string                             
         exit(EXIT_FAILURE);
     };
 
-    if ((!storage || evalFile.current != evalfilePath) && required)
+    if ((!state.weights || state.currentFile != evalfilePath) && required)
         abort_with_message();
 
     if (!f)
         return;
 
-    if (!storage || evalFile.current != evalfilePath)
+    if (!state.weights || state.currentFile != evalfilePath)
     {
         f("Falcon network inactive (requested '" + evalfilePath
           + "'); falling back to EvalFileSmall outputs.");
         return;
     }
 
-    size_t size = sizeof(*storage->featureTransformer) + sizeof(Arch) * LayerStacks;
+    size_t size = sizeof(*state.weights->featureTransformer) + sizeof(Arch) * LayerStacks;
 
-    std::time_t loadedAt = loaded_time();
+    std::time_t loadedAt = state.loadedAt;
     char        buffer[64]{};
     if (loadedAt != 0)
     {
@@ -391,13 +434,13 @@ void Network<Arch, Transformer>::verify(std::string                             
         std::strftime(buffer, sizeof(buffer), "%Y-%m-%d %H:%M:%SZ", &tm);
     }
 
-    std::string origin = loaded_from().empty() ? "(unknown)" : loaded_from();
+    std::string origin = state.loadedFrom.empty() ? "(unknown)" : state.loadedFrom;
 
     f("NNUE evaluation using " + evalfilePath + " (" + std::to_string(size / (1024 * 1024))
-      + "MiB, (" + std::to_string(storage->featureTransformer->InputDimensions) + ", "
-      + std::to_string(storage->network[0].TransformedFeatureDimensions) + ", "
-      + std::to_string(storage->network[0].FC_0_OUTPUTS) + ", "
-      + std::to_string(storage->network[0].FC_1_OUTPUTS) + ", 1))\n"
+      + "MiB, (" + std::to_string(state.weights->featureTransformer->InputDimensions) + ", "
+      + std::to_string(state.weights->network[0].TransformedFeatureDimensions) + ", "
+      + std::to_string(state.weights->network[0].FC_0_OUTPUTS) + ", "
+      + std::to_string(state.weights->network[0].FC_1_OUTPUTS) + ", 1))\n"
       + "    source: " + origin + "\n    loaded: " + (loadedAt ? buffer : "never"));
 }
 

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -71,7 +71,8 @@ class Network {
         embeddedType(type),
         versionCounter(0),
         available(false),
-        lastLoadedTime(0) {}
+        lastLoadedTime(0),
+        lastLoadedFromPtr(nullptr) {}
 
     Network(const Network& other);
     Network(Network&& other) = default;
@@ -86,7 +87,19 @@ class Network {
     std::uint64_t version() const;
     bool          is_available() const;
     std::time_t   loaded_time() const;
-    const std::string& loaded_from() const;
+    std::string loaded_from() const;
+
+    struct StateSnapshot {
+        WeightsPtr     weights;
+        std::uint64_t  version;
+        bool           available;
+        std::time_t    loadedAt;
+        std::string    loadedFrom;
+        std::string    currentFile;
+        std::string    description;
+    };
+
+    [[nodiscard]] StateSnapshot snapshot() const;
 
     NetworkOutput evaluate(const Position&                         pos,
                            AccumulatorStack&                       accumulatorStack,
@@ -121,8 +134,12 @@ class Network {
 
     std::atomic<std::uint64_t> versionCounter;
     std::atomic<bool>          available;
-    std::atomic<std::time_t>   lastLoadedTime;
-    std::string                lastLoadedFrom;
+    std::atomic<std::time_t>             lastLoadedTime;
+    std::shared_ptr<const std::string>   lastLoadedFromPtr;
+
+    void set_loaded_from(std::string value);
+    void record_load(const std::string& resolvedPath, const std::string& evalfilePath);
+    void clear_loaded_metadata();
 
     // Hash value of evaluation function structure
     static constexpr std::uint32_t hash = Transformer::get_hash_value() ^ Arch::get_hash_value();

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -26,6 +26,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <memory>
 #include <vector>
 
 #include "../types.h"
@@ -77,7 +78,7 @@ struct AccumulatorCaches {
 
             // To initialize a refresh entry, we set all its bitboards empty,
             // so we put the biases in the accumulation, without any weights on top
-            void clear(const BiasType* biases) {
+            void reset(const BiasType* biases) {
 
                 std::memcpy(accumulation, biases, sizeof(accumulation));
                 std::memset((uint8_t*) this + offsetof(Entry, psqtAccumulation), 0,
@@ -85,14 +86,12 @@ struct AccumulatorCaches {
             }
         };
 
-        template<typename Network>
-        void clear(const Network& network) {
-            auto weights = network.weights_handle();
-            assert(weights);
+        void reset_from_biases(const BiasType* biases) {
+            assert(biases);
 
             for (auto& entries1D : entries)
                 for (auto& entry : entries1D)
-                    entry.clear(weights->featureTransformer->biases);
+                    entry.reset(biases);
         }
 
         std::array<Entry, COLOR_NB>& operator[](Square sq) { return entries[sq]; }
@@ -100,39 +99,79 @@ struct AccumulatorCaches {
         std::array<std::array<Entry, COLOR_NB>, SQUARE_NB> entries;
     };
 
+    struct CacheBinding {
+        template<typename Network, IndexType Size>
+        void prime(const Network& network, Cache<Size>& cache) {
+            auto handle = network.weights_handle();
+            assert(handle);
+            auto alias = std::shared_ptr<void>(handle, static_cast<void*>(handle.get()));
+            cache.reset_from_biases(handle->featureTransformer->biases);
+            weights = alias;
+            version = network.version();
+        }
+
+        template<typename Network, IndexType Size>
+        bool ensure(const Network& network, Cache<Size>& cache) {
+            return ensure_internal(network, cache, false);
+        }
+
+        void invalidate() {
+            version = 0;
+            weights.reset();
+        }
+
+        template<typename Network, IndexType Size>
+        bool ensure_internal(const Network& network, Cache<Size>& cache, bool force) {
+            auto handle = network.weights_handle();
+            if (!handle)
+                return false;
+
+            auto alias = std::shared_ptr<void>(handle, static_cast<void*>(handle.get()));
+            auto locked = weights.lock();
+            bool refresh = force || !locked || locked.get() != alias.get()
+                           || version != network.version();
+
+            if (refresh)
+            {
+                cache.reset_from_biases(handle->featureTransformer->biases);
+                weights = alias;
+                version = network.version();
+            }
+
+            return true;
+        }
+
+        std::weak_ptr<void> weights;
+        std::uint64_t       version = 0;
+    };
+
     template<typename Networks>
     void clear(const Networks& networks) {
-        bigCache.cache.clear(networks.big);
-        bigCache.version = networks.big.version();
+        if (auto weights = networks.big.weights_handle())
+        {
+            bigCache.binding.prime(networks.big, bigCache.cache);
+        }
+        else
+            bigCache.binding.invalidate();
 
         sharedSmall.reset();
-        sharedSmall.cache.clear(networks.small);
-        sharedSmall.owner        = SharedSmallCache::Owner::Small;
-        sharedSmall.smallVersion = networks.small.version();
-        sharedSmall.falconVersion = networks.falcon.version();
+
+        if (auto weights = networks.small.weights_handle())
+        {
+            sharedSmall.bindingSmall.prime(networks.small, sharedSmall.cache);
+            sharedSmall.owner = SharedSmallCache::Owner::Small;
+        }
     }
 
     template<typename Network>
     Cache<TransformedFeatureDimensionsBig>& cache_for_big(const Network& network) {
-        auto version = network.version();
-        if (bigCache.version != version)
-        {
-            bigCache.cache.clear(network);
-            bigCache.version = version;
-        }
+        bigCache.binding.ensure(network, bigCache.cache);
         return bigCache.cache;
     }
 
     template<typename Network>
     Cache<TransformedFeatureDimensionsSmall>& cache_for_small(const Network& network) {
-        auto version = network.version();
-        if (sharedSmall.owner != SharedSmallCache::Owner::Small
-            || sharedSmall.smallVersion != version)
-        {
-            sharedSmall.cache.clear(network);
-            sharedSmall.owner        = SharedSmallCache::Owner::Small;
-            sharedSmall.smallVersion = version;
-        }
+        sharedSmall.ensure_owner(network, SharedSmallCache::Owner::Small);
         return sharedSmall.cache;
     }
 
@@ -140,38 +179,33 @@ struct AccumulatorCaches {
     Cache<TransformedFeatureDimensionsSmall>& cache_for_falcon(const Network& network) {
         if (!network.is_available())
         {
-            sharedSmall.owner = SharedSmallCache::Owner::None;
+            if (sharedSmall.owner == SharedSmallCache::Owner::Falcon)
+                sharedSmall.owner = SharedSmallCache::Owner::None;
+            sharedSmall.bindingFalcon.invalidate();
             return sharedSmall.cache;
         }
 
-        auto version = network.version();
-        if (sharedSmall.owner != SharedSmallCache::Owner::Falcon
-            || sharedSmall.falconVersion != version)
-        {
-            sharedSmall.cache.clear(network);
-            sharedSmall.owner         = SharedSmallCache::Owner::Falcon;
-            sharedSmall.falconVersion = version;
-        }
+        sharedSmall.ensure_owner(network, SharedSmallCache::Owner::Falcon);
         return sharedSmall.cache;
     }
 
-    void invalidate_big() { bigCache.version = 0; }
+    void invalidate_big() { bigCache.binding.invalidate(); }
 
     void invalidate_small() {
-        sharedSmall.smallVersion = 0;
         if (sharedSmall.owner == SharedSmallCache::Owner::Small)
             sharedSmall.owner = SharedSmallCache::Owner::None;
+        sharedSmall.bindingSmall.invalidate();
     }
 
     void invalidate_falcon() {
-        sharedSmall.falconVersion = 0;
         if (sharedSmall.owner == SharedSmallCache::Owner::Falcon)
             sharedSmall.owner = SharedSmallCache::Owner::None;
+        sharedSmall.bindingFalcon.invalidate();
     }
 
     struct BigCacheState {
         Cache<TransformedFeatureDimensionsBig> cache;
-        std::uint64_t                         version = 0;
+        CacheBinding                           binding;
     };
 
     struct SharedSmallCache {
@@ -179,14 +213,33 @@ struct AccumulatorCaches {
 
         void reset() {
             owner         = Owner::None;
-            smallVersion  = 0;
-            falconVersion = 0;
+            bindingSmall.invalidate();
+            bindingFalcon.invalidate();
+        }
+
+        template<typename Network>
+        void ensure_owner(const Network& network, Owner desiredOwner) {
+            CacheBinding& binding = desiredOwner == Owner::Small ? bindingSmall : bindingFalcon;
+
+            if (!binding.ensure(network, cache))
+            {
+                if ((desiredOwner == Owner::Falcon && owner == Owner::Falcon)
+                    || desiredOwner == Owner::Small)
+                    owner = Owner::None;
+                return;
+            }
+
+            if (owner != desiredOwner)
+            {
+                owner = desiredOwner;
+                (desiredOwner == Owner::Small ? bindingFalcon : bindingSmall).invalidate();
+            }
         }
 
         Cache<TransformedFeatureDimensionsSmall> cache;
-        std::uint64_t                            smallVersion  = 0;
-        std::uint64_t                            falconVersion = 0;
-        Owner                                    owner         = Owner::None;
+        CacheBinding                             bindingSmall;
+        CacheBinding                             bindingFalcon;
+        Owner                                    owner = Owner::None;
     };
 
     BigCacheState    bigCache;


### PR DESCRIPTION
## Summary
- refactor the NNUE network to expose a reusable state snapshot, track metadata via atomics, and harden load bookkeeping
- rework the accumulator caches to use weight-aware bindings for big, small, and falcon nets instead of version-only invalidation
- tidy engine status reporting to avoid repeated NNUE metadata queries

## Testing
- make build ARCH=x86-64-sse41-popcnt -C src

------
https://chatgpt.com/codex/tasks/task_e_68d40e123d248327b8dec5edf3d344a4