### PR TITLE
Update engine identifier to Wordfish-2.80-061025

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Wordfish Chess Engine
 
-**Versión v.2.70-dev-250925**
+**Versión 2.80-061025**
 
-Este build se identifica como `Wordfish v.2.70-dev-250925`.
+Este build se identifica como `Wordfish-2.80-061025`.
 
 <div align="center">
   <img src="[https://ijccrl.com/wp-content/uploads/2025/08/wordfish.png]" 

--- a/scripts/fishtest_local.sh
+++ b/scripts/fishtest_local.sh
@@ -4,7 +4,7 @@
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE="$ROOT_DIR/src/Wordfish v.2.70-dev-250925"
+ENGINE="$ROOT_DIR/src/Wordfish-2.80-061025"
 FISHTEST_DIR="${FISHTEST_DIR:-$HOME/fishtest}"
 
 if [ ! -x "$ENGINE" ]; then

--- a/scripts/match.sh
+++ b/scripts/match.sh
@@ -4,7 +4,7 @@
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE_NAME="Wordfish v.2.70-dev-250925"
+ENGINE_NAME="Wordfish-2.80-061025"
 ENGINE_DEFAULT="$ROOT_DIR/src/$ENGINE_NAME"
 ENGINE="${ENGINE:-$ENGINE_DEFAULT}"
 OPPONENT="${1:?Opponent engine path required}"

--- a/scripts/perft.sh
+++ b/scripts/perft.sh
@@ -4,7 +4,7 @@
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE="$ROOT_DIR/src/Wordfish v.2.70-dev-250925"
+ENGINE="$ROOT_DIR/src/Wordfish-2.80-061025"
 TEST_DIR="$ROOT_DIR/tests"
 
 if [ ! -x "$ENGINE" ]; then

--- a/scripts/spsa.py
+++ b/scripts/spsa.py
@@ -21,7 +21,7 @@ def run_bench(engine, name, value):
 def main():
     p = argparse.ArgumentParser(description="SPSA tuning for Wordfish")
     p.add_argument("--param", nargs=4, metavar=("NAME", "START", "MIN", "MAX"), action='append', required=True)
-    p.add_argument("--engine", default="src/Wordfish v.2.70-dev-250925")
+    p.add_argument("--engine", default="src/Wordfish-2.80-061025")
     p.add_argument("--iterations", type=int, default=10)
     args = p.parse_args()
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = Wordfish_v.2.70-dev-250925.exe
+        EXE = Wordfish-2.80-061025.exe
 else
-        EXE = Wordfish_v.2.70-dev-250925
+        EXE = Wordfish-2.80-061025
 endif
 
 ### Installation dir definitions
@@ -859,11 +859,11 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 # UCI "id name" string shown in GUIs.
 # Defaults:
-#   - ENGINE_NAME: "Wordfish v.2.70-dev-250925"
+#   - ENGINE_NAME: "Wordfish-2.80-061025"
 #   - ENGINE_BUILD_DATE: optional build identifier
 # You can override on the command line:
-#   make ENGINE_NAME="Wordfish v.2.70-dev-250925" ENGINE_BUILD_DATE=20250907
-ENGINE_NAME        ?= Wordfish v.2.70-dev-250925
+#   make ENGINE_NAME="Wordfish-2.80-061025" ENGINE_BUILD_DATE=20250907
+ENGINE_NAME        ?= Wordfish-2.80-061025
 ENGINE_BUILD_DATE  ?=
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 

--- a/src/version.h
+++ b/src/version.h
@@ -4,7 +4,7 @@
 #include <string_view>
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "Wordfish v.2.70-dev-250925"
+    #define ENGINE_NAME "Wordfish-2.80-061025"
 #endif
 
 #ifndef ENGINE_BUILD_DATE


### PR DESCRIPTION
## Summary
- update the engine name and binary packaging defaults to Wordfish-2.80-061025 so GUIs display the new identifier
- refresh helper scripts and documentation to reference the new engine id

## Testing
- make -C src build


------
https://chatgpt.com/codex/tasks/task_e_68e2f44b5cb48327aa12fa1b7e683c65