### PR TITLE
Report large memory page availability through UCI info string

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -27,6 +27,7 @@
 #include <iterator>
 #include <optional>
 #include <sstream>
+#include <string>
 #include <string_view>
 #include <utility>
 #include <vector>
@@ -126,6 +127,10 @@ void UCIEngine::loop() {
               << "\n"
               << engine.get_options() << std::endl;
             sync_cout_end();
+
+            const bool largePagesAvailable = has_large_pages();
+            print_info_string(std::string("Large Memory Pages    : ")
+                              + (largePagesAvailable ? "available" : "unavailable"));
 
             sync_cout << "uciok" << sync_endl;
 


### PR DESCRIPTION
## Summary
- add a dedicated UCI info string that reports whether large memory pages are available
- include the necessary header so the engine can build the message string

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6908fb541c5c8327a2bd63e74c75a5e1