### PR TITLE
Apply correction history patch and rename engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Wordfish Chess Engine
 
-**Versión 2.80-061025**
+**Versión 2.81-071025**
 
-Este build se identifica como `Wordfish-2.80-061025`.
+Este build se identifica como `wordfish-2.81-071025`.
 
 <div align="center">
   <img src="[https://ijccrl.com/wp-content/uploads/2025/08/wordfish.png]" 

--- a/scripts/fishtest_local.sh
+++ b/scripts/fishtest_local.sh
@@ -4,7 +4,7 @@
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE="$ROOT_DIR/src/Wordfish-2.80-061025"
+ENGINE="$ROOT_DIR/src/wordfish-2.81-071025"
 FISHTEST_DIR="${FISHTEST_DIR:-$HOME/fishtest}"
 
 if [ ! -x "$ENGINE" ]; then

--- a/scripts/match.sh
+++ b/scripts/match.sh
@@ -4,7 +4,7 @@
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE_NAME="Wordfish-2.80-061025"
+ENGINE_NAME="wordfish-2.81-071025"
 ENGINE_DEFAULT="$ROOT_DIR/src/$ENGINE_NAME"
 ENGINE="${ENGINE:-$ENGINE_DEFAULT}"
 OPPONENT="${1:?Opponent engine path required}"

--- a/scripts/perft.sh
+++ b/scripts/perft.sh
@@ -4,7 +4,7 @@
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE="$ROOT_DIR/src/Wordfish-2.80-061025"
+ENGINE="$ROOT_DIR/src/wordfish-2.81-071025"
 TEST_DIR="$ROOT_DIR/tests"
 
 if [ ! -x "$ENGINE" ]; then

--- a/scripts/spsa.py
+++ b/scripts/spsa.py
@@ -21,7 +21,7 @@ def run_bench(engine, name, value):
 def main():
     p = argparse.ArgumentParser(description="SPSA tuning for Wordfish")
     p.add_argument("--param", nargs=4, metavar=("NAME", "START", "MIN", "MAX"), action='append', required=True)
-    p.add_argument("--engine", default="src/Wordfish-2.80-061025")
+    p.add_argument("--engine", default="src/wordfish-2.81-071025")
     p.add_argument("--iterations", type=int, default=10)
     args = p.parse_args()
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = Wordfish-2.80-061025.exe
+        EXE = wordfish-2.81-071025.exe
 else
-        EXE = Wordfish-2.80-061025
+        EXE = wordfish-2.81-071025
 endif
 
 ### Installation dir definitions
@@ -859,11 +859,11 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 # UCI "id name" string shown in GUIs.
 # Defaults:
-#   - ENGINE_NAME: "Wordfish-2.80-061025"
+#   - ENGINE_NAME: "wordfish-2.81-071025"
 #   - ENGINE_BUILD_DATE: optional build identifier
 # You can override on the command line:
-#   make ENGINE_NAME="Wordfish-2.80-061025" ENGINE_BUILD_DATE=20250907
-ENGINE_NAME        ?= Wordfish-2.80-061025
+#   make ENGINE_NAME="wordfish-2.81-071025" ENGINE_BUILD_DATE=20250907
+ENGINE_NAME        ?= wordfish-2.81-071025
 ENGINE_BUILD_DATE  ?=
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -196,15 +196,21 @@ int correction_value(const Worker& w,
                      const Position& pos,
                      const Stack* const ss,
                      Depth            depth) {
-    const Color us    = pos.side_to_move();
-    const auto  m     = (ss - 1)->currentMove;
-    const auto  pcv   = w.pawnCorrectionHistory[pawn_correction_history_index(pos)][us];
-    const auto  micv  = w.minorPieceCorrectionHistory[minor_piece_index(pos)][us];
-    const auto  wnpcv = w.nonPawnCorrectionHistory[non_pawn_index<WHITE>(pos)][WHITE][us];
-    const auto  bnpcv = w.nonPawnCorrectionHistory[non_pawn_index<BLACK>(pos)][BLACK][us];
-    const auto  cntcv =
-      m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-                 : 0;
+    const Color  us   = pos.side_to_move();
+    const auto   m    = (ss - 1)->currentMove;
+    const auto   pcv  = w.pawnCorrectionHistory[pawn_correction_history_index(pos)][us];
+    const auto   micv = w.minorPieceCorrectionHistory[minor_piece_index(pos)][us];
+    const auto   wnpcv = w.nonPawnCorrectionHistory[non_pawn_index<WHITE>(pos)][WHITE][us];
+    const auto   bnpcv = w.nonPawnCorrectionHistory[non_pawn_index<BLACK>(pos)][BLACK][us];
+    int cntcv = 8;
+
+    if (m.is_ok())
+    {
+        const Square to = m.to_sq();
+        const Piece  pc = pos.piece_on(to);
+        cntcv = (*(ss - 2)->continuationCorrectionHistory)[pc][to]
+                + (*(ss - 4)->continuationCorrectionHistory)[pc][to];
+    }
 
     const int depthLeft     = std::max(int(depth), 0);
     const int depthScale    = 128 - std::min(48, depthLeft * 4);
@@ -254,8 +260,12 @@ void update_correction_history(const Position& pos,
       << scaledBonus * nonPawnWeight / 128;
 
     if (m.is_ok())
-        (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
-          << scaledBonus * 153 / 128;
+    {
+        const Square to = m.to_sq();
+        const Piece  pc = pos.piece_on(to);
+        (*(ss - 2)->continuationCorrectionHistory)[pc][to] << scaledBonus * 153 / 128;
+        (*(ss - 4)->continuationCorrectionHistory)[pc][to] << scaledBonus * 64 / 128;
+    }
 }
 
 // Add a small random component to draw evaluations to avoid 3-fold blindness

--- a/src/version.h
+++ b/src/version.h
@@ -4,7 +4,7 @@
 #include <string_view>
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "Wordfish-2.80-061025"
+    #define ENGINE_NAME "wordfish-2.81-071025"
 #endif
 
 #ifndef ENGINE_BUILD_DATE


### PR DESCRIPTION
## Summary
- incorporate the latest Stockfish correction history adjustments so continuation history uses deeper context
- update all build scripts and documentation to rename the binary and UCI id to `wordfish-2.81-071025`

## Testing
- `make -j2 build ARCH=x86-64`


------
https://chatgpt.com/codex/tasks/task_e_68e5539d814c8327912e43e931a07495