### PR TITLE
Add CI workflow for perft and quick tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ubuntu:
+    name: Ubuntu CI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y expect python3-venv python3-requests
+
+      - name: Run perft validation
+        run: scripts/perft.sh
+
+      - name: Run quick Python tests
+        run: python3 tests/testing.py --quick

--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ Improvements require extensive testing:
 - Participate in active tests on [Wordfish Test Suite][testsuite-link]
 - Verify ELO gains through SPRT validation
 
+### Continuous Integration
+Automated checks run for every push and pull request targeting `main`.
+The [CI workflow](.github/workflows/ci.yml) executes on Ubuntu, installs the
+required system packages (`expect`, `python3-venv`, `python3-requests`), and
+then runs the core validation commands:
+
+```bash
+scripts/perft.sh
+python3 tests/testing.py --quick
+```
+
+These jobs must pass before changes are merged.
+
 ### Community
 Technical discussions occur primarily through:
 - [Wordfish Discord Server][discord-link]


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs on pushes and pull requests targeting main
- install the required Ubuntu system dependencies before executing the checks
- run the existing perft script and quick Python tests and document the workflow in the README

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_69012a5c93bc8327afa2019b0179481c