### PR TITLE
Instrument warm-up profiling and add bullet preset

### DIFF
--- a/scripts/presets/bullet-10_0.1.sh
+++ b/scripts/presets/bullet-10_0.1.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Configure a Cute Chess match preset for 10+0.1 bullet games.
+# Applies a low-latency configuration for Wordfish by disabling Falcon/Experience
+# features, reducing move overhead, and enforcing a 10 ms minimum thinking time.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+CUTECHESS_CLI_BIN="${CUTECHESS_CLI:-cutechess-cli}"
+ENGINE_NAME="${ENGINE_NAME:-}"
+ENGINE_BIN="${ENGINE:-}"
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 /path/to/opponent [games]" >&2
+  exit 1
+fi
+
+if ! command -v "$CUTECHESS_CLI_BIN" >/dev/null; then
+  echo "cutechess-cli is required but was not found in PATH" >&2
+  exit 1
+fi
+
+if [[ -z "$ENGINE_BIN" ]]; then
+  # Prefer a bundled Wordfish binary if one exists under src/.
+  ENGINE_BIN="$(find "$ROOT_DIR/src" -maxdepth 1 -type f -perm -111 -name 'wordfish*' | sort | head -n1 || true)"
+fi
+
+if [[ -z "$ENGINE_BIN" ]]; then
+  echo "Unable to locate the Wordfish binary. Set the ENGINE environment variable." >&2
+  exit 1
+fi
+
+if [[ -z "$ENGINE_NAME" ]]; then
+  ENGINE_NAME="$(basename "$ENGINE_BIN")"
+fi
+
+OPPONENT_BIN="$1"
+GAMES="${2:-20}"
+OPPONENT_NAME="${OPPONENT_NAME:-Opponent}"
+CONCURRENCY="${CONCURRENCY:-4}"
+OUTPUT_PGN="${OUTPUT_PGN:-$ROOT_DIR/bullet-10_0.1.pgn}"
+
+"$CUTECHESS_CLI_BIN" \
+  -engine cmd="$ENGINE_BIN" name="$ENGINE_NAME" \
+    option.FalconFile=None \
+    option."Experience Enabled"=false \
+    option."Experience Book"=false \
+    option."Experience Concurrent"=false \
+    option."Minimum Thinking Time"=10 \
+    option."Move Overhead"=5 \
+  -engine cmd="$OPPONENT_BIN" name="$OPPONENT_NAME" \
+  -each proto=uci tc=10+0.1 \
+  -games "$GAMES" \
+  -concurrency "$CONCURRENCY" \
+  -pgn "$OUTPUT_PGN"

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -328,6 +328,8 @@ void Engine::set_position(const std::string& fen, const std::vector<std::string>
         states->emplace_back();
         pos.do_move(m, states->back());
     }
+
+    Eval::notify_new_fen(pos.game_ply());
 }
 
 // modifiers

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -19,11 +19,16 @@
 #include "evaluate.h"
 
 #include <algorithm>
+#include <array>
+#include <atomic>
+#include <cstdint>
 #include <cassert>
+#include <chrono>
 #include <cmath>
 #include <cstdlib>
 #include <iomanip>
 #include <iostream>
+#include <limits>
 #include <memory>
 #include <sstream>
 #include <tuple>
@@ -31,6 +36,7 @@
 #include "nnue/network.h"
 #include "nnue/nnue_misc.h"
 #include "bitboard.h"
+#include "misc.h"
 #include "position.h"
 #include "types.h"
 #include "uci.h"
@@ -50,6 +56,32 @@ int Eval::simple_eval(const Position& pos) {
 bool Eval::use_smallnet(const Position& pos) { return std::abs(simple_eval(pos)) > 962; }
 
 namespace {
+
+enum class WarmupSlot : std::size_t {
+    Big,
+    Small,
+    Falcon,
+    Count
+};
+
+struct WarmupProfile {
+    std::atomic<int>         basePly{std::numeric_limits<int>::min()};
+    std::atomic<std::uint32_t> seenMask{0};
+    std::atomic<bool>          active{false};
+} warmupProfile;
+
+void log_warmup_sample(int relPly, const std::array<double, 3>& durations) {
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(3);
+    oss << "NNUE warmup ply " << (relPly + 1)
+        << " big=" << durations[static_cast<std::size_t>(WarmupSlot::Big)] << "ms"
+        << " small=" << durations[static_cast<std::size_t>(WarmupSlot::Small)] << "ms"
+        << " falcon=" << durations[static_cast<std::size_t>(WarmupSlot::Falcon)] << "ms";
+
+    sync_cout_start();
+    std::cout << "info string " << oss.str() << '\n';
+    sync_cout_end();
+}
 
 struct MaterialSummary {
     int totalPieces;
@@ -244,9 +276,44 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
                      const Position&                pos,
                      Eval::NNUE::AccumulatorStack&  accumulators,
                      Eval::NNUE::AccumulatorCaches& caches,
-                     int                            optimism) {
+                     int                            optimism,
+                     Depth                          searchDepth) {
 
     assert(!pos.checkers());
+
+    using Clock = std::chrono::steady_clock;
+
+    std::array<double, static_cast<std::size_t>(WarmupSlot::Count)> warmupDurations{};
+    std::uint32_t warmupMask  = 0;
+    bool          warmupLog   = false;
+    int           warmupRelPly = -1;
+
+    if (warmupProfile.active.load(std::memory_order_relaxed))
+    {
+        int base = warmupProfile.basePly.load(std::memory_order_relaxed);
+        if (base != std::numeric_limits<int>::min())
+        {
+            int rel = pos.game_ply() - base;
+            if (rel >= 0 && rel < 5)
+            {
+                warmupMask  = 1u << rel;
+                warmupRelPly = rel;
+                if (!(warmupProfile.seenMask.load(std::memory_order_relaxed) & warmupMask))
+                    warmupLog = true;
+            }
+        }
+    }
+
+    auto time_call = [&](auto&& fn, WarmupSlot slot) {
+        if (!warmupLog)
+            return fn();
+
+        auto start   = Clock::now();
+        auto result  = fn();
+        auto elapsed = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
+        warmupDurations[static_cast<std::size_t>(slot)] += elapsed;
+        return result;
+    };
 
     const int  simpleEvalAbs    = std::abs(simple_eval(pos));
     const auto materialSummary = summarize_material(pos, simpleEvalAbs);
@@ -262,10 +329,12 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     if (useFalconNet)
     {
         auto& falconCache = caches.cache_for_falcon(networks.falcon);
-        auto  falconEval  = networks.falcon.evaluate(pos, accumulators, &falconCache);
+        auto  falconEval  = time_call(
+          [&] { return networks.falcon.evaluate(pos, accumulators, &falconCache); }, WarmupSlot::Falcon);
 
         auto& bigCache = caches.cache_for_big(networks.big);
-        auto  bigEval  = networks.big.evaluate(pos, accumulators, &bigCache);
+        auto  bigEval  = time_call(
+          [&] { return networks.big.evaluate(pos, accumulators, &bigCache); }, WarmupSlot::Big);
 
         Value falconPsqt, falconPositional;
         Value bigPsqt, bigPositional;
@@ -291,12 +360,16 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
         if (smallNetCandidate)
         {
             auto& smallCache = caches.cache_for_small(networks.small);
-            std::tie(psqt, positional) = networks.small.evaluate(pos, accumulators, &smallCache);
+            auto smallEval = time_call(
+              [&] { return networks.small.evaluate(pos, accumulators, &smallCache); }, WarmupSlot::Small);
+            std::tie(psqt, positional) = smallEval;
         }
         else
         {
             auto& bigCache = caches.cache_for_big(networks.big);
-            std::tie(psqt, positional) = networks.big.evaluate(pos, accumulators, &bigCache);
+            auto bigEval = time_call(
+              [&] { return networks.big.evaluate(pos, accumulators, &bigCache); }, WarmupSlot::Big);
+            std::tie(psqt, positional) = bigEval;
             smallNet                   = false;
         }
 
@@ -307,7 +380,9 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     if (!useFalconNet && smallNet && (std::abs(nnue) < 236))
     {
         auto& bigCache = caches.cache_for_big(networks.big);
-        std::tie(psqt, positional) = networks.big.evaluate(pos, accumulators, &bigCache);
+        auto  bigEval  = time_call(
+          [&] { return networks.big.evaluate(pos, accumulators, &bigCache); }, WarmupSlot::Big);
+        std::tie(psqt, positional) = bigEval;
         nnue                       = (125 * psqt + 131 * positional) / 128;
         smallNet                   = false;
     }
@@ -323,8 +398,16 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     const Color us   = pos.side_to_move();
     const Color them = ~us;
 
+    int ourStormPenalty = flank_storm_penalty(pos, us);
+    if (ourStormPenalty && searchDepth < 14)
+    {
+        int depthShortfall = std::max(0, 14 - std::max<int>(0, searchDepth));
+        int scale          = 128 + depthShortfall * 12;
+        ourStormPenalty    = ourStormPenalty * scale / 128;
+    }
+
     int ourPenalty = king_open_file_penalty(pos, us) + king_dark_square_penalty(pos, us)
-                   + flank_storm_penalty(pos, us);
+                   + ourStormPenalty;
     int theirPenalty = king_open_file_penalty(pos, them) + king_dark_square_penalty(pos, them)
                      + flank_storm_penalty(pos, them);
 
@@ -339,7 +422,24 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     // Guarantee evaluation does not hit the tablebase range
     v = std::clamp(v, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);
 
+    if (warmupLog && warmupMask)
+    {
+        std::uint32_t previous = warmupProfile.seenMask.fetch_or(warmupMask, std::memory_order_acq_rel);
+        if ((previous & warmupMask) == 0 && warmupRelPly >= 0)
+        {
+            log_warmup_sample(warmupRelPly, warmupDurations);
+            if ((previous | warmupMask) == ((1u << 5) - 1))
+                warmupProfile.active.store(false, std::memory_order_relaxed);
+        }
+    }
+
     return v;
+}
+
+void Eval::notify_new_fen(int gamePly) {
+    warmupProfile.seenMask.store(0, std::memory_order_relaxed);
+    warmupProfile.basePly.store(gamePly, std::memory_order_relaxed);
+    warmupProfile.active.store(true, std::memory_order_relaxed);
 }
 
 // Like evaluate(), but instead of returning a value, it returns
@@ -366,7 +466,7 @@ std::string Eval::trace(Position& pos, const Eval::NNUE::Networks& networks) {
     v                       = pos.side_to_move() == WHITE ? v : -v;
     ss << "NNUE evaluation        " << 0.01 * UCIEngine::to_cp(v, pos) << " (white side)\n";
 
-    v = evaluate(networks, pos, accumulators, *caches, VALUE_ZERO);
+    v = evaluate(networks, pos, accumulators, *caches, VALUE_ZERO, Depth(99));
     v = pos.side_to_move() == WHITE ? v : -v;
     ss << "Final evaluation       " << 0.01 * UCIEngine::to_cp(v, pos) << " (white side)";
     ss << " [with scaled NNUE, ...]";

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -52,10 +52,15 @@ Value evaluate(const NNUE::Networks&          networks,
                const Position&                pos,
                Eval::NNUE::AccumulatorStack&  accumulators,
                Eval::NNUE::AccumulatorCaches& caches,
-               int                            optimism);
+               int                            optimism,
+               Depth                          searchDepth);
 
 // Toggle for optional style-based evaluation adjustments.
 void set_adaptive_style(bool enabled);
+
+// Notify the evaluator that a new root FEN has been loaded so warm-up profiling
+// can cover the first few plies of the fresh position.
+void notify_new_fen(int gamePly);
 }  // namespace Eval
 
 }  // namespace Stockfish

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -940,7 +940,8 @@ Value Search::Worker::search(
         // Step 2. Check for aborted search and immediate draw
         if (threads.stop.load(std::memory_order_relaxed) || pos.is_draw(ss->ply)
             || ss->ply >= MAX_PLY)
-            return (ss->ply >= MAX_PLY && !ss->inCheck) ? evaluate(pos) : value_draw(nodes);
+            return (ss->ply >= MAX_PLY && !ss->inCheck) ? evaluate(pos, depth)
+                                                        : value_draw(nodes);
 
         // Step 3. Mate distance pruning. Even if we mate at the next move our score
         // would be at best mate_in(ss->ply + 1), but if alpha is already bigger because
@@ -1100,7 +1101,7 @@ Value Search::Worker::search(
         // Never assume anything about values stored in TT
         unadjustedStaticEval = ttData.eval;
         if (!is_valid(unadjustedStaticEval))
-            unadjustedStaticEval = evaluate(pos);
+            unadjustedStaticEval = evaluate(pos, depth);
 
         ss->staticEval = eval = to_corrected_static_eval(unadjustedStaticEval, correctionValue);
 
@@ -1111,7 +1112,7 @@ Value Search::Worker::search(
     }
     else
     {
-        unadjustedStaticEval = evaluate(pos);
+        unadjustedStaticEval = evaluate(pos, depth);
         ss->staticEval = eval = to_corrected_static_eval(unadjustedStaticEval, correctionValue);
 
         // Static evaluation is saved as it was before adjustment by correction history
@@ -1847,7 +1848,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
 
     // Step 2. Check for an immediate draw or maximum ply reached
     if (pos.is_draw(ss->ply) || ss->ply >= MAX_PLY)
-        return (ss->ply >= MAX_PLY && !ss->inCheck) ? evaluate(pos) : VALUE_DRAW;
+        return (ss->ply >= MAX_PLY && !ss->inCheck) ? evaluate(pos, Depth(0)) : VALUE_DRAW;
 
     assert(0 <= ss->ply && ss->ply < MAX_PLY);
 
@@ -1884,7 +1885,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
             // Never assume anything about values stored in TT
             unadjustedStaticEval = ttData.eval;
             if (!is_valid(unadjustedStaticEval))
-                unadjustedStaticEval = evaluate(pos);
+                unadjustedStaticEval = evaluate(pos, Depth(0));
             ss->staticEval = bestValue =
               to_corrected_static_eval(unadjustedStaticEval, correctionValue);
 
@@ -1895,7 +1896,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
         }
         else
         {
-            unadjustedStaticEval = evaluate(pos);
+            unadjustedStaticEval = evaluate(pos, Depth(0));
 
             ss->staticEval = bestValue =
               to_corrected_static_eval(unadjustedStaticEval, correctionValue);
@@ -2076,9 +2077,9 @@ TimePoint Search::Worker::elapsed() const {
 
 TimePoint Search::Worker::elapsed_time() const { return main_manager()->tm.elapsed_time(); }
 
-Value Search::Worker::evaluate(const Position& pos) {
+Value Search::Worker::evaluate(const Position& pos, Depth depth) {
     return Eval::evaluate(networks[numaAccessToken], pos, accumulatorStack, refreshTable,
-                          optimism[pos.side_to_move()]);
+                          optimism[pos.side_to_move()], depth);
 }
 
 namespace {

--- a/src/search.h
+++ b/src/search.h
@@ -325,7 +325,7 @@ class Worker {
     TimePoint elapsed() const;
     TimePoint elapsed_time() const;
 
-    Value evaluate(const Position&);
+    Value evaluate(const Position&, Depth depth);
 
     LimitsType limits;
 


### PR DESCRIPTION
## Summary
- instrument the evaluator to time big/small/falcon NNUE calls during the first five plies of a new FEN and emit UCI info logs
- scale king-side pawn storm penalties when the remaining depth is below 14 and plumb a notification from `Engine::set_position`
- provide a `scripts/presets/bullet-10_0.1.sh` helper that disables Falcon/experience features and tightens bullet time-management defaults

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eaafd1c0708327a58ad311ae3010bd