### PR TITLE
Improve king safety and search verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+### Added
+- Documented new training emphasis on king safety, rook coordination, and endgame supervision. 
+
+### Changed
+- Tightened king-safety heuristics for open files, rook lifts, and dark-square weaknesses.
+- Reduced aggressive pruning in sharp positions and added verification search for large evaluation swings.
+- Rewarded connected rooks while penalizing premature flank pawn storms in the handcrafted evaluation.
+
 ## [2.42-190825]
 ### Changed
 - Updated engine id name to "Wordfish 2.42-190825".

--- a/docs/training_plan.md
+++ b/docs/training_plan.md
@@ -1,0 +1,18 @@
+# Training and Evaluation Adjustments
+
+## King Safety Focus
+- Increase self-play sampling of positions with aggressive pawn storms around the king.
+- Track open-file exposure, rook lifts, and dark-square weaknesses in evaluation logs.
+- Add targeted puzzles highlighting premature pawn pushes near the king to the regression suite.
+
+## Development Prioritization
+- Prioritize game fragments where both rooks remain disconnected beyond move 12.
+- Emphasize feature extraction that rewards timely rook coordination before flank pawn advances.
+
+## Selective Search Verification
+- Schedule dedicated testing of verification search thresholds on tactical suites (mate nets, perpetuals).
+- Monitor late-move reduction statistics to ensure sharp positions retain sufficient depth.
+
+## Endgame Reinforcement
+- Expand simplified-position self-play batches with restricted material (rook endings, bishop vs. pawns).
+- Integrate Syzygy tablebase evaluations during training labels to penalize inaccurate pawn pushes.

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -30,6 +30,7 @@
 
 #include "nnue/network.h"
 #include "nnue/nnue_misc.h"
+#include "bitboard.h"
 #include "position.h"
 #include "types.h"
 #include "uci.h"
@@ -86,6 +87,152 @@ bool should_use_falcon(const MaterialSummary& summary, bool smallNetPreferred) {
 }
 
 }  // namespace
+
+constexpr Bitboard DarkSquaresMask = 0xAA55AA55AA55AA55ULL;
+
+bool rooks_connected_home(const Position& pos, Color c) {
+    if (pos.count<ROOK>(c) < 2)
+        return false;
+
+    Bitboard rooks    = pos.pieces(c, ROOK);
+    Bitboard homeRank = rank_bb(relative_rank(c, RANK_1));
+    Bitboard homeRooks = rooks & homeRank;
+
+    if (popcount(homeRooks) < 2)
+        return false;
+
+    Square left  = lsb(homeRooks);
+    Square right = msb(homeRooks);
+
+    Bitboard between = between_bb(left, right) ^ square_bb(right);
+    return !(between & pos.pieces());
+}
+
+int rook_connection_bonus(const Position& pos, Color c) {
+    if (pos.count<ROOK>(c) < 2)
+        return 0;
+
+    int      bonus       = 0;
+    Bitboard rooks       = pos.pieces(c, ROOK);
+    Bitboard connected   = rooks_connected_home(pos, c) ? rooks : Bitboard(0);
+    Bitboard liftedRanks = c == WHITE ? (rank_bb(RANK_3) | rank_bb(RANK_4))
+                                      : (rank_bb(RANK_6) | rank_bb(RANK_5));
+
+    if (connected)
+        bonus += 18;
+
+    Bitboard lifted = rooks & liftedRanks;
+    while (lifted)
+    {
+        Square rsq = pop_lsb(lifted);
+        if (!(pos.pieces(c, PAWN) & file_bb(file_of(rsq))))
+            bonus += 5;
+    }
+
+    return bonus;
+}
+
+int king_open_file_penalty(const Position& pos, Color c) {
+    const Square kingSq  = pos.square<KING>(c);
+    const File   kingFile = file_of(kingSq);
+
+    int penalty = 0;
+
+    for (int df = -1; df <= 1; ++df)
+    {
+        File f = File(int(kingFile) + df);
+        if (f < FILE_A || f > FILE_H)
+            continue;
+
+        Bitboard friendly = pos.pieces(c, PAWN) & file_bb(f);
+        Bitboard enemy    = pos.pieces(~c, PAWN) & file_bb(f);
+
+        if (!friendly)
+        {
+            penalty += enemy ? 16 : 20;
+            if (pos.pieces(~c, ROOK, QUEEN) & file_bb(f))
+                penalty += 8;
+        }
+        else
+        {
+            Square guardSq = c == WHITE ? msb(friendly) : lsb(friendly);
+            Rank   relRank = relative_rank(c, guardSq);
+
+            if (relRank >= RANK_4)
+                penalty += 10 + 2 * (int(relRank) - int(RANK_3));
+        }
+    }
+
+    return penalty;
+}
+
+int king_dark_square_penalty(const Position& pos, Color c) {
+    const Square kingSq    = pos.square<KING>(c);
+    const bool   kingOnDark = ((rank_of(kingSq) + file_of(kingSq)) % 2) == 0;
+
+    Bitboard bishops = pos.pieces(c, BISHOP);
+    bool     bishopCover = kingOnDark ? (bishops & DarkSquaresMask)
+                                      : (bishops & ~DarkSquaresMask);
+
+    if (bishopCover)
+        return 0;
+
+    int        penalty = 0;
+    const int  forward = c == WHITE ? 8 : -8;
+
+    for (int df = -1; df <= 1; ++df)
+    {
+        Square shieldSq = Square(int(kingSq) + forward + df);
+        if (!is_ok(shieldSq))
+            continue;
+
+        const bool sameColor = ((rank_of(shieldSq) + file_of(shieldSq)) % 2)
+                               == (kingOnDark ? 0 : 1);
+        if (!sameColor)
+            continue;
+
+        Piece shield = pos.piece_on(shieldSq);
+        if (shield == NO_PIECE)
+            penalty += 7;
+        else if (color_of(shield) == ~c)
+            penalty += 5;
+        else if (type_of(shield) == PAWN && relative_rank(c, shieldSq) >= RANK_4)
+            penalty += 6;
+    }
+
+    return penalty;
+}
+
+int flank_storm_penalty(const Position& pos, Color c) {
+    static constexpr File flankFiles[] = {FILE_A, FILE_B, FILE_G, FILE_H};
+
+    int      penalty      = 0;
+    Bitboard pawns        = pos.pieces(c, PAWN);
+    const bool rooksReady = rooks_connected_home(pos, c);
+
+    for (File f : flankFiles)
+    {
+        Bitboard filePawns = pawns & file_bb(f);
+        if (!filePawns)
+            continue;
+
+        Square front = c == WHITE ? msb(filePawns) : lsb(filePawns);
+        Rank   rel   = relative_rank(c, front);
+
+        if (rel >= RANK_4)
+        {
+            int base = (f == FILE_A || f == FILE_H) ? 14 : 10;
+            base += 2 * std::max(0, int(rel) - int(RANK_4));
+
+            if (!rooksReady)
+                base += 8;
+
+            penalty += base;
+        }
+    }
+
+    return penalty;
+}
 
 // Evaluate is the evaluator for the outer world. It returns a static evaluation
 // of the position from the point of view of the side to move.
@@ -168,6 +315,19 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
 
     int material = 535 * materialSummary.pawns + pos.non_pawn_material();
     int v        = (nnue * (77777 + material) + optimism * (7777 + material)) / 77777;
+
+    const Color us   = pos.side_to_move();
+    const Color them = ~us;
+
+    int ourPenalty = king_open_file_penalty(pos, us) + king_dark_square_penalty(pos, us)
+                   + flank_storm_penalty(pos, us);
+    int theirPenalty = king_open_file_penalty(pos, them) + king_dark_square_penalty(pos, them)
+                     + flank_storm_penalty(pos, them);
+
+    int safetySwing = theirPenalty - ourPenalty;
+    int rookDiff    = rook_connection_bonus(pos, us) - rook_connection_bonus(pos, them);
+
+    v += safetySwing + rookDiff;
 
     // Damp down the evaluation linearly when shuffling
     v -= v * pos.rule50_count() / 212;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -70,8 +70,9 @@ constexpr int SEARCHEDLIST_CAPACITY = 32;
 using SearchedList                  = ValueList<Move, SEARCHEDLIST_CAPACITY>;
 
 int king_file_exposure_scale(const Position& pos, Color us) {
-    const Square kingSq  = pos.square<KING>(us);
-    const int    forward = us == WHITE ? 8 : -8;
+    const Square     kingSq  = pos.square<KING>(us);
+    const int        forward = us == WHITE ? 8 : -8;
+    constexpr Bitboard DarkSquaresMask = 0xAA55AA55AA55AA55ULL;
 
     bool friendlyShield = false;
     bool enemyPressure  = false;
@@ -107,10 +108,82 @@ int king_file_exposure_scale(const Position& pos, Color us) {
     enemyPressure = enemyPressure || check_pressure(Square(int(kingSq) + forward))
                     || check_pressure(Square(int(kingSq) + 2 * forward));
 
-    if (enemyPressure)
-        return friendlyShield ? 112 : 96;
+    int scale = enemyPressure ? (friendlyShield ? 112 : 96) : (friendlyShield ? 140 : 128);
 
-    return friendlyShield ? 140 : 128;
+    const auto file_safety_penalty = [&](File f) {
+        if (f < FILE_A || f > FILE_H)
+            return 0;
+
+        Bitboard friendlyPawns = pos.pieces(us, PAWN) & file_bb(f);
+        Bitboard enemyPawns    = pos.pieces(~us, PAWN) & file_bb(f);
+
+        int penalty = 0;
+
+        if (!friendlyPawns)
+        {
+            penalty += enemyPawns ? 6 : 9;
+
+            if (pos.pieces(~us, ROOK, QUEEN) & file_bb(f))
+                penalty += 5;
+        }
+        else
+        {
+            Square guardSq = us == WHITE ? msb(friendlyPawns) : lsb(friendlyPawns);
+            Rank   guardRank = relative_rank(us, guardSq);
+
+            if (guardRank >= RANK_4)
+                penalty += 4 + (guardRank - RANK_3) * 2;
+        }
+
+        return penalty;
+    };
+
+    File kingFile = file_of(kingSq);
+    scale -= file_safety_penalty(kingFile);
+    scale -= file_safety_penalty(File(kingFile - 1));
+    scale -= file_safety_penalty(File(kingFile + 1));
+
+    Bitboard liftedMask = us == WHITE ? (rank_bb(RANK_3) | rank_bb(RANK_4))
+                                      : (rank_bb(RANK_6) | rank_bb(RANK_5));
+    Bitboard liftedRooks = pos.pieces(us, ROOK) & liftedMask;
+    while (liftedRooks)
+    {
+        Square rookSq = pop_lsb(liftedRooks);
+        if (std::abs(file_of(rookSq) - file_of(kingSq)) <= 1)
+            scale -= enemyPressure ? 6 : 8;
+    }
+
+    const bool kingOnDark = ((rank_of(kingSq) + file_of(kingSq)) % 2) == 0;
+    Bitboard   bishops    = pos.pieces(us, BISHOP);
+    const bool bishopCover = kingOnDark ? (bishops & DarkSquaresMask)
+                                        : (bishops & ~DarkSquaresMask);
+
+    if (!bishopCover)
+    {
+        int    weakDark = 0;
+        Square guardSq;
+
+        for (int df = -1; df <= 1; ++df)
+        {
+            guardSq = Square(int(kingSq) + forward + df);
+            if (!is_ok(guardSq))
+                continue;
+
+            const bool sameColor = ((rank_of(guardSq) + file_of(guardSq)) % 2)
+                                   == (kingOnDark ? 0 : 1);
+            if (!sameColor)
+                continue;
+
+            Piece pc = pos.piece_on(guardSq);
+            if (pc == NO_PIECE || color_of(pc) == ~us)
+                ++weakDark;
+        }
+
+        scale -= weakDark * 4;
+    }
+
+    scale = std::clamp(scale, 72, 160);
+    return scale;
 }
 
 // (*Scalers):
@@ -1092,7 +1165,8 @@ Value Search::Worker::search(
         assert((ss - 1)->currentMove != Move::null());
 
         // Null move dynamic reduction based on depth
-        Depth R = 7 + depth / 3;
+        int exposureScale = king_file_exposure_scale(pos, us);
+        Depth R = 6 + depth / 3 - Depth(std::clamp((140 - exposureScale) / 16, 0, 2));
 
         ss->currentMove                   = Move::null();
         ss->continuationHistory           = &continuationHistory[0][0][NO_PIECE][0];
@@ -1237,6 +1311,8 @@ moves_loop:  // When in check, search starts here
         capture    = pos.capture_stage(move);
         movedPiece = pos.moved_piece(move);
         givesCheck = pos.gives_check(move);
+
+        (ss + 1)->skipVerification = false;
 
         const bool negativeSee = capture && !pos.see_ge(move, VALUE_ZERO);
 
@@ -1411,7 +1487,8 @@ moves_loop:  // When in check, search starts here
 
         // These reduction adjustments have no proven non-linear scaling
 
-        r += 650;  // Base reduction offset to compensate for other tweaks
+        r += 520;  // Base reduction offset to compensate for other tweaks
+        r -= std::clamp((160 - king_file_exposure_scale(pos, us)) * 6, 0, 640);
         if (negativeSee)
             r = std::max<int>(0, r - 1024);
         r -= moveCount * 69;
@@ -1495,6 +1572,19 @@ moves_loop:  // When in check, search starts here
                 newDepth = std::max(newDepth, 1);
 
             value = -search<PV>(pos, ss + 1, -beta, -alpha, newDepth, false);
+        }
+
+        if (!rootNode && depth >= 3 && !capture && !givesCheck && !(ss + 1)->skipVerification)
+        {
+            Value swing = value - ss->staticEval;
+            if (std::abs(swing) > 320 && ((value > alpha && swing > 0) || (value < alpha && swing < 0)))
+            {
+                (ss + 1)->skipVerification = true;
+                Depth verifyDepth = std::max(1, newDepth - std::max(0, ss->reduction - 1));
+                Value verifyValue = -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha, verifyDepth, true);
+                value             = verifyValue;
+                (ss + 1)->skipVerification = false;
+            }
         }
 
         // Step 19. Undo move

--- a/src/search.h
+++ b/src/search.h
@@ -76,6 +76,7 @@ struct Stack {
     int                         cutoffCnt;
     int                         reduction;
     int                         quietMoveStreak;
+    bool                        skipVerification;
 };
 
 


### PR DESCRIPTION
## Summary
- tighten king-safety modelling by tracking open files, rook lifts, dark-square coverage, and rewarding connected rooks
- moderate selective pruning with exposure-aware null-move depth, lighter LMR base reductions, and verification searches on large evaluation swings
- document the revised training plan that emphasizes king safety, development discipline, search verification, and tablebase-guided endgames

## Testing
- ninja *(fails: build.ninja is not generated in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e33eee80f083279d6a801aee51b05f