### PR TITLE
Fix NNUE cache entries to include tracked bitboards

### DIFF
--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -68,10 +68,12 @@ struct AccumulatorCaches {
     struct alignas(CacheLineSize) Cache {
 
         struct alignas(CacheLineSize) Entry {
-            BiasType       accumulation[Size];
-            PSQTWeightType psqtAccumulation[PSQTBuckets];
-            Piece          pieces[SQUARE_NB];
-            Bitboard       pieceBB;
+            BiasType                      accumulation[Size];
+            PSQTWeightType                psqtAccumulation[PSQTBuckets];
+            Piece                         pieces[SQUARE_NB];
+            Bitboard                      pieceBB;
+            std::array<Bitboard, COLOR_NB>     byColorBB;
+            std::array<Bitboard, PIECE_TYPE_NB> byTypeBB;
 
             // To initialize a refresh entry, we set all its bitboards empty,
             // so we put the biases in the accumulation, without any weights on top


### PR DESCRIPTION
## Summary
- add the missing color and piece-type bitboard arrays to NNUE accumulator cache entries so refresh code can compile

## Testing
- make -j profile-build ARCH=x86-64-sse41-popcnt COMP=clang CXX=clang++-20 EXTRALDFLAGS="-fuse-ld=lld"

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690c01b366c883278743128f131621cc)