### PR TITLE
Fix version string concatenation for clang

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -30,10 +30,14 @@ inline std::string string() {
 
     if (ends_with_joiner)
         result.append(BuildTag);
-    else if (!has_space && !result.empty())
-        result.append('-').append(BuildTag);
-    else if (!result.empty())
-        result.append(" ").append(BuildTag);
+    else if (!has_space && !result.empty()) {
+        result.push_back('-');
+        result.append(BuildTag);
+    }
+    else if (!result.empty()) {
+        result.push_back(' ');
+        result.append(BuildTag);
+    }
     else
         result = std::string(BuildTag);
 


### PR DESCRIPTION
## Summary
- fix version string generation to append separator characters in a clang-compatible way

## Testing
- make -j profile-build ARCH=x86-64-sse41-popcnt COMP=clang CXX=clang++-20 EXTRALDFLAGS="-fuse-ld=lld"

------
https://chatgpt.com/codex/tasks/task_e_69013aca5e2c8327871ecc37118369f2