### PR TITLE
Update engine identity to Wordfish v.2.70-dev-250925

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Wordfish Chess Engine
 
-**Versión v.2.60 230925**
+**Versión v.2.70-dev-250925**
 
-Este build se identifica como `Wordfish v.2.60 230925`.
+Este build se identifica como `Wordfish v.2.70-dev-250925`.
 
 <div align="center">
   <img src="[https://ijccrl.com/wp-content/uploads/2025/08/wordfish.png]" 

--- a/scripts/fishtest_local.sh
+++ b/scripts/fishtest_local.sh
@@ -4,7 +4,7 @@
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE="$ROOT_DIR/src/wordfish"
+ENGINE="$ROOT_DIR/src/Wordfish v.2.70-dev-250925"
 FISHTEST_DIR="${FISHTEST_DIR:-$HOME/fishtest}"
 
 if [ ! -x "$ENGINE" ]; then

--- a/scripts/match.sh
+++ b/scripts/match.sh
@@ -4,7 +4,9 @@
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE="${ENGINE:-$ROOT_DIR/src/wordfish}"
+ENGINE_NAME="Wordfish v.2.70-dev-250925"
+ENGINE_DEFAULT="$ROOT_DIR/src/$ENGINE_NAME"
+ENGINE="${ENGINE:-$ENGINE_DEFAULT}"
 OPPONENT="${1:?Opponent engine path required}"
 GAMES="${2:-10}"
 TC="${3:-40/0.4+0.4}"
@@ -15,7 +17,7 @@ if ! command -v cutechess-cli >/dev/null; then
 fi
 
 cutechess-cli \
-  -engine cmd="$ENGINE" name=Wordfish \
+  -engine cmd="$ENGINE" name="$ENGINE_NAME" \
   -engine cmd="$OPPONENT" name=Opponent \
   -each proto=uci tc=$TC \
   -games $GAMES -concurrency 2 \

--- a/scripts/perft.sh
+++ b/scripts/perft.sh
@@ -4,7 +4,7 @@
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE="$ROOT_DIR/src/wordfish"
+ENGINE="$ROOT_DIR/src/Wordfish v.2.70-dev-250925"
 TEST_DIR="$ROOT_DIR/tests"
 
 if [ ! -x "$ENGINE" ]; then

--- a/scripts/spsa.py
+++ b/scripts/spsa.py
@@ -21,7 +21,7 @@ def run_bench(engine, name, value):
 def main():
     p = argparse.ArgumentParser(description="SPSA tuning for Wordfish")
     p.add_argument("--param", nargs=4, metavar=("NAME", "START", "MIN", "MAX"), action='append', required=True)
-    p.add_argument("--engine", default="src/wordfish")
+    p.add_argument("--engine", default="src/Wordfish v.2.70-dev-250925")
     p.add_argument("--iterations", type=int, default=10)
     args = p.parse_args()
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = wordfish_230925_v.2.60.exe
+        EXE = Wordfish\ v.2.70-dev-250925.exe
 else
-        EXE = wordfish_230925_v.2.60
+        EXE = Wordfish\ v.2.70-dev-250925
 endif
 
 ### Installation dir definitions
@@ -859,11 +859,11 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 # UCI "id name" string shown in GUIs.
 # Defaults:
-#   - ENGINE_NAME: "Wordfish v.2.60 230925"
+#   - ENGINE_NAME: "Wordfish v.2.70-dev-250925"
 #   - ENGINE_BUILD_DATE: optional build identifier
 # You can override on the command line:
-#   make ENGINE_NAME="Wordfish v.2.60 230925" ENGINE_BUILD_DATE=20250907
-ENGINE_NAME        ?= Wordfish v.2.60 230925
+#   make ENGINE_NAME="Wordfish v.2.70-dev-250925" ENGINE_BUILD_DATE=20250907
+ENGINE_NAME        ?= Wordfish v.2.70-dev-250925
 ENGINE_BUILD_DATE  ?=
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 

--- a/src/version.h
+++ b/src/version.h
@@ -4,7 +4,7 @@
 #include <string_view>
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "Wordfish v.2.60 230925"
+    #define ENGINE_NAME "Wordfish v.2.70-dev-250925"
 #endif
 
 #ifndef ENGINE_BUILD_DATE


### PR DESCRIPTION
## Summary
- update the engine version string to `Wordfish v.2.70-dev-250925` and propagate it across documentation and build defaults
- rename the produced executable to match the new id name and adjust helper scripts to reference the new binary name

## Testing
- make -j2 build COMP=clang *(fails: clang++ not found in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d49e3064148327b8762b4f928b2839