### PR TITLE
Fix default experience format

### DIFF
--- a/src/experience.h
+++ b/src/experience.h
@@ -54,7 +54,7 @@ class Experience {
     bool                                                  is_ready() const;
     std::unordered_map<Key, std::vector<ExperienceEntry>> table;
     bool                                                  binaryFormat     = false;
-    bool                                                  brainLearnFormat = true;
+    bool                                                  brainLearnFormat = false;
     std::future<void>                                     loader;
     mutable std::mutex                                    tableMutex;
 };


### PR DESCRIPTION
## Summary
- set the default experience table format to the standard SugaR V2 layout so freshly created files are written correctly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5557697548327b20c8e9bdf0089e2