### PR TITLE
Fix Windows linking for clang profile builds

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -490,6 +490,9 @@ CXXFLAGS += -DUSE_LIVEBOOK
 DEPENDFLAGS = $(ENV_DEPENDFLAGS) -std=c++17
 LDFLAGS = $(ENV_LDFLAGS) $(EXTRALDFLAGS) -lz
 LDFLAGS += -lcurl
+ifeq ($(target_windows),yes)
+        LDFLAGS += -lws2_32 -lnghttp2
+endif
 
 ifeq ($(COMP),)
 	COMP=gcc


### PR DESCRIPTION
## Summary
- add Windows-specific socket and HTTP/2 libraries to the link flags when targeting Windows so static libcurl builds succeed

## Testing
- make -j2 profile-build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld" *(fails: x86_64-w64-mingw32-clang++ not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e3b61543083279ec4ead09960a380)