### PR TITLE
Initialize NNUE eval file metadata in engine constructor

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -63,9 +63,12 @@ Engine::Engine(std::optional<std::string> path) :
     networks(
       numaContext,
       NN::Networks(
-        NN::NetworkBig({EvalFileDefaultNameBig, "None", ""}, NN::EmbeddedNNUEType::BIG),
-        NN::NetworkSmall({EvalFileDefaultNameSmall, "None", ""}, NN::EmbeddedNNUEType::SMALL),
-        NN::NetworkFalcon({FalconFileDefaultName, "None", ""}, NN::EmbeddedNNUEType::FALCON))) {
+        NN::NetworkBig({EvalFileDefaultNameBig, "None", "", "", std::nullopt},
+                       NN::EmbeddedNNUEType::BIG),
+        NN::NetworkSmall({EvalFileDefaultNameSmall, "None", "", "", std::nullopt},
+                         NN::EmbeddedNNUEType::SMALL),
+        NN::NetworkFalcon({FalconFileDefaultName, "None", "", "", std::nullopt},
+                          NN::EmbeddedNNUEType::FALCON))) {
     pos.set(StartFEN, false, &states->back());
 
 


### PR DESCRIPTION
## Summary
- fully populate the EvalFile metadata for each embedded network to avoid missing field warnings during compilation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2f8dc240c832794e4252954923fe0