### PR TITLE
Fix duplicate bullet time cap in time management

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -136,14 +136,6 @@ void TimeManagement::init(Search::LimitsType& limits,
     maximumTime =
       TimePoint(std::min(0.825179 * limits.time[us] - moveOverhead, maxScale * optimumTime)) - 10;
 
-    // In very fast time controls (e.g. bullet), cap thinking time to avoid
-    // losing on time due to overly deep searches.
-    if (limits.time[us] < 60000)
-    {
-        optimumTime = std::min(optimumTime, TimePoint(limits.time[us] / 40));
-        maximumTime = std::min(maximumTime, TimePoint(limits.time[us] / 20));
-    }
-
     if (options["Ponder"])
         optimumTime += optimumTime / 4;
 


### PR DESCRIPTION
## Summary
- remove the redundant bullet-time clamp so the engine only applies the node-aware cap once

## Testing
- `cd src && make build ARCH=x86-64`

------
https://chatgpt.com/codex/tasks/task_e_68eab43ef9fc8327b46649c0777f6196