### PR TITLE
Handle missing ngtcp2 libraries when targeting Windows

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -491,7 +491,11 @@ DEPENDFLAGS = $(ENV_DEPENDFLAGS) -std=c++17
 LDFLAGS = $(ENV_LDFLAGS) $(EXTRALDFLAGS) -lz
 LDFLAGS += -lcurl
 ifeq ($(target_windows),yes)
-       LDFLAGS += -lws2_32 -lnghttp2 -lssl -lcrypto -lssh2 -lidn2 -lpsl -lngtcp2_crypto_openssl -lngtcp2 -lwldap32 -lsecur32 -lbcrypt -lcrypt32
+       ifeq ($(shell pkg-config --exists libngtcp2_crypto_openssl libngtcp2 && echo yes),yes)
+               LDFLAGS += -lws2_32 -lnghttp2 -lssl -lcrypto -lssh2 -lidn2 -lpsl -lngtcp2_crypto_openssl -lngtcp2 -lwldap32 -lsecur32 -lbcrypt -lcrypt32
+       else
+               LDFLAGS += -lws2_32 -lnghttp2 -lssl -lcrypto -lssh2 -lidn2 -lpsl -lwldap32 -lsecur32 -lbcrypt -lcrypt32
+       endif
 endif
 
 ifeq ($(COMP),)


### PR DESCRIPTION
## Summary
- guard the Windows-specific link flags so ngtcp2 libraries are only added when available

## Testing
- make -j profile-build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld" *(fails: clang++ not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e3f3959f88327a518232285389a8b)