### PR TITLE
Enable experience dump command in release builds

### DIFF
--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -398,7 +398,6 @@ void Experience::update(Position& pos, Move move, int score, int depth) {
     vec.push_back({move, score, depth, 1});
 }
 
-#ifdef WORDFISH_TESTING
 std::vector<std::pair<Key, std::vector<ExperienceEntry>>> Experience::dump_table() const {
     wait_until_loaded();
     std::lock_guard<std::mutex> lock(tableMutex);
@@ -423,7 +422,6 @@ std::vector<std::pair<Key, std::vector<ExperienceEntry>>> Experience::dump_table
 
     return snapshot;
 }
-#endif
 
 void Experience::show(const Position& pos, int evalImportance, int maxMoves) const {
     if (!is_ready())

--- a/src/experience.h
+++ b/src/experience.h
@@ -26,9 +26,7 @@
 #include <string>
 #include <future>
 #include <mutex>
-#ifdef WORDFISH_TESTING
-#    include <utility>
-#endif
+#include <utility>
 
 #include "position.h"
 #include "types.h"
@@ -52,9 +50,7 @@ class Experience {
     Move probe(Position& pos, int width, int evalImportance, int minDepth, int maxMoves);
     void update(Position& pos, Move move, int score, int depth);
     void show(const Position& pos, int evalImportance, int maxMoves) const;
-#ifdef WORDFISH_TESTING
     std::vector<std::pair<Key, std::vector<ExperienceEntry>>> dump_table() const;
-#endif
 
    private:
     bool                                                  is_ready() const;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -164,7 +164,6 @@ void UCIEngine::loop() {
         else if (token == "showexp")
             experience.show(engine.position(), (int) engine.get_options()["Experience Eval Weight"],
                             (int) engine.get_options()["Experience Book Max Moves"]);
-#ifdef WORDFISH_TESTING
         else if (token == "experience")
         {
             std::string subcommand;
@@ -185,7 +184,6 @@ void UCIEngine::loop() {
                 sync_cout_end();
             }
         }
-#endif
         else if (token == "compiler")
             sync_cout << compiler_info() << sync_endl;
         else if (token == "export_net")


### PR DESCRIPTION
## Summary
- expose the `experience dump` helper command in all builds so the integration tests can inspect the learning table
- always build the `Experience::dump_table` helper that backs the dump command

## Testing
- `STOCKFISH_BINARY=src/Wordfish-3.10-011125 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6906647cd8f883279bace0c89b24d487