### PR TITLE
Improve NNUE loading metadata and evaluation efficiency

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -50,15 +50,31 @@ bool Eval::use_smallnet(const Position& pos) { return std::abs(simple_eval(pos))
 
 namespace {
 
-bool should_use_falcon(const Position& pos, bool smallNetPreferred) {
-    const int totalPieces    = pos.count<ALL_PIECES>();
-    const int pawns          = pos.count<PAWN>();
-    const int majorPieces    = pos.count<ROOK>() + pos.count<QUEEN>();
-    const int minorPieces    = pos.count<BISHOP>() + pos.count<KNIGHT>();
-    const int materialImb    = std::abs(Eval::simple_eval(pos));
-    const bool deepEndgame   = totalPieces <= 7 || (pawns <= 4 && majorPieces <= 1);
-    const bool lightMaterial = (pawns <= 5 && totalPieces <= 12) || minorPieces <= 1;
-    const bool highImbalance = materialImb > 800 && (pawns <= 6 || majorPieces <= 1);
+struct MaterialSummary {
+    int totalPieces;
+    int pawns;
+    int majorPieces;
+    int minorPieces;
+    int materialImbalance;
+};
+
+MaterialSummary summarize_material(const Position& pos, int simpleEvalAbs) {
+    MaterialSummary summary{};
+    summary.totalPieces       = pos.count<ALL_PIECES>();
+    summary.pawns             = pos.count<PAWN>();
+    summary.majorPieces       = pos.count<ROOK>() + pos.count<QUEEN>();
+    summary.minorPieces       = pos.count<BISHOP>() + pos.count<KNIGHT>();
+    summary.materialImbalance = simpleEvalAbs;
+    return summary;
+}
+
+bool should_use_falcon(const MaterialSummary& summary, bool smallNetPreferred) {
+    const bool deepEndgame   = summary.totalPieces <= 7
+                            || (summary.pawns <= 4 && summary.majorPieces <= 1);
+    const bool lightMaterial = (summary.pawns <= 5 && summary.totalPieces <= 12)
+                            || summary.minorPieces <= 1;
+    const bool highImbalance = summary.materialImbalance > 800
+                               && (summary.pawns <= 6 || summary.majorPieces <= 1);
 
     if (deepEndgame)
         return true;
@@ -81,9 +97,12 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
 
     assert(!pos.checkers());
 
-    bool  smallNetCandidate = use_smallnet(pos);
+    const int  simpleEvalAbs    = std::abs(simple_eval(pos));
+    const auto materialSummary = summarize_material(pos, simpleEvalAbs);
+
+    bool  smallNetCandidate = materialSummary.materialImbalance > 962;
     bool  falconAvailable   = networks.falcon.is_available();
-    bool  useFalconNet      = falconAvailable && should_use_falcon(pos, smallNetCandidate);
+    bool  useFalconNet      = falconAvailable && should_use_falcon(materialSummary, smallNetCandidate);
     bool  smallNet          = smallNetCandidate;
     Value nnue              = VALUE_ZERO;
     Value psqt              = VALUE_ZERO;
@@ -102,8 +121,8 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
         std::tie(falconPsqt, falconPositional) = falconEval;
         std::tie(bigPsqt, bigPositional)       = bigEval;
 
-        int imbalance     = std::min(1500, std::abs(simple_eval(pos)));
-        int scarcityBonus = std::max(0, 10 - pos.count<ALL_PIECES>());
+        int imbalance     = std::min(1500, materialSummary.materialImbalance);
+        int scarcityBonus = std::max(0, 10 - materialSummary.totalPieces);
         int falconWeight  = 64 + imbalance * 32 / 1500 + scarcityBonus * 4;
         falconWeight      = std::clamp(falconWeight, 48, 120);
 
@@ -147,7 +166,7 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     optimism += optimism * nnueComplexity / 468;
     nnue -= nnue * nnueComplexity / 18000;
 
-    int material = 535 * pos.count<PAWN>() + pos.non_pawn_material();
+    int material = 535 * materialSummary.pawns + pos.non_pawn_material();
     int v        = (nnue * (77777 + material) + optimism * (7777 + material)) / 77777;
 
     // Damp down the evaluation linearly when shuffling

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -20,7 +20,9 @@
 
 #include <cassert>
 #include <cstdlib>
+#include <filesystem>
 #include <fstream>
+#include <system_error>
 #include <ctime>
 #include <iostream>
 #include <memory>
@@ -189,9 +191,10 @@ bool Network<Arch, Transformer>::load(const std::string& rootDirectory, std::str
 
         if (directory != "<internal>")
         {
-            loaded = load_user_net(directory, evalfilePath);
+            std::string resolvedCandidate;
+            loaded = load_user_net(directory, evalfilePath, resolvedCandidate);
             if (loaded)
-                resolvedPath = directory.empty() ? evalfilePath : directory + evalfilePath;
+                resolvedPath = std::move(resolvedCandidate);
         }
 
         if (!loaded && directory == "<internal>" && evalfilePath == evalFile.defaultName)
@@ -344,6 +347,8 @@ template<typename Arch, typename Transformer>
 void Network<Arch, Transformer>::clear_loaded_metadata() {
     set_loaded_from(std::string{});
     lastLoadedTime.store(0, std::memory_order_relaxed);
+    evalFile.resolvedPath.clear();
+    evalFile.lastWriteTime = std::nullopt;
 }
 
 
@@ -482,15 +487,50 @@ Network<Arch, Transformer>::trace_evaluate(const Position&                      
 
 template<typename Arch, typename Transformer>
 bool Network<Arch, Transformer>::load_user_net(const std::string& dir,
-                                               const std::string& evalfilePath) {
-    std::ifstream stream(dir + evalfilePath, std::ios::binary);
-    auto          description = load(stream);
+                                               const std::string& evalfilePath,
+                                               std::string&       resolvedPathOut) {
+    namespace fs = std::filesystem;
+
+    const fs::path basePath = dir.empty() ? fs::path(evalfilePath) : fs::path(dir) / evalfilePath;
+
+    std::error_code ec;
+    fs::path        resolvedPath = fs::absolute(basePath, ec);
+    if (ec)
+        resolvedPath = basePath;
+
+    resolvedPath = resolvedPath.lexically_normal();
+    resolvedPathOut = resolvedPath.string();
+
+    std::optional<fs::file_time_type> candidateTimestamp;
+    auto                               timestamp = fs::last_write_time(resolvedPath, ec);
+    if (!ec)
+        candidateTimestamp = timestamp;
+
+    const bool hasLoadedWeights = available.load(std::memory_order_relaxed)
+                                  && bool(weights_handle()) && evalFile.current == evalfilePath
+                                  && !evalFile.resolvedPath.empty()
+                                  && evalFile.resolvedPath == resolvedPathOut;
+
+    if (hasLoadedWeights && evalFile.lastWriteTime && candidateTimestamp
+        && *evalFile.lastWriteTime == *candidateTimestamp)
+    {
+        resolvedPathOut = evalFile.resolvedPath;
+        return true;
+    }
+
+    std::ifstream stream(resolvedPath, std::ios::binary);
+    if (!stream)
+        return false;
+
+    auto description = load(stream);
 
     if (!description.has_value())
         return false;
 
     evalFile.current        = evalfilePath;
     evalFile.netDescription = description.value();
+    evalFile.resolvedPath   = resolvedPathOut;
+    evalFile.lastWriteTime  = candidateTimestamp;
     return true;
 }
 
@@ -519,6 +559,8 @@ bool Network<Arch, Transformer>::load_internal() {
 
     evalFile.current        = evalFile.defaultName;
     evalFile.netDescription = description.value();
+    evalFile.resolvedPath   = "<internal>";
+    evalFile.lastWriteTime  = std::nullopt;
     return true;
 }
 

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -112,7 +112,7 @@ class Network {
                                  AccumulatorCaches::Cache<FTDimensions>* cache) const;
 
    private:
-    bool load_user_net(const std::string&, const std::string&);
+    bool load_user_net(const std::string&, const std::string&, std::string& resolvedPathOut);
     bool load_internal();
 
     WeightsPtr allocate_weights() const;

--- a/src/nnue/nnue_misc.h
+++ b/src/nnue/nnue_misc.h
@@ -20,6 +20,8 @@
 #define NNUE_MISC_H_INCLUDED
 
 #include <cstddef>
+#include <filesystem>
+#include <optional>
 #include <string>
 
 #include "../types.h"
@@ -39,6 +41,10 @@ struct EvalFile {
     std::string current;
     // Net description extracted from the net file
     std::string netDescription;
+    // Fully resolved path from which the network was loaded, if any
+    std::string resolvedPath;
+    // Timestamp of the backing file when the weights were last loaded
+    std::optional<std::filesystem::file_time_type> lastWriteTime;
 };
 
 


### PR DESCRIPTION
## Summary
- track resolved NNUE file paths and last-write timestamps so unchanged nets reuse cached weights instead of reloading
- canonicalize user-provided NNUE paths, clear metadata when loads fail, and retain provenance for embedded networks
- reuse a material summary when selecting between NNUE networks to avoid redundant counting work during evaluation

## Testing
- make -C src build ARCH=x86-64 COMP=clang *(fails: clang++ is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2efbdb67c8327b3005382f65d2fc6