### PR TITLE
Adopt shared memory NNUE weight infrastructure

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -485,7 +485,7 @@ endif
 ifeq ($(COMP),gcc)
 	comp=gcc
 	CXX=g++
-	CXXFLAGS += -pedantic -Wextra -Wshadow -Wmissing-declarations
+       CXXFLAGS += -pedantic -Wextra -Wshadow -Wmissing-declarations -Wstack-usage=128000
 
 	ifeq ($(arch),$(filter $(arch),armv7 armv8 riscv64))
 		ifeq ($(OS),Android)
@@ -667,7 +667,20 @@ ifneq ($(comp),mingw)
 		# Haiku has pthreads in its libroot, so only link it in on other platforms
 		ifneq ($(KERNEL),Haiku)
 			ifneq ($(COMP),ndk)
-				LDFLAGS += -lpthread
+                               LDFLAGS += -lpthread
+
+                               add_lrt = yes
+                               ifeq ($(target_windows),yes)
+                                       add_lrt = no
+                               endif
+
+                               ifeq ($(KERNEL),Darwin)
+                                       add_lrt = no
+                               endif
+
+                               ifeq ($(add_lrt),yes)
+                                       LDFLAGS += -lrt
+                               endif
 			endif
 		endif
 	endif
@@ -677,7 +690,8 @@ endif
 ifeq ($(debug),no)
 	CXXFLAGS += -DNDEBUG
 else
-	CXXFLAGS += -g
+       CXXFLAGS += -g
+       CXXFLAGS += -D_GLIBCXX_ASSERTIONS -D_GLIBCXX_DEBUG
 endif
 
 ### 3.2.2 Debugging with undefined behavior sanitizers

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -36,12 +36,14 @@
 #include "misc.h"
 #include "nnue/network.h"
 #include "nnue/nnue_common.h"
+#include "nnue/nnue_misc.h"
 #include "numa.h"
 #include "perft.h"
 #include "polybook.h"
 #include "position.h"
 #include "experience.h"
 #include "search.h"
+#include "shm.h"
 #include "syzygy/tbprobe.h"
 #include "types.h"
 #include "uci.h"
@@ -62,11 +64,13 @@ Engine::Engine(std::optional<std::string> path) :
     threads(),
     networks(
       numaContext,
-      NN::Networks(
-        NN::NetworkBig({EvalFileDefaultNameBig, "None", "", "", std::nullopt},
-                       NN::EmbeddedNNUEType::BIG),
-        NN::NetworkSmall({EvalFileDefaultNameSmall, "None", "", "", std::nullopt},
-                         NN::EmbeddedNNUEType::SMALL))) {
+      // Heap-allocate because sizeof(NN::Networks) is large
+      std::make_unique<NN::Networks>(
+        std::make_unique<NN::NetworkBig>(
+          NN::EvalFile{EvalFileDefaultNameBig, "None", ""}, NN::EmbeddedNNUEType::BIG),
+        std::make_unique<NN::NetworkSmall>(
+          NN::EvalFile{EvalFileDefaultNameSmall, "None", ""}, NN::EmbeddedNNUEType::SMALL))) {
+
     pos.set(StartFEN, false, &states->back());
 
 
@@ -371,6 +375,36 @@ void Engine::set_ponderhit(bool b) { threads.main_manager()->ponder = b; }
 void Engine::verify_networks() const {
     networks->big.verify(options["EvalFile"], onVerifyNetworks);
     networks->small.verify(options["EvalFileSmall"], onVerifyNetworks);
+
+    auto statuses = networks.get_status_and_errors();
+    for (size_t i = 0; i < statuses.size(); ++i)
+    {
+        const auto [status, error] = statuses[i];
+        std::string message        = "Network replica " + std::to_string(i + 1) + ": ";
+        if (status == SystemWideSharedConstantAllocationStatus::NoAllocation)
+        {
+            message += "No allocation.";
+        }
+        else if (status == SystemWideSharedConstantAllocationStatus::LocalMemory)
+        {
+            message += "Local memory.";
+        }
+        else if (status == SystemWideSharedConstantAllocationStatus::SharedMemory)
+        {
+            message += "Shared memory.";
+        }
+        else
+        {
+            message += "Unknown status.";
+        }
+
+        if (error.has_value())
+        {
+            message += " " + *error;
+        }
+
+        onVerifyNetworks(message);
+    }
 }
 
 void Engine::load_networks() {

--- a/src/engine.h
+++ b/src/engine.h
@@ -116,10 +116,10 @@ class Engine {
     Position     pos;
     StateListPtr states;
 
-    OptionsMap                               options;
-    ThreadPool                               threads;
-    TranspositionTable                       tt;
-    LazyNumaReplicated<Eval::NNUE::Networks> networks;
+    OptionsMap                                         options;
+    ThreadPool                                         threads;
+    TranspositionTable                                 tt;
+    LazyNumaReplicatedSystemWide<Eval::NNUE::Networks> networks;
 
     Search::SearchManager::UpdateContext  updateContext;
     std::function<void(std::string_view)> onVerifyNetworks;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -309,14 +309,14 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
 
     if (smallNetCandidate)
     {
-        auto& smallCache = caches.cache_for_small(networks.small);
+        auto& smallCache = caches.small;
         auto  smallEval  = time_call(
           [&] { return networks.small.evaluate(pos, accumulators, &smallCache); }, WarmupSlot::Small);
         std::tie(psqt, positional) = smallEval;
     }
     else
     {
-        auto& bigCache = caches.cache_for_big(networks.big);
+        auto& bigCache = caches.big;
         auto  bigEval  = time_call(
           [&] { return networks.big.evaluate(pos, accumulators, &bigCache); }, WarmupSlot::Big);
         std::tie(psqt, positional) = bigEval;
@@ -328,7 +328,7 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     // Re-evaluate the position when higher eval accuracy is worth the time spent
     if (smallNet && (std::abs(nnue) < 236))
     {
-        auto& bigCache = caches.cache_for_big(networks.big);
+        auto& bigCache = caches.big;
         auto  bigEval  = time_call(
           [&] { return networks.big.evaluate(pos, accumulators, &bigCache); }, WarmupSlot::Big);
         std::tie(psqt, positional) = bigEval;
@@ -400,8 +400,8 @@ std::string Eval::trace(Position& pos, const Eval::NNUE::Networks& networks) {
     if (pos.checkers())
         return "Final evaluation: none (in check)";
 
-    Eval::NNUE::AccumulatorStack accumulators;
-    auto                         caches = std::make_unique<Eval::NNUE::AccumulatorCaches>(networks);
+    auto accumulators = std::make_unique<Eval::NNUE::AccumulatorStack>();
+    auto caches       = std::make_unique<Eval::NNUE::AccumulatorCaches>(networks);
 
     std::stringstream ss;
     ss << std::showpoint << std::noshowpos << std::fixed << std::setprecision(2);
@@ -409,13 +409,12 @@ std::string Eval::trace(Position& pos, const Eval::NNUE::Networks& networks) {
 
     ss << std::showpoint << std::showpos << std::fixed << std::setprecision(2) << std::setw(15);
 
-    auto& bigCache = caches->cache_for_big(networks.big);
-    auto [psqt, positional] = networks.big.evaluate(pos, accumulators, &bigCache);
+    auto [psqt, positional] = networks.big.evaluate(pos, *accumulators, &caches->big);
     Value v                 = psqt + positional;
     v                       = pos.side_to_move() == WHITE ? v : -v;
     ss << "NNUE evaluation        " << 0.01 * UCIEngine::to_cp(v, pos) << " (white side)\n";
 
-    v = evaluate(networks, pos, accumulators, *caches, VALUE_ZERO, Depth(99));
+    v = evaluate(networks, pos, *accumulators, *caches, VALUE_ZERO, Depth(99));
     v = pos.side_to_move() == WHITE ? v : -v;
     ss << "Final evaluation       " << 0.01 * UCIEngine::to_cp(v, pos) << " (white side)";
     ss << " [with scaled NNUE, ...]";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,8 @@
   Modifications Copyright (C) 2024 Jorge Ruiz Centelles
 */
 
+#include <memory>
+
 #include "misc.h"
 #include "uci.h"
 #include "tune.h"
@@ -48,10 +50,10 @@ int main(int argc, char* argv[]) {
     Bitboards::init();
     Position::init();
 
-    UCIEngine uci(argc, argv);
+    auto uci = std::make_unique<UCIEngine>(argc, argv);
 
-    Tune::init(uci.engine_options());
+    Tune::init(uci->engine_options());
 
-    uci.loop();
+    uci->loop();
     return 0;
 }

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -55,12 +55,6 @@
 // the calls at compile time), try to load them at runtime. To do this we need
 // first to define the corresponding function pointers.
 
-extern "C" {
-using OpenProcessToken_t      = bool (*)(HANDLE, DWORD, PHANDLE);
-using LookupPrivilegeValueA_t = bool (*)(LPCSTR, LPCSTR, PLUID);
-using AdjustTokenPrivileges_t =
-  bool (*)(HANDLE, BOOL, PTOKEN_PRIVILEGES, DWORD, PTOKEN_PRIVILEGES, PDWORD);
-}
 #endif
 
 
@@ -106,94 +100,14 @@ void std_aligned_free(void* ptr) {
 #if defined(_WIN32)
 
 static void* aligned_large_pages_alloc_windows([[maybe_unused]] size_t allocSize) {
-
-    #if !defined(_WIN64)
-    return nullptr;
-    #else
-
-    HANDLE hProcessToken{};
-    LUID   luid{};
-    void*  mem = nullptr;
-
-    const size_t largePageSize = GetLargePageMinimum();
-    if (!largePageSize)
-        return nullptr;
-
-    // Dynamically link OpenProcessToken, LookupPrivilegeValue and AdjustTokenPrivileges
-
-    struct Advapi32Guard {
-        HMODULE hModule{};
-        bool    loaded{};
-
-        Advapi32Guard() {
-            hModule = GetModuleHandle(TEXT("advapi32.dll"));
-            if (!hModule) {
-                hModule = LoadLibrary(TEXT("advapi32.dll"));
-                loaded  = (hModule != nullptr);
-            }
-        }
-
-        ~Advapi32Guard() {
-            if (loaded && hModule)
-                FreeLibrary(hModule);
-        }
-    } advapi32;
-
-    if (!advapi32.hModule)
-        return nullptr;
-
-    auto OpenProcessToken_f =
-      OpenProcessToken_t((void (*)()) GetProcAddress(advapi32.hModule, "OpenProcessToken"));
-    if (!OpenProcessToken_f)
-        return nullptr;
-    auto LookupPrivilegeValueA_f =
-      LookupPrivilegeValueA_t((void (*)()) GetProcAddress(advapi32.hModule, "LookupPrivilegeValueA"));
-    if (!LookupPrivilegeValueA_f)
-        return nullptr;
-    auto AdjustTokenPrivileges_f =
-      AdjustTokenPrivileges_t((void (*)()) GetProcAddress(advapi32.hModule, "AdjustTokenPrivileges"));
-    if (!AdjustTokenPrivileges_f)
-        return nullptr;
-
-    // We need SeLockMemoryPrivilege, so try to enable it for the process
-
-    if (!OpenProcessToken_f(  // OpenProcessToken()
-          GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, &hProcessToken))
-        return nullptr;
-
-    if (LookupPrivilegeValueA_f(nullptr, "SeLockMemoryPrivilege", &luid))
-    {
-        TOKEN_PRIVILEGES tp{};
-        TOKEN_PRIVILEGES prevTp{};
-        DWORD            prevTpLen = 0;
-
-        tp.PrivilegeCount           = 1;
-        tp.Privileges[0].Luid       = luid;
-        tp.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
-
-        // Try to enable SeLockMemoryPrivilege. Note that even if AdjustTokenPrivileges()
-        // succeeds, we still need to query GetLastError() to ensure that the privileges
-        // were actually obtained.
-
-        if (AdjustTokenPrivileges_f(hProcessToken, FALSE, &tp, sizeof(TOKEN_PRIVILEGES), &prevTp,
-                                    &prevTpLen)
-            && GetLastError() == ERROR_SUCCESS)
-        {
-            // Round up size to full pages and allocate
-            allocSize = (allocSize + largePageSize - 1) & ~size_t(largePageSize - 1);
-            mem       = VirtualAlloc(nullptr, allocSize, MEM_RESERVE | MEM_COMMIT | MEM_LARGE_PAGES,
-                                     PAGE_READWRITE);
-
-            // Privilege no longer needed, restore previous state
-            AdjustTokenPrivileges_f(hProcessToken, FALSE, &prevTp, 0, nullptr, nullptr);
-        }
-    }
-
-    CloseHandle(hProcessToken);
-
-    return mem;
-
-    #endif
+    return windows_try_with_large_page_priviliges(
+      [&](size_t largePageSize) {
+          // Round up size to full pages and allocate
+          allocSize = (allocSize + largePageSize - 1) & ~size_t(largePageSize - 1);
+          return VirtualAlloc(nullptr, allocSize, MEM_RESERVE | MEM_COMMIT | MEM_LARGE_PAGES,
+                              PAGE_READWRITE);
+      },
+      []() { return (void*) nullptr; });
 }
 
 void* aligned_large_pages_alloc(size_t allocSize) {

--- a/src/memory.h
+++ b/src/memory.h
@@ -29,6 +29,29 @@
 
 #include "types.h"
 
+#if defined(_WIN64)
+
+    #if _WIN32_WINNT < 0x0601
+        #undef _WIN32_WINNT
+        #define _WIN32_WINNT 0x0601  // Force to include needed API prototypes
+    #endif
+
+    #if !defined(NOMINMAX)
+        #define NOMINMAX
+    #endif
+    #include <windows.h>
+
+    #include <psapi.h>
+
+extern "C" {
+using OpenProcessToken_t      = bool (*)(HANDLE, DWORD, PHANDLE);
+using LookupPrivilegeValueA_t = bool (*)(LPCSTR, LPCSTR, PLUID);
+using AdjustTokenPrivileges_t =
+  bool (*)(HANDLE, BOOL, PTOKEN_PRIVILEGES, DWORD, PTOKEN_PRIVILEGES, PDWORD);
+}
+#endif
+
+
 namespace Stockfish {
 
 void* std_aligned_alloc(size_t alignment, size_t size);
@@ -211,6 +234,81 @@ T* align_ptr_up(T* ptr) {
       reinterpret_cast<char*>((ptrint + (Alignment - 1)) / Alignment * Alignment));
 }
 
+#if defined(_WIN32)
+
+template<typename FuncYesT, typename FuncNoT>
+auto windows_try_with_large_page_priviliges([[maybe_unused]] FuncYesT&& fyes, FuncNoT&& fno) {
+
+    #if !defined(_WIN64)
+    return fno();
+    #else
+
+    HANDLE hProcessToken{};
+    LUID   luid{};
+
+    const size_t largePageSize = GetLargePageMinimum();
+    if (!largePageSize)
+        return fno();
+
+    // Dynamically link OpenProcessToken, LookupPrivilegeValue and AdjustTokenPrivileges
+
+    HMODULE hAdvapi32 = GetModuleHandle(TEXT("advapi32.dll"));
+
+    if (!hAdvapi32)
+        hAdvapi32 = LoadLibrary(TEXT("advapi32.dll"));
+
+    auto OpenProcessToken_f =
+      OpenProcessToken_t((void (*)()) GetProcAddress(hAdvapi32, "OpenProcessToken"));
+    if (!OpenProcessToken_f)
+        return fno();
+    auto LookupPrivilegeValueA_f =
+      LookupPrivilegeValueA_t((void (*)()) GetProcAddress(hAdvapi32, "LookupPrivilegeValueA"));
+    if (!LookupPrivilegeValueA_f)
+        return fno();
+    auto AdjustTokenPrivileges_f =
+      AdjustTokenPrivileges_t((void (*)()) GetProcAddress(hAdvapi32, "AdjustTokenPrivileges"));
+    if (!AdjustTokenPrivileges_f)
+        return fno();
+
+    // We need SeLockMemoryPrivilege, so try to enable it for the process
+
+    if (!OpenProcessToken_f(  // OpenProcessToken()
+          GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, &hProcessToken))
+        return fno();
+
+    if (!LookupPrivilegeValueA_f(nullptr, "SeLockMemoryPrivilege", &luid))
+        return fno();
+
+    TOKEN_PRIVILEGES tp{};
+    TOKEN_PRIVILEGES prevTp{};
+    DWORD            prevTpLen = 0;
+
+    tp.PrivilegeCount           = 1;
+    tp.Privileges[0].Luid       = luid;
+    tp.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
+
+    // Try to enable SeLockMemoryPrivilege. Note that even if AdjustTokenPrivileges()
+    // succeeds, we still need to query GetLastError() to ensure that the privileges
+    // were actually obtained.
+
+    if (!AdjustTokenPrivileges_f(hProcessToken, FALSE, &tp, sizeof(TOKEN_PRIVILEGES), &prevTp,
+                                 &prevTpLen)
+        || GetLastError() != ERROR_SUCCESS)
+        return fno();
+
+    auto&& ret = fyes(largePageSize);
+
+    // Privilege no longer needed, restore previous state
+    AdjustTokenPrivileges_f(hProcessToken, FALSE, &prevTp, 0, nullptr, nullptr);
+
+    CloseHandle(hProcessToken);
+
+    return std::forward<decltype(ret)>(ret);
+
+    #endif
+}
+
+#endif
 
 }  // namespace Stockfish
 

--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -181,6 +181,15 @@ class AffineTransform {
 
         return !stream.fail();
     }
+
+    std::size_t get_content_hash() const {
+        std::size_t h = 0;
+        hash_combine(h, get_raw_data_hash(biases));
+        hash_combine(h, get_raw_data_hash(weights));
+        hash_combine(h, get_hash_value(0));
+        return h;
+    }
+
     // Forward propagation
     void propagate(const InputType* input, OutputType* output) const {
 

--- a/src/nnue/layers/affine_transform_sparse_input.h
+++ b/src/nnue/layers/affine_transform_sparse_input.h
@@ -239,6 +239,15 @@ class AffineTransformSparseInput {
 
         return !stream.fail();
     }
+
+    std::size_t get_content_hash() const {
+        std::size_t h = 0;
+        hash_combine(h, get_raw_data_hash(biases));
+        hash_combine(h, get_raw_data_hash(weights));
+        hash_combine(h, get_hash_value(0));
+        return h;
+    }
+
     // Forward propagation
     void propagate(const InputType* input, OutputType* output) const {
 

--- a/src/nnue/layers/clipped_relu.h
+++ b/src/nnue/layers/clipped_relu.h
@@ -58,6 +58,12 @@ class ClippedReLU {
     // Write network parameters
     bool write_parameters(std::ostream&) const { return true; }
 
+    std::size_t get_content_hash() const {
+        std::size_t h = 0;
+        hash_combine(h, get_hash_value(0));
+        return h;
+    }
+
     // Forward propagation
     void propagate(const InputType* input, OutputType* output) const {
 

--- a/src/nnue/layers/sqr_clipped_relu.h
+++ b/src/nnue/layers/sqr_clipped_relu.h
@@ -58,6 +58,12 @@ class SqrClippedReLU {
     // Write network parameters
     bool write_parameters(std::ostream&) const { return true; }
 
+    std::size_t get_content_hash() const {
+        std::size_t h = 0;
+        hash_combine(h, get_hash_value(0));
+        return h;
+    }
+
     // Forward propagation
     void propagate(const InputType* input, OutputType* output) const {
 

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -18,24 +18,17 @@
 
 #include "network.h"
 
-#include <cassert>
 #include <cstdlib>
-#include <filesystem>
 #include <fstream>
-#include <system_error>
-#include <ctime>
 #include <iostream>
-#include <memory>
 #include <optional>
 #include <type_traits>
-#include <utility>
 #include <vector>
 
 #define INCBIN_SILENCE_BITCODE_WARNING
 #include "../incbin/incbin.h"
 
 #include "../evaluate.h"
-#include "../memory.h"
 #include "../misc.h"
 #include "../position.h"
 #include "../types.h"
@@ -81,8 +74,8 @@ using namespace Stockfish::Eval::NNUE;
 EmbeddedNNUE get_embedded(EmbeddedNNUEType type) {
     if (type == EmbeddedNNUEType::BIG)
         return EmbeddedNNUE(gEmbeddedNNUEBigData, gEmbeddedNNUEBigEnd, gEmbeddedNNUEBigSize);
-
-    return EmbeddedNNUE(gEmbeddedNNUESmallData, gEmbeddedNNUESmallEnd, gEmbeddedNNUESmallSize);
+    else
+        return EmbeddedNNUE(gEmbeddedNNUESmallData, gEmbeddedNNUESmallEnd, gEmbeddedNNUESmallSize);
 }
 
 }
@@ -106,7 +99,7 @@ bool read_parameters(std::istream& stream, T& reference) {
 
 // Write evaluation function parameters
 template<typename T>
-bool write_parameters(std::ostream& stream, T& reference) {
+bool write_parameters(std::ostream& stream, const T& reference) {
 
     write_little_endian<std::uint32_t>(stream, T::get_hash_value());
     return reference.write_parameters(stream);
@@ -115,46 +108,7 @@ bool write_parameters(std::ostream& stream, T& reference) {
 }  // namespace Detail
 
 template<typename Arch, typename Transformer>
-Network<Arch, Transformer>::Weights::Weights() :
-    featureTransformer(make_unique_large_page<Transformer>()),
-    network(make_unique_aligned<Arch[]>(LayerStacks)) {}
-
-template<typename Arch, typename Transformer>
-Network<Arch, Transformer>::Network(const Network<Arch, Transformer>& other) :
-    weights(std::atomic_load(&other.weights)),
-    evalFile(other.evalFile),
-    embeddedType(other.embeddedType),
-    lastLoadedFromPtr(std::atomic_load(&other.lastLoadedFromPtr)) {
-    versionCounter.store(other.versionCounter.load(std::memory_order_relaxed),
-                         std::memory_order_relaxed);
-    available.store(other.available.load(std::memory_order_relaxed), std::memory_order_relaxed);
-    lastLoadedTime.store(other.lastLoadedTime.load(std::memory_order_relaxed),
-                         std::memory_order_relaxed);
-}
-
-template<typename Arch, typename Transformer>
-Network<Arch, Transformer>&
-Network<Arch, Transformer>::operator=(const Network<Arch, Transformer>& other) {
-    if (this == &other)
-        return *this;
-
-    evalFile     = other.evalFile;
-    embeddedType = other.embeddedType;
-
-    versionCounter.store(other.versionCounter.load(std::memory_order_relaxed),
-                         std::memory_order_relaxed);
-    available.store(other.available.load(std::memory_order_relaxed), std::memory_order_relaxed);
-    lastLoadedTime.store(other.lastLoadedTime.load(std::memory_order_relaxed),
-                         std::memory_order_relaxed);
-    std::atomic_store(&lastLoadedFromPtr, std::atomic_load(&other.lastLoadedFromPtr));
-
-    std::atomic_store(&weights, std::atomic_load(&other.weights));
-
-    return *this;
-}
-
-template<typename Arch, typename Transformer>
-bool Network<Arch, Transformer>::load(const std::string& rootDirectory, std::string evalfilePath) {
+void Network<Arch, Transformer>::load(const std::string& rootDirectory, std::string evalfilePath) {
 #if defined(DEFAULT_NNUE_DIRECTORY)
     std::vector<std::string> dirs = {"<internal>", "", rootDirectory,
                                      stringify(DEFAULT_NNUE_DIRECTORY)};
@@ -165,63 +119,21 @@ bool Network<Arch, Transformer>::load(const std::string& rootDirectory, std::str
     if (evalfilePath.empty())
         evalfilePath = evalFile.defaultName;
 
-    auto previousWeights = weights_handle();
-    bool loadedNewWeights = false;
-    std::string resolvedPath;
-
     for (const auto& directory : dirs)
     {
-        if (evalFile.current == evalfilePath && available.load(std::memory_order_relaxed))
-            break;
-
-        bool loaded = false;
-
-        if (directory != "<internal>")
+        if (std::string(evalFile.current) != evalfilePath)
         {
-            std::string resolvedCandidate;
-            loaded = load_user_net(directory, evalfilePath, resolvedCandidate);
-            if (loaded)
-                resolvedPath = std::move(resolvedCandidate);
-        }
+            if (directory != "<internal>")
+            {
+                load_user_net(directory, evalfilePath);
+            }
 
-        if (!loaded && directory == "<internal>" && evalfilePath == evalFile.defaultName)
-        {
-            loaded = load_internal();
-            if (loaded)
-                resolvedPath = "<internal>";
-        }
-
-        if (loaded)
-        {
-            loadedNewWeights = true;
-            break;
+            if (directory == "<internal>" && evalfilePath == std::string(evalFile.defaultName))
+            {
+                load_internal();
+            }
         }
     }
-
-    auto currentWeights = weights_handle();
-
-    bool alreadyLoaded = evalFile.current == evalfilePath && bool(currentWeights);
-    bool success       = loadedNewWeights || alreadyLoaded;
-
-    if (success)
-    {
-        available.store(true, std::memory_order_relaxed);
-
-        if (loadedNewWeights && currentWeights && currentWeights != previousWeights)
-        {
-            versionCounter.fetch_add(1, std::memory_order_relaxed);
-            record_load(resolvedPath, evalfilePath);
-        }
-
-        return true;
-    }
-
-    available.store(false, std::memory_order_relaxed);
-
-    evalFile.current.clear();
-    clear_loaded_metadata();
-
-    return false;
 }
 
 
@@ -234,7 +146,7 @@ bool Network<Arch, Transformer>::save(const std::optional<std::string>& filename
         actualFilename = filename.value();
     else
     {
-        if (evalFile.current != evalFile.defaultName)
+        if (std::string(evalFile.current) != std::string(evalFile.defaultName))
         {
             msg = "Failed to export a net. "
                   "A non-embedded net can only be saved if the filename is specified";
@@ -247,92 +159,12 @@ bool Network<Arch, Transformer>::save(const std::optional<std::string>& filename
     }
 
     std::ofstream stream(actualFilename, std::ios_base::binary);
-    auto          storage = weights_handle();
-
-    if (!storage)
-    {
-        msg = "Failed to export a net";
-        sync_cout << msg << sync_endl;
-        return false;
-    }
-
-    bool saved = save(stream, evalFile.current, evalFile.netDescription, *storage);
+    bool          saved = save(stream, evalFile.current, evalFile.netDescription);
 
     msg = saved ? "Network saved successfully to " + actualFilename : "Failed to export a net";
 
     sync_cout << msg << sync_endl;
     return saved;
-}
-
-
-template<typename Arch, typename Transformer>
-typename Network<Arch, Transformer>::WeightsPtr
-Network<Arch, Transformer>::weights_handle() const {
-    return std::atomic_load(&weights);
-}
-
-template<typename Arch, typename Transformer>
-std::uint64_t Network<Arch, Transformer>::version() const {
-    return versionCounter.load(std::memory_order_relaxed);
-}
-
-template<typename Arch, typename Transformer>
-bool Network<Arch, Transformer>::is_available() const {
-    return available.load(std::memory_order_relaxed) && bool(std::atomic_load(&weights));
-}
-
-template<typename Arch, typename Transformer>
-std::time_t Network<Arch, Transformer>::loaded_time() const {
-    return lastLoadedTime.load(std::memory_order_relaxed);
-}
-
-template<typename Arch, typename Transformer>
-std::string Network<Arch, Transformer>::loaded_from() const {
-    auto path = std::atomic_load(&lastLoadedFromPtr);
-    return path ? *path : std::string();
-}
-
-template<typename Arch, typename Transformer>
-typename Network<Arch, Transformer>::StateSnapshot
-Network<Arch, Transformer>::snapshot() const {
-    StateSnapshot state{};
-    state.weights   = weights_handle();
-    state.version   = versionCounter.load(std::memory_order_relaxed);
-    state.available = available.load(std::memory_order_relaxed) && bool(state.weights);
-    state.loadedAt  = lastLoadedTime.load(std::memory_order_relaxed);
-
-    if (auto path = std::atomic_load(&lastLoadedFromPtr))
-        state.loadedFrom = *path;
-
-    state.currentFile = evalFile.current;
-    state.description = evalFile.netDescription;
-
-    return state;
-}
-
-template<typename Arch, typename Transformer>
-void Network<Arch, Transformer>::set_loaded_from(std::string value) {
-    std::shared_ptr<const std::string> newPtr;
-    if (!value.empty())
-        newPtr = std::make_shared<std::string>(std::move(value));
-
-    std::atomic_store(&lastLoadedFromPtr, std::move(newPtr));
-}
-
-template<typename Arch, typename Transformer>
-void Network<Arch, Transformer>::record_load(const std::string& resolvedPath,
-                                             const std::string& evalfilePath) {
-    const std::string origin = resolvedPath.empty() ? evalfilePath : resolvedPath;
-    set_loaded_from(origin);
-    lastLoadedTime.store(std::time(nullptr), std::memory_order_relaxed);
-}
-
-template<typename Arch, typename Transformer>
-void Network<Arch, Transformer>::clear_loaded_metadata() {
-    set_loaded_from(std::string{});
-    lastLoadedTime.store(0, std::memory_order_relaxed);
-    evalFile.resolvedPath.clear();
-    evalFile.lastWriteTime = std::nullopt;
 }
 
 
@@ -349,17 +181,10 @@ Network<Arch, Transformer>::evaluate(const Position&                         pos
 
     ASSERT_ALIGNED(transformedFeatures, alignment);
 
-    auto storage = weights_handle();
-    if (!storage)
-    {
-        assert(storage && "NNUE weights not initialized");
-        return {Value(0), Value(0)};
-    }
-
     const int  bucket = (pos.count<ALL_PIECES>() - 1) / 4;
-    const auto psqt = storage->featureTransformer->transform(pos, accumulatorStack, cache,
-                                                             transformedFeatures, bucket);
-    const auto positional = storage->network[bucket].propagate(transformedFeatures);
+    const auto psqt =
+      featureTransformer.transform(pos, accumulatorStack, cache, transformedFeatures, bucket);
+    const auto positional = network[bucket].propagate(transformedFeatures);
     return {static_cast<Value>(psqt / OutputScale), static_cast<Value>(positional / OutputScale)};
 }
 
@@ -370,9 +195,8 @@ void Network<Arch, Transformer>::verify(std::string                             
     if (evalfilePath.empty())
         evalfilePath = evalFile.defaultName;
 
-    auto state = snapshot();
-
-    auto abort_with_message = [&]() {
+    if (std::string(evalFile.current) != evalfilePath)
+    {
         if (f)
         {
             std::string msg1 =
@@ -382,7 +206,7 @@ void Network<Arch, Transformer>::verify(std::string                             
                                "including the directory name, to the network file.";
             std::string msg4 = "The default net can be downloaded from: "
                                "https://tests.stockfishchess.org/api/nn/"
-                             + evalFile.defaultName;
+                             + std::string(evalFile.defaultName);
             std::string msg5 = "The engine will be terminated now.";
 
             std::string msg = "ERROR: " + msg1 + '\n' + "ERROR: " + msg2 + '\n' + "ERROR: " + msg3
@@ -392,37 +216,17 @@ void Network<Arch, Transformer>::verify(std::string                             
         }
 
         exit(EXIT_FAILURE);
-    };
-
-    if (!state.weights || state.currentFile != evalfilePath)
-        abort_with_message();
-
-    if (!f)
-        return;
-
-    size_t size = sizeof(*state.weights->featureTransformer) + sizeof(Arch) * LayerStacks;
-
-    std::time_t loadedAt = state.loadedAt;
-    char        buffer[64]{};
-    if (loadedAt != 0)
-    {
-        std::tm tm{};
-#ifdef _WIN32
-        gmtime_s(&tm, &loadedAt);
-#else
-        gmtime_r(&loadedAt, &tm);
-#endif
-        std::strftime(buffer, sizeof(buffer), "%Y-%m-%d %H:%M:%SZ", &tm);
     }
 
-    std::string origin = state.loadedFrom.empty() ? "(unknown)" : state.loadedFrom;
-
-    f("NNUE evaluation using " + evalfilePath + " (" + std::to_string(size / (1024 * 1024))
-      + "MiB, (" + std::to_string(state.weights->featureTransformer->InputDimensions) + ", "
-      + std::to_string(state.weights->network[0].TransformedFeatureDimensions) + ", "
-      + std::to_string(state.weights->network[0].FC_0_OUTPUTS) + ", "
-      + std::to_string(state.weights->network[0].FC_1_OUTPUTS) + ", 1))\n"
-      + "    source: " + origin + "\n    loaded: " + (loadedAt ? buffer : "never"));
+    if (f)
+    {
+        size_t size = sizeof(featureTransformer) + sizeof(Arch) * LayerStacks;
+        f("NNUE evaluation using " + evalfilePath + " (" + std::to_string(size / (1024 * 1024))
+          + "MiB, (" + std::to_string(featureTransformer.InputDimensions) + ", "
+          + std::to_string(network[0].TransformedFeatureDimensions) + ", "
+          + std::to_string(network[0].FC_0_OUTPUTS) + ", " + std::to_string(network[0].FC_1_OUTPUTS)
+          + ", 1))");
+    }
 }
 
 
@@ -441,17 +245,11 @@ Network<Arch, Transformer>::trace_evaluate(const Position&                      
 
     NnueEvalTrace t{};
     t.correctBucket = (pos.count<ALL_PIECES>() - 1) / 4;
-    auto storage    = weights_handle();
-    if (!storage)
-    {
-        assert(storage && "NNUE weights not initialized");
-        return t;
-    }
     for (IndexType bucket = 0; bucket < LayerStacks; ++bucket)
     {
-        const auto materialist = storage->featureTransformer->transform(pos, accumulatorStack, cache,
-                                                                        transformedFeatures, bucket);
-        const auto positional = storage->network[bucket].propagate(transformedFeatures);
+        const auto materialist =
+          featureTransformer.transform(pos, accumulatorStack, cache, transformedFeatures, bucket);
+        const auto positional = network[bucket].propagate(transformedFeatures);
 
         t.psqt[bucket]       = static_cast<Value>(materialist / OutputScale);
         t.positional[bucket] = static_cast<Value>(positional / OutputScale);
@@ -462,57 +260,21 @@ Network<Arch, Transformer>::trace_evaluate(const Position&                      
 
 
 template<typename Arch, typename Transformer>
-bool Network<Arch, Transformer>::load_user_net(const std::string& dir,
-                                               const std::string& evalfilePath,
-                                               std::string&       resolvedPathOut) {
-    namespace fs = std::filesystem;
+void Network<Arch, Transformer>::load_user_net(const std::string& dir,
+                                               const std::string& evalfilePath) {
+    std::ifstream stream(dir + evalfilePath, std::ios::binary);
+    auto          description = load(stream);
 
-    const fs::path basePath = dir.empty() ? fs::path(evalfilePath) : fs::path(dir) / evalfilePath;
-
-    std::error_code ec;
-    fs::path        resolvedPath = fs::absolute(basePath, ec);
-    if (ec)
-        resolvedPath = basePath;
-
-    resolvedPath = resolvedPath.lexically_normal();
-    resolvedPathOut = resolvedPath.string();
-
-    std::optional<fs::file_time_type> candidateTimestamp;
-    auto                               timestamp = fs::last_write_time(resolvedPath, ec);
-    if (!ec)
-        candidateTimestamp = timestamp;
-
-    const bool hasLoadedWeights = available.load(std::memory_order_relaxed)
-                                  && bool(weights_handle()) && evalFile.current == evalfilePath
-                                  && !evalFile.resolvedPath.empty()
-                                  && evalFile.resolvedPath == resolvedPathOut;
-
-    if (hasLoadedWeights && evalFile.lastWriteTime && candidateTimestamp
-        && *evalFile.lastWriteTime == *candidateTimestamp)
+    if (description.has_value())
     {
-        resolvedPathOut = evalFile.resolvedPath;
-        return true;
+        evalFile.current        = evalfilePath;
+        evalFile.netDescription = description.value();
     }
-
-    std::ifstream stream(resolvedPath, std::ios::binary);
-    if (!stream)
-        return false;
-
-    auto description = load(stream);
-
-    if (!description.has_value())
-        return false;
-
-    evalFile.current        = evalfilePath;
-    evalFile.netDescription = description.value();
-    evalFile.resolvedPath   = resolvedPathOut;
-    evalFile.lastWriteTime  = candidateTimestamp;
-    return true;
 }
 
 
 template<typename Arch, typename Transformer>
-bool Network<Arch, Transformer>::load_internal() {
+void Network<Arch, Transformer>::load_internal() {
     // C++ way to prepare a buffer for a memory stream
     class MemoryBuffer: public std::basic_streambuf<char> {
        public:
@@ -528,52 +290,55 @@ bool Network<Arch, Transformer>::load_internal() {
                         size_t(embedded.size));
 
     std::istream stream(&buffer);
-    auto description = load(stream);
+    auto         description = load(stream);
 
-    if (!description.has_value())
-        return false;
-
-    evalFile.current        = evalFile.defaultName;
-    evalFile.netDescription = description.value();
-    evalFile.resolvedPath   = "<internal>";
-    evalFile.lastWriteTime  = std::nullopt;
-    return true;
+    if (description.has_value())
+    {
+        evalFile.current        = evalFile.defaultName;
+        evalFile.netDescription = description.value();
+    }
 }
 
 
 template<typename Arch, typename Transformer>
-typename Network<Arch, Transformer>::WeightsPtr
-Network<Arch, Transformer>::allocate_weights() const {
-    return std::make_shared<Weights>();
+void Network<Arch, Transformer>::initialize() {
+    initialized = true;
 }
 
 
 template<typename Arch, typename Transformer>
 bool Network<Arch, Transformer>::save(std::ostream&      stream,
                                       const std::string& name,
-                                      const std::string& netDescription,
-                                      const Weights&     storage) const {
+                                      const std::string& netDescription) const {
     if (name.empty() || name == "None")
         return false;
 
-    return write_parameters(stream, netDescription, storage);
+    return write_parameters(stream, netDescription);
 }
 
 
 template<typename Arch, typename Transformer>
 std::optional<std::string> Network<Arch, Transformer>::load(std::istream& stream) {
+    initialize();
     std::string description;
 
-    auto newWeights = allocate_weights();
-
-    if (!read_parameters(stream, description, *newWeights))
-        return std::nullopt;
-
-    std::atomic_store(&weights, std::move(newWeights));
-
-    return std::make_optional(description);
+    return read_parameters(stream, description) ? std::make_optional(description) : std::nullopt;
 }
 
+
+template<typename Arch, typename Transformer>
+std::size_t Network<Arch, Transformer>::get_content_hash() const {
+    if (!initialized)
+        return 0;
+
+    std::size_t h = 0;
+    hash_combine(h, featureTransformer);
+    for (auto&& layerstack : network)
+        hash_combine(h, layerstack);
+    hash_combine(h, evalFile);
+    hash_combine(h, static_cast<int>(embeddedType));
+    return h;
+}
 
 // Read network header
 template<typename Arch, typename Transformer>
@@ -608,18 +373,17 @@ bool Network<Arch, Transformer>::write_header(std::ostream&      stream,
 
 template<typename Arch, typename Transformer>
 bool Network<Arch, Transformer>::read_parameters(std::istream& stream,
-                                                 std::string&  netDescription,
-                                                 Weights&      storage) const {
+                                                 std::string&  netDescription) {
     std::uint32_t hashValue;
     if (!read_header(stream, &hashValue, &netDescription))
         return false;
     if (hashValue != Network::hash)
         return false;
-    if (!Detail::read_parameters(stream, *storage.featureTransformer))
+    if (!Detail::read_parameters(stream, featureTransformer))
         return false;
     for (std::size_t i = 0; i < LayerStacks; ++i)
     {
-        if (!Detail::read_parameters(stream, storage.network[i]))
+        if (!Detail::read_parameters(stream, network[i]))
             return false;
     }
     return stream && stream.peek() == std::ios::traits_type::eof();
@@ -628,15 +392,14 @@ bool Network<Arch, Transformer>::read_parameters(std::istream& stream,
 
 template<typename Arch, typename Transformer>
 bool Network<Arch, Transformer>::write_parameters(std::ostream&      stream,
-                                                  const std::string& netDescription,
-                                                  const Weights&     storage) const {
+                                                  const std::string& netDescription) const {
     if (!write_header(stream, Network::hash, netDescription))
         return false;
-    if (!Detail::write_parameters(stream, *storage.featureTransformer))
+    if (!Detail::write_parameters(stream, featureTransformer))
         return false;
     for (std::size_t i = 0; i < LayerStacks; ++i)
     {
-        if (!Detail::write_parameters(stream, storage.network[i]))
+        if (!Detail::write_parameters(stream, network[i]))
             return false;
     }
     return bool(stream);

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -19,7 +19,7 @@
 #ifndef NETWORK_H_INCLUDED
 #define NETWORK_H_INCLUDED
 
-#include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <iostream>
@@ -29,9 +29,8 @@
 #include <string_view>
 #include <tuple>
 #include <utility>
-#include <ctime>
 
-#include "../memory.h"
+#include "../misc.h"
 #include "../types.h"
 #include "nnue_accumulator.h"
 #include "nnue_architecture.h"
@@ -52,53 +51,28 @@ enum class EmbeddedNNUEType {
 
 using NetworkOutput = std::tuple<Value, Value>;
 
+// The network must be a trivial type, i.e. the memory must be in-line.
+// This is required to allow sharing the network via shared memory, as
+// there is no way to run destructors.
 template<typename Arch, typename Transformer>
 class Network {
     static constexpr IndexType FTDimensions = Arch::TransformedFeatureDimensions;
 
    public:
-    struct Weights {
-        Weights();
-        LargePagePtr<Transformer> featureTransformer;
-        AlignedPtr<Arch[]>        network;
-    };
-    using WeightsPtr = std::shared_ptr<Weights>;
-
     Network(EvalFile file, EmbeddedNNUEType type) :
-        weights(std::make_shared<Weights>()),
         evalFile(file),
-        embeddedType(type),
-        versionCounter(0),
-        available(false),
-        lastLoadedTime(0),
-        lastLoadedFromPtr(nullptr) {}
+        embeddedType(type) {}
 
-    Network(const Network& other);
-    Network(Network&& other) = default;
+    Network(const Network& other) = default;
+    Network(Network&& other)      = default;
 
-    Network& operator=(const Network& other);
-    Network& operator=(Network&& other) = default;
+    Network& operator=(const Network& other) = default;
+    Network& operator=(Network&& other)      = default;
 
-    bool load(const std::string& rootDirectory, std::string evalfilePath);
+    void load(const std::string& rootDirectory, std::string evalfilePath);
     bool save(const std::optional<std::string>& filename) const;
 
-    WeightsPtr weights_handle() const;
-    std::uint64_t version() const;
-    bool          is_available() const;
-    std::time_t   loaded_time() const;
-    std::string loaded_from() const;
-
-    struct StateSnapshot {
-        WeightsPtr     weights;
-        std::uint64_t  version;
-        bool           available;
-        std::time_t    loadedAt;
-        std::string    loadedFrom;
-        std::string    currentFile;
-        std::string    description;
-    };
-
-    [[nodiscard]] StateSnapshot snapshot() const;
+    std::size_t get_content_hash() const;
 
     NetworkOutput evaluate(const Position&                         pos,
                            AccumulatorStack&                       accumulatorStack,
@@ -111,42 +85,36 @@ class Network {
                                  AccumulatorCaches::Cache<FTDimensions>* cache) const;
 
    private:
-    bool load_user_net(const std::string&, const std::string&, std::string& resolvedPathOut);
-    bool load_internal();
+    void load_user_net(const std::string&, const std::string&);
+    void load_internal();
 
-    WeightsPtr allocate_weights() const;
+    void initialize();
 
-    bool save(std::ostream&, const std::string&, const std::string&, const Weights&) const;
+    bool                       save(std::ostream&, const std::string&, const std::string&) const;
     std::optional<std::string> load(std::istream&);
 
     bool read_header(std::istream&, std::uint32_t*, std::string*) const;
     bool write_header(std::ostream&, std::uint32_t, const std::string&) const;
 
-    bool read_parameters(std::istream&, std::string&, Weights&) const;
-    bool write_parameters(std::ostream&, const std::string&, const Weights&) const;
+    bool read_parameters(std::istream&, std::string&);
+    bool write_parameters(std::ostream&, const std::string&) const;
 
     // Input feature converter
-    WeightsPtr weights;
+    Transformer featureTransformer;
+
+    // Evaluation function
+    Arch network[LayerStacks];
 
     EvalFile         evalFile;
     EmbeddedNNUEType embeddedType;
 
-    std::atomic<std::uint64_t> versionCounter;
-    std::atomic<bool>          available;
-    std::atomic<std::time_t>             lastLoadedTime;
-    std::shared_ptr<const std::string>   lastLoadedFromPtr;
-
-    void set_loaded_from(std::string value);
-    void record_load(const std::string& resolvedPath, const std::string& evalfilePath);
-    void clear_loaded_metadata();
+    bool initialized = false;
 
     // Hash value of evaluation function structure
     static constexpr std::uint32_t hash = Transformer::get_hash_value() ^ Arch::get_hash_value();
 
     template<IndexType Size>
     friend struct AccumulatorCaches::Cache;
-
-    friend class AccumulatorStack;
 };
 
 // Definitions of the network types
@@ -159,10 +127,12 @@ using BigNetworkArchitecture = NetworkArchitecture<TransformedFeatureDimensionsB
 
 using NetworkBig   = Network<BigNetworkArchitecture, BigFeatureTransformer>;
 using NetworkSmall = Network<SmallNetworkArchitecture, SmallFeatureTransformer>;
+
+
 struct Networks {
-    Networks(NetworkBig&& nB, NetworkSmall&& nS) :
-        big(std::move(nB)),
-        small(std::move(nS)) {}
+    Networks(std::unique_ptr<NetworkBig>&& nB, std::unique_ptr<NetworkSmall>&& nS) :
+        big(std::move(*nB)),
+        small(std::move(*nS)) {}
 
     NetworkBig   big;
     NetworkSmall small;
@@ -170,5 +140,23 @@ struct Networks {
 
 
 }  // namespace Stockfish
+
+template<typename ArchT, typename FeatureTransformerT>
+struct std::hash<Stockfish::Eval::NNUE::Network<ArchT, FeatureTransformerT>> {
+    std::size_t operator()(
+      const Stockfish::Eval::NNUE::Network<ArchT, FeatureTransformerT>& network) const noexcept {
+        return network.get_content_hash();
+    }
+};
+
+template<>
+struct std::hash<Stockfish::Eval::NNUE::Networks> {
+    std::size_t operator()(const Stockfish::Eval::NNUE::Networks& networks) const noexcept {
+        std::size_t h = 0;
+        Stockfish::hash_combine(h, networks.big);
+        Stockfish::hash_combine(h, networks.small);
+        return h;
+    }
+};
 
 #endif

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -22,12 +22,9 @@
 #define NNUE_ACCUMULATOR_H_INCLUDED
 
 #include <array>
-#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
-#include <memory>
-#include <vector>
 
 #include "../types.h"
 #include "nnue_architecture.h"
@@ -50,7 +47,7 @@ template<IndexType Size>
 struct alignas(CacheLineSize) Accumulator {
     std::int16_t               accumulation[COLOR_NB][Size];
     std::int32_t               psqtAccumulation[COLOR_NB][PSQTBuckets];
-    std::array<bool, COLOR_NB> computed;
+    std::array<bool, COLOR_NB> computed = {};
 };
 
 
@@ -73,12 +70,12 @@ struct AccumulatorCaches {
         struct alignas(CacheLineSize) Entry {
             BiasType       accumulation[Size];
             PSQTWeightType psqtAccumulation[PSQTBuckets];
-            Bitboard       byColorBB[COLOR_NB];
-            Bitboard       byTypeBB[PIECE_TYPE_NB];
+            Piece          pieces[SQUARE_NB];
+            Bitboard       pieceBB;
 
             // To initialize a refresh entry, we set all its bitboards empty,
             // so we put the biases in the accumulation, without any weights on top
-            void reset(const BiasType* biases) {
+            void clear(const BiasType* biases) {
 
                 std::memcpy(accumulation, biases, sizeof(accumulation));
                 std::memset((uint8_t*) this + offsetof(Entry, psqtAccumulation), 0,
@@ -86,12 +83,11 @@ struct AccumulatorCaches {
             }
         };
 
-        void reset_from_biases(const BiasType* biases) {
-            assert(biases);
-
+        template<typename Network>
+        void clear(const Network& network) {
             for (auto& entries1D : entries)
                 for (auto& entry : entries1D)
-                    entry.reset(biases);
+                    entry.clear(network.featureTransformer.biases);
         }
 
         std::array<Entry, COLOR_NB>& operator[](Square sq) { return entries[sq]; }
@@ -99,97 +95,14 @@ struct AccumulatorCaches {
         std::array<std::array<Entry, COLOR_NB>, SQUARE_NB> entries;
     };
 
-    struct CacheBinding {
-        template<typename Network, IndexType Size>
-        void prime(const Network& network, Cache<Size>& cache) {
-            auto handle = network.weights_handle();
-            assert(handle);
-            auto alias = std::shared_ptr<void>(handle, static_cast<void*>(handle.get()));
-            cache.reset_from_biases(handle->featureTransformer->biases);
-            weights = alias;
-            version = network.version();
-        }
-
-        template<typename Network, IndexType Size>
-        bool ensure(const Network& network, Cache<Size>& cache) {
-            return ensure_internal(network, cache, false);
-        }
-
-        void invalidate() {
-            version = 0;
-            weights.reset();
-        }
-
-        template<typename Network, IndexType Size>
-        bool ensure_internal(const Network& network, Cache<Size>& cache, bool force) {
-            auto handle = network.weights_handle();
-            if (!handle)
-                return false;
-
-            auto alias = std::shared_ptr<void>(handle, static_cast<void*>(handle.get()));
-            auto locked = weights.lock();
-            bool refresh = force || !locked || locked.get() != alias.get()
-                           || version != network.version();
-
-            if (refresh)
-            {
-                cache.reset_from_biases(handle->featureTransformer->biases);
-                weights = alias;
-                version = network.version();
-            }
-
-            return true;
-        }
-
-        std::weak_ptr<void> weights;
-        std::uint64_t       version = 0;
-    };
-
     template<typename Networks>
     void clear(const Networks& networks) {
-        if (auto weights = networks.big.weights_handle())
-        {
-            bigCache.binding.prime(networks.big, bigCache.cache);
-        }
-        else
-            bigCache.binding.invalidate();
-
-        if (auto weights = networks.small.weights_handle())
-        {
-            smallCache.binding.prime(networks.small, smallCache.cache);
-        }
-        else
-            smallCache.binding.invalidate();
+        big.clear(networks.big);
+        small.clear(networks.small);
     }
 
-    template<typename Network>
-    Cache<TransformedFeatureDimensionsBig>& cache_for_big(const Network& network) {
-        bigCache.binding.ensure(network, bigCache.cache);
-        return bigCache.cache;
-    }
-
-    template<typename Network>
-    Cache<TransformedFeatureDimensionsSmall>& cache_for_small(const Network& network) {
-        smallCache.binding.ensure(network, smallCache.cache);
-        return smallCache.cache;
-    }
-
-    void invalidate_big() { bigCache.binding.invalidate(); }
-
-    void invalidate_small() { smallCache.binding.invalidate(); }
-
-    struct BigCacheState {
-        Cache<TransformedFeatureDimensionsBig> cache;
-        CacheBinding                           binding;
-    };
-
-    struct SmallCacheState {
-        Cache<TransformedFeatureDimensionsSmall> cache;
-        CacheBinding                             binding;
-    };
-
-    BigCacheState   bigCache;
-    SmallCacheState smallCache;
+    Cache<TransformedFeatureDimensionsBig>   big;
+    Cache<TransformedFeatureDimensionsSmall> small;
 };
 
 
@@ -228,10 +141,6 @@ struct AccumulatorState {
 
 class AccumulatorStack {
    public:
-    AccumulatorStack() :
-        accumulators(MAX_PLY + 1),
-        size{1} {}
-
     [[nodiscard]] const AccumulatorState& latest() const noexcept;
 
     void reset() noexcept;
@@ -264,8 +173,8 @@ class AccumulatorStack {
                                      const FeatureTransformer<Dimensions>& featureTransformer,
                                      const std::size_t                     end) noexcept;
 
-    std::vector<AccumulatorState> accumulators;
-    std::size_t                   size;
+    std::array<AccumulatorState, MAX_PLY + 1> accumulators;
+    std::size_t                               size = 1;
 };
 
 }  // namespace Stockfish::Eval::NNUE

--- a/src/nnue/nnue_architecture.h
+++ b/src/nnue/nnue_architecture.h
@@ -97,7 +97,7 @@ struct NetworkArchitecture {
             && fc_2.write_parameters(stream);
     }
 
-    std::int32_t propagate(const TransformedFeatureType* transformedFeatures) {
+    std::int32_t propagate(const TransformedFeatureType* transformedFeatures) const {
         struct alignas(CacheLineSize) Buffer {
             alignas(CacheLineSize) typename decltype(fc_0)::OutputBuffer fc_0_out;
             alignas(CacheLineSize) typename decltype(ac_sqr_0)::OutputType
@@ -136,8 +136,28 @@ struct NetworkArchitecture {
 
         return outputValue;
     }
+
+    std::size_t get_content_hash() const {
+        std::size_t h = 0;
+        hash_combine(h, fc_0.get_content_hash());
+        hash_combine(h, ac_sqr_0.get_content_hash());
+        hash_combine(h, ac_0.get_content_hash());
+        hash_combine(h, fc_1.get_content_hash());
+        hash_combine(h, ac_1.get_content_hash());
+        hash_combine(h, fc_2.get_content_hash());
+        hash_combine(h, get_hash_value());
+        return h;
+    }
 };
 
 }  // namespace Stockfish::Eval::NNUE
+
+template<Stockfish::Eval::NNUE::IndexType L1, int L2, int L3>
+struct std::hash<Stockfish::Eval::NNUE::NetworkArchitecture<L1, L2, L3>> {
+    std::size_t
+    operator()(const Stockfish::Eval::NNUE::NetworkArchitecture<L1, L2, L3>& arch) const noexcept {
+        return arch.get_content_hash();
+    }
+};
 
 #endif  // #ifndef NNUE_ARCHITECTURE_H_INCLUDED

--- a/src/nnue/nnue_common.h
+++ b/src/nnue/nnue_common.h
@@ -258,8 +258,8 @@ inline void write_leb_128(std::ostream& stream, const IntType* values, std::size
         }
     };
 
-    auto write = [&](std::uint8_t byte) {
-        buf[buf_pos++] = byte;
+    auto write = [&](std::uint8_t b) {
+        buf[buf_pos++] = b;
         if (buf_pos == BUF_SIZE)
             flush();
     };

--- a/src/nnue/nnue_misc.cpp
+++ b/src/nnue/nnue_misc.cpp
@@ -120,12 +120,11 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
             format_cp_compact(value, &board[y + 2][x + 2], pos);
     };
 
-    AccumulatorStack accumulators;
+    auto accumulators = std::make_unique<AccumulatorStack>();
 
     // We estimate the value of each piece by doing a differential evaluation from
     // the current base eval, simulating the removal of the piece from its square.
-    auto& cacheToUse = caches.cache_for_big(networks.big);
-    auto [psqt, positional] = networks.big.evaluate(pos, accumulators, &cacheToUse);
+    auto [psqt, positional] = networks.big.evaluate(pos, *accumulators, &caches.big);
     Value base              = psqt + positional;
     base                    = pos.side_to_move() == WHITE ? base : -base;
 
@@ -140,9 +139,8 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
             {
                 pos.remove_piece(sq);
 
-                accumulators.reset();
-                auto& loopCache = caches.cache_for_big(networks.big);
-                std::tie(psqt, positional) = networks.big.evaluate(pos, accumulators, &loopCache);
+                accumulators->reset();
+                std::tie(psqt, positional) = networks.big.evaluate(pos, *accumulators, &caches.big);
                 Value eval                 = psqt + positional;
                 eval                       = pos.side_to_move() == WHITE ? eval : -eval;
                 v                          = base - eval;
@@ -158,9 +156,8 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
         ss << board[row] << '\n';
     ss << '\n';
 
-    accumulators.reset();
-    auto& traceCache = caches.cache_for_big(networks.big);
-    auto t = networks.big.trace_evaluate(pos, accumulators, &traceCache);
+    accumulators->reset();
+    auto t = networks.big.trace_evaluate(pos, *accumulators, &caches.big);
 
     ss << " NNUE network contributions "
        << (pos.side_to_move() == WHITE ? "(White to move)" : "(Black to move)") << std::endl

--- a/src/nnue/nnue_misc.h
+++ b/src/nnue/nnue_misc.h
@@ -20,10 +20,10 @@
 #define NNUE_MISC_H_INCLUDED
 
 #include <cstddef>
-#include <filesystem>
-#include <optional>
+#include <memory>
 #include <string>
 
+#include "../misc.h"
 #include "../types.h"
 #include "nnue_architecture.h"
 
@@ -33,20 +33,16 @@ class Position;
 
 namespace Eval::NNUE {
 
+// EvalFile uses fixed string types because it's part of the network structure which must be trivial.
 struct EvalFile {
     // Default net name, will use one of the EvalFileDefaultName* macros defined
     // in evaluate.h
-    std::string defaultName;
+    FixedString<256> defaultName;
     // Selected net name, either via uci option or default
-    std::string current;
+    FixedString<256> current;
     // Net description extracted from the net file
-    std::string netDescription;
-    // Fully resolved path from which the network was loaded, if any
-    std::string resolvedPath;
-    // Timestamp of the backing file when the weights were last loaded
-    std::optional<std::filesystem::file_time_type> lastWriteTime;
+    FixedString<256> netDescription;
 };
-
 
 struct NnueEvalTrace {
     static_assert(LayerStacks == PSQTBuckets);
@@ -63,5 +59,16 @@ std::string trace(Position& pos, const Networks& networks, AccumulatorCaches& ca
 
 }  // namespace Stockfish::Eval::NNUE
 }  // namespace Stockfish
+
+template<>
+struct std::hash<Stockfish::Eval::NNUE::EvalFile> {
+    std::size_t operator()(const Stockfish::Eval::NNUE::EvalFile& evalFile) const noexcept {
+        std::size_t h = 0;
+        Stockfish::hash_combine(h, evalFile.defaultName);
+        Stockfish::hash_combine(h, evalFile.current);
+        Stockfish::hash_combine(h, evalFile.netDescription);
+        return h;
+    }
+};
 
 #endif  // #ifndef NNUE_MISC_H_INCLUDED

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -302,36 +302,13 @@ Search::Worker::Worker(SharedState&                    sharedState,
     tt(sharedState.tt),
     networks(sharedState.networks),
     refreshTable(networks[token]) {
-    const auto& netsForToken = networks[token];
-    bigWeightsHandle         = netsForToken.big.weights_handle();
-    smallWeightsHandle       = netsForToken.small.weights_handle();
-    bigWeightsVersion        = netsForToken.big.version();
-    smallWeightsVersion      = netsForToken.small.version();
     clear();
 }
 
 void Search::Worker::ensure_network_replicated() {
-    const auto& nets = networks[numaAccessToken];
-
-    auto newBig   = nets.big.weights_handle();
-    auto newSmall = nets.small.weights_handle();
-
-    bool bigChanged = newBig != bigWeightsHandle || nets.big.version() != bigWeightsVersion;
-    bool smallChanged = newSmall != smallWeightsHandle || nets.small.version() != smallWeightsVersion;
-
-    if (!bigChanged && !smallChanged)
-        return;
-
-    bigWeightsHandle   = std::move(newBig);
-    smallWeightsHandle = std::move(newSmall);
-
-    if (bigChanged)
-        refreshTable.invalidate_big();
-    if (smallChanged)
-        refreshTable.invalidate_small();
-
-    bigWeightsVersion   = nets.big.version();
-    smallWeightsVersion = nets.small.version();
+    // Access once to force lazy initialization.
+    // We do this because we want to avoid initialization during search.
+    (void) (networks[numaAccessToken]);
 }
 
 bool Search::Worker::experience_guidance_available() const { return experienceAvailable; }

--- a/src/search.h
+++ b/src/search.h
@@ -135,19 +135,19 @@ struct LimitsType {
 // The UCI stores the uci options, thread pool, and transposition table.
 // This struct is used to easily forward data to the Search::Worker class.
 struct SharedState {
-    SharedState(const OptionsMap&                               optionsMap,
-                ThreadPool&                                     threadPool,
-                TranspositionTable&                             transpositionTable,
-                const LazyNumaReplicated<Eval::NNUE::Networks>& nets) :
+    SharedState(const OptionsMap&                                         optionsMap,
+                ThreadPool&                                               threadPool,
+                TranspositionTable&                                       transpositionTable,
+                const LazyNumaReplicatedSystemWide<Eval::NNUE::Networks>& nets) :
         options(optionsMap),
         threads(threadPool),
         tt(transpositionTable),
         networks(nets) {}
 
-    const OptionsMap&                               options;
-    ThreadPool&                                     threads;
-    TranspositionTable&                             tt;
-    const LazyNumaReplicated<Eval::NNUE::Networks>& networks;
+    const OptionsMap&                                         options;
+    ThreadPool&                                               threads;
+    TranspositionTable&                                       tt;
+    const LazyNumaReplicatedSystemWide<Eval::NNUE::Networks>& networks;
 };
 
 class Worker;
@@ -352,18 +352,14 @@ class Worker {
 
     Tablebases::Config tbConfig;
 
-    const OptionsMap&                               options;
-    ThreadPool&                                     threads;
-    TranspositionTable&                             tt;
-    const LazyNumaReplicated<Eval::NNUE::Networks>& networks;
+    const OptionsMap&                                         options;
+    ThreadPool&                                               threads;
+    TranspositionTable&                                       tt;
+    const LazyNumaReplicatedSystemWide<Eval::NNUE::Networks>& networks;
 
     // Used by NNUE
     Eval::NNUE::AccumulatorStack  accumulatorStack;
     Eval::NNUE::AccumulatorCaches refreshTable;
-    Eval::NNUE::NetworkBig::WeightsPtr   bigWeightsHandle;
-    Eval::NNUE::NetworkSmall::WeightsPtr smallWeightsHandle;
-    std::uint64_t                        bigWeightsVersion   = 0;
-    std::uint64_t                        smallWeightsVersion = 0;
 
     bool experienceAvailable = false;
 

--- a/src/shm.h
+++ b/src/shm.h
@@ -1,0 +1,634 @@
+/*
+  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+  Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
+
+  Stockfish is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Stockfish is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef SHM_H_INCLUDED
+#define SHM_H_INCLUDED
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <new>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+#if !defined(_WIN32) && !defined(__ANDROID__)
+    #include "shm_linux.h"
+#endif
+
+#if defined(__ANDROID__)
+    #include <limits.h>
+    #define SF_MAX_SEM_NAME_LEN NAME_MAX
+#endif
+
+#include "types.h"
+
+#include "memory.h"
+
+#if defined(_WIN32)
+
+    #if _WIN32_WINNT < 0x0601
+        #undef _WIN32_WINNT
+        #define _WIN32_WINNT 0x0601  // Force to include needed API prototypes
+    #endif
+
+    #if !defined(NOMINMAX)
+        #define NOMINMAX
+    #endif
+    #include <windows.h>
+#else
+    #include <cstring>
+    #include <fcntl.h>
+    #include <pthread.h>
+    #include <semaphore.h>
+    #include <sys/mman.h>
+    #include <sys/stat.h>
+    #include <unistd.h>
+#endif
+
+
+#if defined(__APPLE__)
+    #include <mach-o/dyld.h>
+    #include <sys/syslimits.h>
+
+#elif defined(__sun)
+    #include <stdlib.h>
+
+#elif defined(__FreeBSD__)
+    #include <sys/sysctl.h>
+    #include <sys/types.h>
+    #include <unistd.h>
+
+#elif defined(__NetBSD__) || defined(__DragonFly__) || defined(__linux__)
+    #include <limits.h>
+    #include <unistd.h>
+#endif
+
+
+namespace Stockfish {
+
+// argv[0] CANNOT be used because we need to identify the executable.
+// argv[0] contains the command used to invoke it, which does not involve the full path.
+// Just using a path is not fully resilient either, as the executable could
+// have changed if it wasn't locked by the OS. Ideally we would hash the executable
+// but it's not really that important at this point.
+// If the path is longer than 4095 bytes the hash will be computed from an unspecified
+// amount of bytes of the path; in particular it can a hash of an empty string.
+
+inline std::string getExecutablePathHash() {
+    char        executable_path[4096] = {0};
+    std::size_t path_length           = 0;
+
+#if defined(_WIN32)
+    path_length = GetModuleFileNameA(NULL, executable_path, sizeof(executable_path));
+
+#elif defined(__APPLE__)
+    uint32_t size = sizeof(executable_path);
+    if (_NSGetExecutablePath(executable_path, &size) == 0)
+    {
+        path_length = std::strlen(executable_path);
+    }
+
+#elif defined(__sun)  // Solaris
+    const char* path = getexecname();
+    if (path)
+    {
+        std::strncpy(executable_path, path, sizeof(executable_path) - 1);
+        path_length = std::strlen(executable_path);
+    }
+
+#elif defined(__FreeBSD__)
+    size_t size   = sizeof(executable_path);
+    int    mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1};
+    if (sysctl(mib, 4, executable_path, &size, NULL, 0) == 0)
+    {
+        path_length = std::strlen(executable_path);
+    }
+
+#elif defined(__NetBSD__) || defined(__DragonFly__)
+    ssize_t len = readlink("/proc/curproc/exe", executable_path, sizeof(executable_path) - 1);
+    if (len >= 0)
+    {
+        executable_path[len] = '\0';
+        path_length          = len;
+    }
+
+#elif defined(__linux__)
+    ssize_t len = readlink("/proc/self/exe", executable_path, sizeof(executable_path) - 1);
+    if (len >= 0)
+    {
+        executable_path[len] = '\0';
+        path_length          = len;
+    }
+
+#endif
+
+    // In case of any error the path will be empty.
+    return std::string(executable_path, path_length);
+}
+
+enum class SystemWideSharedConstantAllocationStatus {
+    NoAllocation,
+    LocalMemory,
+    SharedMemory
+};
+
+#if defined(_WIN32)
+
+inline std::string GetLastErrorAsString(DWORD error) {
+    //Get the error message ID, if any.
+    DWORD errorMessageID = error;
+    if (errorMessageID == 0)
+    {
+        return std::string();  //No error message has been recorded
+    }
+
+    LPSTR messageBuffer = nullptr;
+
+    //Ask Win32 to give us the string version of that message ID.
+    //The parameters we pass in, tell Win32 to create the buffer that holds the message for us (because we don't yet know how long the message string will be).
+    size_t size = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM
+                                   | FORMAT_MESSAGE_IGNORE_INSERTS,
+                                 NULL, errorMessageID, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                                 (LPSTR) &messageBuffer, 0, NULL);
+
+    //Copy the error message into a std::string.
+    std::string message(messageBuffer, size);
+
+    //Free the Win32's string's buffer.
+    LocalFree(messageBuffer);
+
+    return message;
+}
+
+// Utilizes shared memory to store the value. It is deduplicated system-wide (for the single user).
+template<typename T>
+class SharedMemoryBackend {
+   public:
+    enum class Status {
+        Success,
+        LargePageAllocationError,
+        FileMappingError,
+        MapViewError,
+        MutexCreateError,
+        MutexWaitError,
+        MutexReleaseError,
+        NotInitialized
+    };
+
+    static constexpr DWORD IS_INITIALIZED_VALUE = 1;
+
+    SharedMemoryBackend() :
+        status(Status::NotInitialized) {};
+
+    SharedMemoryBackend(const std::string& shm_name, const T& value) :
+        status(Status::NotInitialized) {
+
+        initialize(shm_name, value);
+    }
+
+    bool is_valid() const { return status == Status::Success; }
+
+    std::optional<std::string> get_error_message() const {
+        switch (status)
+        {
+        case Status::Success :
+            return std::nullopt;
+        case Status::LargePageAllocationError :
+            return "Failed to allocate large page memory";
+        case Status::FileMappingError :
+            return "Failed to create file mapping: " + last_error_message;
+        case Status::MapViewError :
+            return "Failed to map view: " + last_error_message;
+        case Status::MutexCreateError :
+            return "Failed to create mutex: " + last_error_message;
+        case Status::MutexWaitError :
+            return "Failed to wait on mutex: " + last_error_message;
+        case Status::MutexReleaseError :
+            return "Failed to release mutex: " + last_error_message;
+        case Status::NotInitialized :
+            return "Not initialized";
+        default :
+            return "Unknown error";
+        }
+    }
+
+    void* get() const { return is_valid() ? pMap : nullptr; }
+
+    ~SharedMemoryBackend() { cleanup(); }
+
+    SharedMemoryBackend(const SharedMemoryBackend&)            = delete;
+    SharedMemoryBackend& operator=(const SharedMemoryBackend&) = delete;
+
+    SharedMemoryBackend(SharedMemoryBackend&& other) noexcept :
+        pMap(other.pMap),
+        hMapFile(other.hMapFile),
+        status(other.status),
+        last_error_message(std::move(other.last_error_message)) {
+
+        other.pMap     = nullptr;
+        other.hMapFile = 0;
+        other.status   = Status::NotInitialized;
+    }
+
+    SharedMemoryBackend& operator=(SharedMemoryBackend&& other) noexcept {
+        if (this != &other)
+        {
+            cleanup();
+            pMap               = other.pMap;
+            hMapFile           = other.hMapFile;
+            status             = other.status;
+            last_error_message = std::move(other.last_error_message);
+
+            other.pMap     = nullptr;
+            other.hMapFile = 0;
+            other.status   = Status::NotInitialized;
+        }
+        return *this;
+    }
+
+    SystemWideSharedConstantAllocationStatus get_status() const {
+        return status == Status::Success ? SystemWideSharedConstantAllocationStatus::SharedMemory
+                                         : SystemWideSharedConstantAllocationStatus::NoAllocation;
+    }
+
+   private:
+    void initialize(const std::string& shm_name, const T& value) {
+        const size_t total_size = sizeof(T) + sizeof(IS_INITIALIZED_VALUE);
+
+        // Try allocating with large pages first.
+        hMapFile = windows_try_with_large_page_priviliges(
+          [&](size_t largePageSize) {
+              const size_t total_size_aligned =
+                (total_size + largePageSize - 1) / largePageSize * largePageSize;
+
+    #if defined(_WIN64)
+              DWORD total_size_low  = total_size_aligned & 0xFFFFFFFFu;
+              DWORD total_size_high = total_size_aligned >> 32u;
+    #else
+              DWORD total_size_low  = total_size_aligned;
+              DWORD total_size_high = 0;
+    #endif
+
+              return CreateFileMappingA(INVALID_HANDLE_VALUE, NULL,
+                                        PAGE_READWRITE | SEC_COMMIT | SEC_LARGE_PAGES,
+                                        total_size_high, total_size_low, shm_name.c_str());
+          },
+          []() { return (void*) nullptr; });
+
+        // Fallback to normal allocation if no large pages available.
+        if (!hMapFile)
+        {
+            hMapFile = CreateFileMappingA(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, 0,
+                                          static_cast<DWORD>(total_size), shm_name.c_str());
+        }
+
+        if (!hMapFile)
+        {
+            const DWORD err    = GetLastError();
+            last_error_message = GetLastErrorAsString(err);
+            status             = Status::FileMappingError;
+            return;
+        }
+
+        pMap = MapViewOfFile(hMapFile, FILE_MAP_ALL_ACCESS, 0, 0, total_size);
+        if (!pMap)
+        {
+            const DWORD err    = GetLastError();
+            last_error_message = GetLastErrorAsString(err);
+            status             = Status::MapViewError;
+            cleanup_partial();
+            return;
+        }
+
+        // Use named mutex to ensure only one initializer
+        std::string mutex_name = shm_name + "$mutex";
+        HANDLE      hMutex     = CreateMutexA(NULL, FALSE, mutex_name.c_str());
+        if (!hMutex)
+        {
+            const DWORD err    = GetLastError();
+            last_error_message = GetLastErrorAsString(err);
+            status             = Status::MutexCreateError;
+            cleanup_partial();
+            return;
+        }
+
+        DWORD wait_result = WaitForSingleObject(hMutex, INFINITE);
+        if (wait_result != WAIT_OBJECT_0)
+        {
+            const DWORD err    = GetLastError();
+            last_error_message = GetLastErrorAsString(err);
+            status             = Status::MutexWaitError;
+            CloseHandle(hMutex);
+            cleanup_partial();
+            return;
+        }
+
+        // Crucially, we place the object first to ensure alignment.
+        volatile DWORD* is_initialized =
+          std::launder(reinterpret_cast<DWORD*>(reinterpret_cast<char*>(pMap) + sizeof(T)));
+        T* object = std::launder(reinterpret_cast<T*>(pMap));
+
+        if (*is_initialized != IS_INITIALIZED_VALUE)
+        {
+            // First time initialization, message for debug purposes
+            new (object) T{value};
+            *is_initialized = IS_INITIALIZED_VALUE;
+        }
+
+        BOOL release_result = ReleaseMutex(hMutex);
+        CloseHandle(hMutex);
+
+        if (!release_result)
+        {
+            const DWORD err    = GetLastError();
+            last_error_message = GetLastErrorAsString(err);
+            status             = Status::MutexReleaseError;
+            cleanup_partial();
+            return;
+        }
+
+        status = Status::Success;
+    }
+
+    void cleanup_partial() {
+        if (pMap != nullptr)
+        {
+            UnmapViewOfFile(pMap);
+            pMap = nullptr;
+        }
+        if (hMapFile)
+        {
+            CloseHandle(hMapFile);
+            hMapFile = 0;
+        }
+    }
+
+    void cleanup() {
+        if (pMap != nullptr)
+        {
+            UnmapViewOfFile(pMap);
+            pMap = nullptr;
+        }
+        if (hMapFile)
+        {
+            CloseHandle(hMapFile);
+            hMapFile = 0;
+        }
+    }
+
+    void*       pMap     = nullptr;
+    HANDLE      hMapFile = 0;
+    Status      status   = Status::NotInitialized;
+    std::string last_error_message;
+};
+
+#elif !defined(__ANDROID__)
+
+template<typename T>
+class SharedMemoryBackend {
+   public:
+    SharedMemoryBackend() = default;
+
+    SharedMemoryBackend(const std::string& shm_name, const T& value) :
+        shm1(shm::create_shared<T>(shm_name, value)) {}
+
+    void* get() const {
+        const T* ptr = &shm1->get();
+        return reinterpret_cast<void*>(const_cast<T*>(ptr));
+    }
+
+    bool is_valid() const { return shm1 && shm1->is_open() && shm1->is_initialized(); }
+
+    SystemWideSharedConstantAllocationStatus get_status() const {
+        return is_valid() ? SystemWideSharedConstantAllocationStatus::SharedMemory
+                          : SystemWideSharedConstantAllocationStatus::NoAllocation;
+    }
+
+    std::optional<std::string> get_error_message() const {
+        if (!shm1)
+            return "Shared memory not initialized";
+
+        if (!shm1->is_open())
+            return "Shared memory is not open";
+
+        if (!shm1->is_initialized())
+            return "Not initialized";
+
+        return std::nullopt;
+    }
+
+   private:
+    std::optional<shm::SharedMemory<T>> shm1;
+};
+
+#else
+
+// For systems that don't have shared memory, or support is troublesome.
+// The way fallback is done is that we need a dummy backend.
+
+template<typename T>
+class SharedMemoryBackend {
+   public:
+    SharedMemoryBackend() = default;
+
+    SharedMemoryBackend(const std::string& shm_name, const T& value) {}
+
+    void* get() const { return nullptr; }
+
+    bool is_valid() const { return false; }
+
+    SystemWideSharedConstantAllocationStatus get_status() const {
+        return SystemWideSharedConstantAllocationStatus::NoAllocation;
+    }
+
+    std::optional<std::string> get_error_message() const { return "Dummy SharedMemoryBackend"; }
+};
+
+#endif
+
+template<typename T>
+struct SharedMemoryBackendFallback {
+    SharedMemoryBackendFallback() = default;
+
+    SharedMemoryBackendFallback(const std::string&, const T& value) :
+        fallback_object(make_unique_large_page<T>(value)) {}
+
+    void* get() const { return fallback_object.get(); }
+
+    SharedMemoryBackendFallback(const SharedMemoryBackendFallback&)            = delete;
+    SharedMemoryBackendFallback& operator=(const SharedMemoryBackendFallback&) = delete;
+
+    SharedMemoryBackendFallback(SharedMemoryBackendFallback&& other) noexcept :
+        fallback_object(std::move(other.fallback_object)) {}
+
+    SharedMemoryBackendFallback& operator=(SharedMemoryBackendFallback&& other) noexcept {
+        fallback_object = std::move(other.fallback_object);
+        return *this;
+    }
+
+    SystemWideSharedConstantAllocationStatus get_status() const {
+        return fallback_object == nullptr ? SystemWideSharedConstantAllocationStatus::NoAllocation
+                                          : SystemWideSharedConstantAllocationStatus::LocalMemory;
+    }
+
+    std::optional<std::string> get_error_message() const {
+        if (fallback_object == nullptr)
+            return "Not initialized";
+
+        return "Shared memory not supported by the OS. Local allocation fallback.";
+    }
+
+   private:
+    LargePagePtr<T> fallback_object;
+};
+
+// Platform-independent wrapper
+template<typename T>
+struct SystemWideSharedConstant {
+   private:
+    static std::string createHashString(const std::string& input) {
+        size_t hash = std::hash<std::string>{}(input);
+
+        std::stringstream ss;
+        ss << std::hex << std::setfill('0') << hash;
+
+        return ss.str();
+    }
+
+   public:
+    // We can't run the destructor because it may be in a completely different process.
+    // The object stored must also be obviously in-line but we can't check for that, other than some basic checks that cover most cases.
+    static_assert(std::is_trivially_destructible_v<T>);
+    static_assert(std::is_trivially_move_constructible_v<T>);
+    static_assert(std::is_trivially_copy_constructible_v<T>);
+
+    SystemWideSharedConstant() = default;
+
+
+    // Content is addressed by its hash. An additional discriminator can be added to account for differences
+    // that are not present in the content, for example NUMA node allocation.
+    SystemWideSharedConstant(const T& value, std::size_t discriminator = 0) {
+        std::size_t content_hash    = std::hash<T>{}(value);
+        std::size_t executable_hash = std::hash<std::string>{}(getExecutablePathHash());
+
+        std::string shm_name = std::string("Local\\sf_") + std::to_string(content_hash) + "$"
+                             + std::to_string(executable_hash) + "$"
+                             + std::to_string(discriminator);
+
+#if !defined(_WIN32)
+        // POSIX shared memory names must start with a slash
+        shm_name = "/sf_" + createHashString(shm_name);
+
+        // hash name and make sure it is not longer than SF_MAX_SEM_NAME_LEN
+        if (shm_name.size() > SF_MAX_SEM_NAME_LEN)
+        {
+            shm_name = shm_name.substr(0, SF_MAX_SEM_NAME_LEN - 1);
+        }
+#endif
+
+        SharedMemoryBackend<T> shm_backend(shm_name, value);
+
+        if (shm_backend.is_valid())
+        {
+            backend = std::move(shm_backend);
+        }
+        else
+        {
+            backend = SharedMemoryBackendFallback<T>(shm_name, value);
+        }
+    }
+
+    SystemWideSharedConstant(const SystemWideSharedConstant&)            = delete;
+    SystemWideSharedConstant& operator=(const SystemWideSharedConstant&) = delete;
+
+    SystemWideSharedConstant(SystemWideSharedConstant&& other) noexcept :
+        backend(std::move(other.backend)) {}
+
+    SystemWideSharedConstant& operator=(SystemWideSharedConstant&& other) noexcept {
+        backend = std::move(other.backend);
+        return *this;
+    }
+
+    const T& operator*() const { return *std::launder(reinterpret_cast<const T*>(get_ptr())); }
+
+    bool operator==(std::nullptr_t) const noexcept { return get_ptr() == nullptr; }
+
+    bool operator!=(std::nullptr_t) const noexcept { return get_ptr() != nullptr; }
+
+    SystemWideSharedConstantAllocationStatus get_status() const {
+        return std::visit(
+          [](const auto& end) -> SystemWideSharedConstantAllocationStatus {
+              if constexpr (std::is_same_v<std::decay_t<decltype(end)>, std::monostate>)
+              {
+                  return SystemWideSharedConstantAllocationStatus::NoAllocation;
+              }
+              else
+              {
+                  return end.get_status();
+              }
+          },
+          backend);
+    }
+
+    std::optional<std::string> get_error_message() const {
+        return std::visit(
+          [](const auto& end) -> std::optional<std::string> {
+              if constexpr (std::is_same_v<std::decay_t<decltype(end)>, std::monostate>)
+              {
+                  return std::nullopt;
+              }
+              else
+              {
+                  return end.get_error_message();
+              }
+          },
+          backend);
+    }
+
+   private:
+    auto get_ptr() const {
+        return std::visit(
+          [](const auto& end) -> void* {
+              if constexpr (std::is_same_v<std::decay_t<decltype(end)>, std::monostate>)
+              {
+                  return nullptr;
+              }
+              else
+              {
+                  return end.get();
+              }
+          },
+          backend);
+    }
+
+    std::variant<std::monostate, SharedMemoryBackend<T>, SharedMemoryBackendFallback<T>> backend;
+};
+
+
+}  // namespace Stockfish
+
+#endif  // #ifndef SHM_H_INCLUDED

--- a/src/shm_linux.h
+++ b/src/shm_linux.h
@@ -1,0 +1,658 @@
+/*
+  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+  Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
+
+  Stockfish is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Stockfish is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef SHM_LINUX_H_INCLUDED
+#define SHM_LINUX_H_INCLUDED
+
+#include <atomic>
+#include <cassert>
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <cstdio>
+#include <dirent.h>
+#include <mutex>
+#include <new>
+#include <optional>
+#include <pthread.h>
+#include <string>
+#include <inttypes.h>
+#include <type_traits>
+#include <unordered_set>
+
+#include <fcntl.h>
+#include <signal.h>
+#include <sys/file.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#if defined(__NetBSD__) || defined(__DragonFly__) || defined(__linux__)
+    #include <limits.h>
+    #define SF_MAX_SEM_NAME_LEN NAME_MAX
+#elif defined(__APPLE__)
+    #define SF_MAX_SEM_NAME_LEN 31
+#else
+    #define SF_MAX_SEM_NAME_LEN 255
+#endif
+
+
+namespace Stockfish::shm {
+
+namespace detail {
+
+struct ShmHeader {
+    static constexpr uint32_t SHM_MAGIC = 0xAD5F1A12;
+    pthread_mutex_t           mutex;
+    std::atomic<uint32_t>     ref_count{0};
+    std::atomic<bool>         initialized{false};
+    uint32_t                  magic = SHM_MAGIC;
+};
+
+class SharedMemoryBase {
+   public:
+    virtual ~SharedMemoryBase()                      = default;
+    virtual void               close() noexcept      = 0;
+    virtual const std::string& name() const noexcept = 0;
+};
+
+class SharedMemoryRegistry {
+   private:
+    static std::mutex                            registry_mutex_;
+    static std::unordered_set<SharedMemoryBase*> active_instances_;
+
+   public:
+    static void register_instance(SharedMemoryBase* instance) {
+        std::scoped_lock lock(registry_mutex_);
+        active_instances_.insert(instance);
+    }
+
+    static void unregister_instance(SharedMemoryBase* instance) {
+        std::scoped_lock lock(registry_mutex_);
+        active_instances_.erase(instance);
+    }
+
+    static void cleanup_all() noexcept {
+        std::scoped_lock lock(registry_mutex_);
+        for (auto* instance : active_instances_)
+            instance->close();
+        active_instances_.clear();
+    }
+};
+
+inline std::mutex                            SharedMemoryRegistry::registry_mutex_;
+inline std::unordered_set<SharedMemoryBase*> SharedMemoryRegistry::active_instances_;
+
+class CleanupHooks {
+   private:
+    static std::once_flag register_once_;
+
+    static void handle_signal(int sig) noexcept {
+        SharedMemoryRegistry::cleanup_all();
+        _Exit(128 + sig);
+    }
+
+    static void register_signal_handlers() noexcept {
+        std::atexit([]() { SharedMemoryRegistry::cleanup_all(); });
+
+        constexpr int signals[] = {SIGHUP,  SIGINT,  SIGQUIT, SIGILL, SIGABRT, SIGFPE,
+                                   SIGSEGV, SIGTERM, SIGBUS,  SIGSYS, SIGXCPU, SIGXFSZ};
+
+        struct sigaction sa;
+        sa.sa_handler = handle_signal;
+        sigemptyset(&sa.sa_mask);
+        sa.sa_flags = 0;
+
+        for (int sig : signals)
+            sigaction(sig, &sa, nullptr);
+    }
+
+   public:
+    static void ensure_registered() noexcept {
+        std::call_once(register_once_, register_signal_handlers);
+    }
+};
+
+inline std::once_flag CleanupHooks::register_once_;
+
+
+inline int portable_fallocate(int fd, off_t offset, off_t length) {
+#ifdef __APPLE__
+    fstore_t store = {F_ALLOCATECONTIG, F_PEOFPOSMODE, offset, length, 0};
+    int      ret   = fcntl(fd, F_PREALLOCATE, &store);
+    if (ret == -1)
+    {
+        store.fst_flags = F_ALLOCATEALL;
+        ret             = fcntl(fd, F_PREALLOCATE, &store);
+    }
+    if (ret != -1)
+        ret = ftruncate(fd, offset + length);
+    return ret;
+#else
+    return posix_fallocate(fd, offset, length);
+#endif
+}
+
+}  // namespace detail
+
+template<typename T>
+class SharedMemory: public detail::SharedMemoryBase {
+    static_assert(std::is_trivially_copyable_v<T>, "T must be trivially copyable");
+    static_assert(!std::is_pointer_v<T>, "T cannot be a pointer type");
+
+   private:
+    std::string        name_;
+    int                fd_         = -1;
+    void*              mapped_ptr_ = nullptr;
+    T*                 data_ptr_   = nullptr;
+    detail::ShmHeader* header_ptr_ = nullptr;
+    size_t             total_size_ = 0;
+    std::string        sentinel_base_;
+    std::string        sentinel_path_;
+
+    static constexpr size_t calculate_total_size() noexcept {
+        return sizeof(T) + sizeof(detail::ShmHeader);
+    }
+
+    static std::string make_sentinel_base(const std::string& name) {
+        uint64_t hash = std::hash<std::string>{}(name);
+        char     buf[32];
+        std::snprintf(buf, sizeof(buf), "sfshm_%016" PRIx64, static_cast<uint64_t>(hash));
+        return buf;
+    }
+
+   public:
+    explicit SharedMemory(const std::string& name) noexcept :
+        name_(name),
+        total_size_(calculate_total_size()),
+        sentinel_base_(make_sentinel_base(name)) {}
+
+    ~SharedMemory() noexcept override {
+        detail::SharedMemoryRegistry::unregister_instance(this);
+        close();
+    }
+
+    SharedMemory(const SharedMemory&)            = delete;
+    SharedMemory& operator=(const SharedMemory&) = delete;
+
+    SharedMemory(SharedMemory&& other) noexcept :
+        name_(std::move(other.name_)),
+        fd_(other.fd_),
+        mapped_ptr_(other.mapped_ptr_),
+        data_ptr_(other.data_ptr_),
+        header_ptr_(other.header_ptr_),
+        total_size_(other.total_size_),
+        sentinel_base_(std::move(other.sentinel_base_)),
+        sentinel_path_(std::move(other.sentinel_path_)) {
+
+        detail::SharedMemoryRegistry::unregister_instance(&other);
+        detail::SharedMemoryRegistry::register_instance(this);
+        other.reset();
+    }
+
+    SharedMemory& operator=(SharedMemory&& other) noexcept {
+        if (this != &other)
+        {
+            detail::SharedMemoryRegistry::unregister_instance(this);
+            close();
+
+            name_          = std::move(other.name_);
+            fd_            = other.fd_;
+            mapped_ptr_    = other.mapped_ptr_;
+            data_ptr_      = other.data_ptr_;
+            header_ptr_    = other.header_ptr_;
+            total_size_    = other.total_size_;
+            sentinel_base_ = std::move(other.sentinel_base_);
+            sentinel_path_ = std::move(other.sentinel_path_);
+
+            detail::SharedMemoryRegistry::unregister_instance(&other);
+            detail::SharedMemoryRegistry::register_instance(this);
+
+            other.reset();
+        }
+        return *this;
+    }
+
+    [[nodiscard]] bool open(const T& initial_value) noexcept {
+        detail::CleanupHooks::ensure_registered();
+
+        bool retried_stale = false;
+
+        while (true)
+        {
+            if (is_open())
+                return false;
+
+            bool created_new = false;
+            fd_              = shm_open(name_.c_str(), O_CREAT | O_EXCL | O_RDWR, 0666);
+
+            if (fd_ == -1)
+            {
+                fd_ = shm_open(name_.c_str(), O_RDWR, 0666);
+                if (fd_ == -1)
+                    return false;
+            }
+            else
+                created_new = true;
+
+            if (!lock_file(LOCK_EX))
+            {
+                ::close(fd_);
+                reset();
+                return false;
+            }
+
+            bool invalid_header = false;
+            bool success =
+              created_new ? setup_new_region(initial_value) : setup_existing_region(invalid_header);
+
+            if (!success)
+            {
+                if (created_new || invalid_header)
+                    shm_unlink(name_.c_str());
+                if (mapped_ptr_)
+                    unmap_region();
+                unlock_file();
+                ::close(fd_);
+                reset();
+
+                if (!created_new && invalid_header && !retried_stale)
+                {
+                    retried_stale = true;
+                    continue;
+                }
+                return false;
+            }
+
+            if (!lock_shared_mutex())
+            {
+                if (created_new)
+                    shm_unlink(name_.c_str());
+                if (mapped_ptr_)
+                    unmap_region();
+                unlock_file();
+                ::close(fd_);
+                reset();
+
+                if (!created_new && !retried_stale)
+                {
+                    retried_stale = true;
+                    continue;
+                }
+                return false;
+            }
+
+            if (!create_sentinel_file_locked())
+            {
+                unlock_shared_mutex();
+                unmap_region();
+                if (created_new)
+                    shm_unlink(name_.c_str());
+                unlock_file();
+                ::close(fd_);
+                reset();
+                return false;
+            }
+
+            header_ptr_->ref_count.fetch_add(1, std::memory_order_acq_rel);
+
+            unlock_shared_mutex();
+            unlock_file();
+            detail::SharedMemoryRegistry::register_instance(this);
+            return true;
+        }
+    }
+
+    void close() noexcept override {
+        if (fd_ == -1 && mapped_ptr_ == nullptr)
+            return;
+
+        bool remove_region = false;
+        bool file_locked   = lock_file(LOCK_EX);
+        bool mutex_locked  = false;
+
+        if (file_locked && header_ptr_ != nullptr)
+            mutex_locked = lock_shared_mutex();
+
+        if (mutex_locked)
+        {
+            if (header_ptr_)
+            {
+                header_ptr_->ref_count.fetch_sub(1, std::memory_order_acq_rel);
+            }
+            remove_sentinel_file();
+            remove_region = !has_other_live_sentinels_locked();
+            unlock_shared_mutex();
+        }
+        else
+        {
+            remove_sentinel_file();
+            decrement_refcount_relaxed();
+        }
+
+        unmap_region();
+
+        if (remove_region)
+            shm_unlink(name_.c_str());
+
+        if (file_locked)
+            unlock_file();
+
+        if (fd_ != -1)
+        {
+            ::close(fd_);
+            fd_ = -1;
+        }
+
+        reset();
+    }
+
+    const std::string& name() const noexcept override { return name_; }
+
+    [[nodiscard]] bool is_open() const noexcept { return fd_ != -1 && mapped_ptr_ && data_ptr_; }
+
+    [[nodiscard]] const T& get() const noexcept { return *data_ptr_; }
+
+    [[nodiscard]] const T* operator->() const noexcept { return data_ptr_; }
+
+    [[nodiscard]] const T& operator*() const noexcept { return *data_ptr_; }
+
+    [[nodiscard]] uint32_t ref_count() const noexcept {
+        return header_ptr_ ? header_ptr_->ref_count.load(std::memory_order_acquire) : 0;
+    }
+
+    [[nodiscard]] bool is_initialized() const noexcept {
+        return header_ptr_ ? header_ptr_->initialized.load(std::memory_order_acquire) : false;
+    }
+
+    static void cleanup_all_instances() noexcept { detail::SharedMemoryRegistry::cleanup_all(); }
+
+   private:
+    void reset() noexcept {
+        fd_         = -1;
+        mapped_ptr_ = nullptr;
+        data_ptr_   = nullptr;
+        header_ptr_ = nullptr;
+        sentinel_path_.clear();
+    }
+
+    void unmap_region() noexcept {
+        if (mapped_ptr_)
+        {
+            munmap(mapped_ptr_, total_size_);
+            mapped_ptr_ = nullptr;
+            data_ptr_   = nullptr;
+            header_ptr_ = nullptr;
+        }
+    }
+
+    [[nodiscard]] bool lock_file(int operation) noexcept {
+        if (fd_ == -1)
+            return false;
+
+        while (flock(fd_, operation) == -1)
+        {
+            if (errno == EINTR)
+                continue;
+            return false;
+        }
+        return true;
+    }
+
+    void unlock_file() noexcept {
+        if (fd_ == -1)
+            return;
+
+        while (flock(fd_, LOCK_UN) == -1)
+        {
+            if (errno == EINTR)
+                continue;
+            break;
+        }
+    }
+
+    std::string sentinel_full_path(pid_t pid) const {
+        std::string path = "/dev/shm/";
+        path += sentinel_base_;
+        path.push_back('.');
+        path += std::to_string(pid);
+        return path;
+    }
+
+    void decrement_refcount_relaxed() noexcept {
+        if (!header_ptr_)
+            return;
+
+        uint32_t expected = header_ptr_->ref_count.load(std::memory_order_relaxed);
+        while (expected != 0
+               && !header_ptr_->ref_count.compare_exchange_weak(
+                 expected, expected - 1, std::memory_order_acq_rel, std::memory_order_relaxed))
+        {}
+    }
+
+    bool create_sentinel_file_locked() noexcept {
+        if (!header_ptr_)
+            return false;
+
+        const pid_t self_pid = getpid();
+        sentinel_path_       = sentinel_full_path(self_pid);
+
+        for (int attempt = 0; attempt < 2; ++attempt)
+        {
+            int fd = ::open(sentinel_path_.c_str(), O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC, 0600);
+            if (fd != -1)
+            {
+                ::close(fd);
+                return true;
+            }
+
+            if (errno == EEXIST)
+            {
+                ::unlink(sentinel_path_.c_str());
+                decrement_refcount_relaxed();
+                continue;
+            }
+
+            break;
+        }
+
+        sentinel_path_.clear();
+        return false;
+    }
+
+    void remove_sentinel_file() noexcept {
+        if (!sentinel_path_.empty())
+        {
+            ::unlink(sentinel_path_.c_str());
+            sentinel_path_.clear();
+        }
+    }
+
+    static bool pid_is_alive(pid_t pid) noexcept {
+        if (pid <= 0)
+            return false;
+
+        if (kill(pid, 0) == 0)
+            return true;
+
+        return errno == EPERM;
+    }
+
+    [[nodiscard]] bool initialize_shared_mutex() noexcept {
+        if (!header_ptr_)
+            return false;
+
+        pthread_mutexattr_t attr;
+        if (pthread_mutexattr_init(&attr) != 0)
+            return false;
+
+        bool success = pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_SHARED) == 0;
+#ifdef PTHREAD_MUTEX_ROBUST
+        if (success)
+            success = pthread_mutexattr_setrobust(&attr, PTHREAD_MUTEX_ROBUST) == 0;
+#endif
+
+        if (success)
+            success = pthread_mutex_init(&header_ptr_->mutex, &attr) == 0;
+
+        pthread_mutexattr_destroy(&attr);
+        return success;
+    }
+
+    [[nodiscard]] bool lock_shared_mutex() noexcept {
+        if (!header_ptr_)
+            return false;
+
+        while (true)
+        {
+            int rc = pthread_mutex_lock(&header_ptr_->mutex);
+            if (rc == 0)
+                return true;
+
+#ifdef PTHREAD_MUTEX_ROBUST
+            if (rc == EOWNERDEAD)
+            {
+                if (pthread_mutex_consistent(&header_ptr_->mutex) == 0)
+                    return true;
+                return false;
+            }
+#endif
+
+            if (rc == EINTR)
+                continue;
+
+            return false;
+        }
+    }
+
+    void unlock_shared_mutex() noexcept {
+        if (header_ptr_)
+            pthread_mutex_unlock(&header_ptr_->mutex);
+    }
+
+    bool has_other_live_sentinels_locked() const noexcept {
+        DIR* dir = opendir("/dev/shm");
+        if (!dir)
+            return false;
+
+        std::string prefix = sentinel_base_ + ".";
+        bool        found  = false;
+
+        while (dirent* entry = readdir(dir))
+        {
+            std::string name = entry->d_name;
+            if (name.rfind(prefix, 0) != 0)
+                continue;
+
+            auto  pid_str = name.substr(prefix.size());
+            char* end     = nullptr;
+            long  value   = std::strtol(pid_str.c_str(), &end, 10);
+            if (!end || *end != '\0')
+                continue;
+
+            pid_t pid = static_cast<pid_t>(value);
+            if (pid_is_alive(pid))
+            {
+                found = true;
+                break;
+            }
+
+            std::string stale_path = std::string("/dev/shm/") + name;
+            ::unlink(stale_path.c_str());
+            const_cast<SharedMemory*>(this)->decrement_refcount_relaxed();
+        }
+
+        closedir(dir);
+        return found;
+    }
+
+    [[nodiscard]] bool setup_new_region(const T& initial_value) noexcept {
+        if (ftruncate(fd_, static_cast<off_t>(total_size_)) == -1)
+            return false;
+
+        if (detail::portable_fallocate(fd_, 0, static_cast<off_t>(total_size_)) != 0)
+            return false;
+
+        mapped_ptr_ = mmap(nullptr, total_size_, PROT_READ | PROT_WRITE, MAP_SHARED, fd_, 0);
+        if (mapped_ptr_ == MAP_FAILED)
+        {
+            mapped_ptr_ = nullptr;
+            return false;
+        }
+
+        data_ptr_ = static_cast<T*>(mapped_ptr_);
+        header_ptr_ =
+          reinterpret_cast<detail::ShmHeader*>(static_cast<char*>(mapped_ptr_) + sizeof(T));
+
+        new (header_ptr_) detail::ShmHeader{};
+        new (data_ptr_) T{initial_value};
+
+        if (!initialize_shared_mutex())
+            return false;
+
+        header_ptr_->ref_count.store(0, std::memory_order_release);
+        header_ptr_->initialized.store(true, std::memory_order_release);
+        return true;
+    }
+
+    [[nodiscard]] bool setup_existing_region(bool& invalid_header) noexcept {
+        invalid_header = false;
+
+        struct stat st;
+        fstat(fd_, &st);
+        if (static_cast<size_t>(st.st_size) < total_size_)
+        {
+            invalid_header = true;
+            return false;
+        }
+
+        mapped_ptr_ = mmap(nullptr, total_size_, PROT_READ | PROT_WRITE, MAP_SHARED, fd_, 0);
+        if (mapped_ptr_ == MAP_FAILED)
+        {
+            mapped_ptr_ = nullptr;
+            return false;
+        }
+
+        data_ptr_   = static_cast<T*>(mapped_ptr_);
+        header_ptr_ = std::launder(
+          reinterpret_cast<detail::ShmHeader*>(static_cast<char*>(mapped_ptr_) + sizeof(T)));
+
+        if (!header_ptr_->initialized.load(std::memory_order_acquire)
+            || header_ptr_->magic != detail::ShmHeader::SHM_MAGIC)
+        {
+            invalid_header = true;
+            unmap_region();
+            return false;
+        }
+
+        return true;
+    }
+};
+
+template<typename T>
+[[nodiscard]] std::optional<SharedMemory<T>> create_shared(const std::string& name,
+                                                           const T& initial_value) noexcept {
+    SharedMemory<T> shm(name);
+    if (shm.open(initial_value))
+        return shm;
+    return std::nullopt;
+}
+
+}  // namespace Stockfish::shm
+
+#endif  // #ifndef SHM_LINUX_H_INCLUDED


### PR DESCRIPTION
## Summary
- add shared memory utilities and wire the engine to use LazyNumaReplicatedSystemWide for NNUE replicas
- inline NNUE network weights, add hashing helpers, and adjust evaluation caches and tracing to new API
- extend build flags with stack-usage checks, debug assertions, and required librt linkage when available

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690bd35be8e88327be484f3190298675