### PR TITLE
Simplify futility pruning formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1160,7 +1160,6 @@ Value Search::Worker::search(
             return futilityMult * d                      //
                  - improving * futilityMult * 2          //
                  - opponentWorsening * futilityMult / 3  //
-                 + (ss - 1)->statScore / 356             //
                  + std::abs(correctionValue) / 171290;
         };
 


### PR DESCRIPTION
## Summary
- align the futility pruning margin with the latest Stockfish patch by removing the statScore-based term

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6906619a00ac8327997003b6a5daf4e2