### PR TITLE
Fix Windows link dependencies for profile builds

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -491,7 +491,7 @@ DEPENDFLAGS = $(ENV_DEPENDFLAGS) -std=c++17
 LDFLAGS = $(ENV_LDFLAGS) $(EXTRALDFLAGS) -lz
 LDFLAGS += -lcurl
 ifeq ($(target_windows),yes)
-        LDFLAGS += -lws2_32 -lnghttp2
+       LDFLAGS += -lws2_32 -lnghttp2 -lssl -lcrypto -lssh2 -lidn2 -lpsl -lngtcp2_crypto_openssl -lngtcp2 -lwldap32 -lsecur32 -lbcrypt -lcrypt32
 endif
 
 ifeq ($(COMP),)


### PR DESCRIPTION
## Summary
- add the Windows-specific libraries required by libcurl to the linker flags

## Testing
- make -j2 profile-build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld" *(fails: clang++ not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e3d4603608327b027504d22a424ef)