### PR TITLE
Fix Windows executable name to avoid spaces

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = Wordfish\ v.2.70-dev-250925.exe
+        EXE = Wordfish_v.2.70-dev-250925.exe
 else
-        EXE = Wordfish\ v.2.70-dev-250925
+        EXE = Wordfish_v.2.70-dev-250925
 endif
 
 ### Installation dir definitions


### PR DESCRIPTION
## Summary
- rename the generated executable to use underscores instead of spaces on all platforms to avoid link failures

## Testing
- make -j2 profile-build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld" *(fails: clang++ unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4a050e6248327982d99a656e4a26e