### PR TITLE
Use huge pages for worker data

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -54,7 +54,7 @@ Thread::Thread(Search::SharedState&                    sharedState,
         // here, but that's minor.
         this->numaAccessToken = binder();
         this->worker =
-          std::make_unique<Search::Worker>(sharedState, std::move(sm), n, this->numaAccessToken);
+          make_unique_large_page<Search::Worker>(sharedState, std::move(sm), n, this->numaAccessToken);
     });
 
     wait_for_search_finished();

--- a/src/thread.h
+++ b/src/thread.h
@@ -28,6 +28,7 @@
 #include <mutex>
 #include <vector>
 
+#include "memory.h"
 #include "numa.h"
 #include "position.h"
 #include "search.h"
@@ -93,8 +94,8 @@ class Thread {
     void   wait_for_search_finished();
     size_t id() const { return idx; }
 
-    std::unique_ptr<Search::Worker> worker;
-    std::function<void()>           jobFunc;
+    LargePagePtr<Search::Worker> worker;
+    std::function<void()>         jobFunc;
 
    private:
     std::mutex                mutex;


### PR DESCRIPTION
## Summary
- allocate search workers using the large-page allocator to back worker data
- store worker instances in a large-page-aware unique pointer

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f402a7a994832786b90a34306bb41f