### PR TITLE
Update Wordfish engine identification to 2.90 191025

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 ## [Unreleased]
 ### Added
-- Documented new training emphasis on king safety, rook coordination, and endgame supervision. 
+- Documented new training emphasis on king safety, rook coordination, and endgame supervision.
 
 ### Changed
 - Tightened king-safety heuristics for open files, rook lifts, and dark-square weaknesses.
 - Reduced aggressive pruning in sharp positions and added verification search for large evaluation swings.
 - Rewarded connected rooks while penalizing premature flank pawn storms in the handcrafted evaluation.
+
+## [2.90 191025]
+### Changed
+- Updated engine id name to "Wordfish 2.90 191025".
 
 ## [2.42-190825]
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Wordfish Chess Engine
 
-**Versión 2.81-071025**
+**Versión 2.90 191025**
 
-Este build se identifica como `wordfish-2.81-071025`.
+Este build se identifica como `Wordfish 2.90 191025` en la consola UCI y el binario predeterminado se distribuye como `wordfish-2.90-191025`.
 
 <div align="center">
   <img src="[https://ijccrl.com/wp-content/uploads/2025/08/wordfish.png]" 

--- a/scripts/fishtest_local.sh
+++ b/scripts/fishtest_local.sh
@@ -4,7 +4,7 @@
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE="$ROOT_DIR/src/wordfish-2.81-071025"
+ENGINE="$ROOT_DIR/src/wordfish-2.90-191025"
 FISHTEST_DIR="${FISHTEST_DIR:-$HOME/fishtest}"
 
 if [ ! -x "$ENGINE" ]; then

--- a/scripts/match.sh
+++ b/scripts/match.sh
@@ -4,9 +4,11 @@
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE_NAME="wordfish-2.81-071025"
-ENGINE_DEFAULT="$ROOT_DIR/src/$ENGINE_NAME"
+ENGINE_ID="Wordfish 2.90 191025"
+ENGINE_BASENAME="wordfish-2.90-191025"
+ENGINE_DEFAULT="$ROOT_DIR/src/$ENGINE_BASENAME"
 ENGINE="${ENGINE:-$ENGINE_DEFAULT}"
+ENGINE_NAME="${ENGINE_NAME:-$ENGINE_ID}"
 OPPONENT="${1:?Opponent engine path required}"
 GAMES="${2:-10}"
 TC="${3:-40/0.4+0.4}"

--- a/scripts/perft.sh
+++ b/scripts/perft.sh
@@ -4,7 +4,7 @@
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE="$ROOT_DIR/src/wordfish-2.81-071025"
+ENGINE="$ROOT_DIR/src/wordfish-2.90-191025"
 TEST_DIR="$ROOT_DIR/tests"
 
 if [ ! -x "$ENGINE" ]; then

--- a/scripts/spsa.py
+++ b/scripts/spsa.py
@@ -21,7 +21,7 @@ def run_bench(engine, name, value):
 def main():
     p = argparse.ArgumentParser(description="SPSA tuning for Wordfish")
     p.add_argument("--param", nargs=4, metavar=("NAME", "START", "MIN", "MAX"), action='append', required=True)
-    p.add_argument("--engine", default="src/wordfish-2.81-071025")
+    p.add_argument("--engine", default="src/wordfish-2.90-191025")
     p.add_argument("--iterations", type=int, default=10)
     args = p.parse_args()
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = wordfish-2.81-071025.exe
+        EXE = wordfish-2.90-191025.exe
 else
-        EXE = wordfish-2.81-071025
+        EXE = wordfish-2.90-191025
 endif
 
 ### Installation dir definitions
@@ -859,12 +859,12 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 # UCI "id name" string shown in GUIs.
 # Defaults:
-#   - ENGINE_NAME: "wordfish-2.81-071025"
+#   - ENGINE_NAME: "Wordfish 2.90"
 #   - ENGINE_BUILD_DATE: optional build identifier
 # You can override on the command line:
-#   make ENGINE_NAME="wordfish-2.81-071025" ENGINE_BUILD_DATE=20250907
-ENGINE_NAME        ?= wordfish-2.81-071025
-ENGINE_BUILD_DATE  ?=
+#   make ENGINE_NAME="Wordfish 2.90" ENGINE_BUILD_DATE=191025
+ENGINE_NAME        ?= Wordfish 2.90
+ENGINE_BUILD_DATE  ?= 191025
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 
 ### 3.9 Link Time Optimization

--- a/src/version.h
+++ b/src/version.h
@@ -4,11 +4,11 @@
 #include <string_view>
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "wordfish-2.81-071025"
+    #define ENGINE_NAME "Wordfish 2.90"
 #endif
 
 #ifndef ENGINE_BUILD_DATE
-    #define ENGINE_BUILD_DATE ""
+    #define ENGINE_BUILD_DATE "191025"
 #endif
 
 namespace Stockfish::Version {


### PR DESCRIPTION
## Summary
- update the default engine UCI id and build metadata to Wordfish 2.90 191025 while renaming the generated binary
- refresh helper scripts and README references so tooling and documentation point to the new executable name
- note the new release in the changelog for visibility

## Testing
- make build ARCH=x86-64

------
https://chatgpt.com/codex/tasks/task_e_68f404c18a9483278f01aa7942813519