### PR TITLE
Clamp experience probe limit to non-negative size

### DIFF
--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -368,7 +368,9 @@ Move Experience::probe(Position& pos, int width, int evalImportance, int minDept
         return (a.score + evalImportance * a.depth) > (b.score + evalImportance * b.depth);
     });
 
-    vec.resize(std::min<int>({maxMoves, width, static_cast<int>(vec.size())}));
+    int limit = std::min<int>({maxMoves, width, static_cast<int>(vec.size())});
+    limit     = std::max(0, limit);
+    vec.resize(static_cast<std::size_t>(limit));
 
     if (vec.empty() || vec.front().depth < minDepth)
         return Move::none();


### PR DESCRIPTION
## Summary
- prevent Experience::probe from resizing with a negative limit by clamping the computed move cap to zero or greater

## Testing
- `STOCKFISH_BINARY=src/Wordfish-3.10-011125 pytest tests/test_experience.py -q`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e388c34b08327bf7de359f8c5bd4b)