### PR TITLE
Wrap evaluation helpers in an anonymous namespace

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -90,6 +90,8 @@ bool should_use_falcon(const MaterialSummary& summary, bool smallNetPreferred) {
 
 constexpr Bitboard DarkSquaresMask = 0xAA55AA55AA55AA55ULL;
 
+namespace {
+
 bool rooks_connected_home(const Position& pos, Color c) {
     if (pos.count<ROOK>(c) < 2)
         return false;
@@ -233,6 +235,8 @@ int flank_storm_penalty(const Position& pos, Color c) {
 
     return penalty;
 }
+
+}  // namespace
 
 // Evaluate is the evaluator for the outer world. It returns a static evaluation
 // of the position from the point of view of the side to move.


### PR DESCRIPTION
## Summary
- wrap the evaluation helper functions in evaluate.cpp in an anonymous namespace to limit their linkage and silence missing prototype warnings

## Testing
- make -j profile-build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld" *(fails: clang++ not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e341f06cdc8327be0cd1423ff78dac