### PR TITLE
Fix perft harness invocation for non-executable scripts

### DIFF
--- a/scripts/perft.sh
+++ b/scripts/perft.sh
@@ -12,4 +12,4 @@ if [ ! -x "$ENGINE" ]; then
   (cd "$ROOT_DIR/src" && make -j2 build ARCH=x86-64 >/dev/null)
 fi
 
-(cd "$TEST_DIR" && ./perft.sh "$ENGINE")
+(cd "$TEST_DIR" && bash ./perft.sh "$ENGINE")


### PR DESCRIPTION
## Summary
- invoke the perft test harness with `bash` so it runs even if the script lacks execute permissions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6908fc6fb5f08327b8036b14b7d653a0