### PR TITLE
Expose live book options in UCI interface

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -210,7 +210,6 @@ Engine::Engine(std::optional<std::string> path) :
     options.add("MCTS Multi MinVisits", Option(5, 0, 1000));
     options.add("MCTS Explore", Option(false));
 
-#ifdef USE_LIVEBOOK
     options.add("LiveBook Proxy Url", Option("", [](const Option& o) {
                     Search::set_proxy_url(o.value());
                     return std::nullopt;
@@ -267,7 +266,6 @@ Engine::Engine(std::optional<std::string> path) :
                     Search::set_chess_db_contribute(bool(o));
                     return std::nullopt;
                 }));
-#endif
 
     // Optional experimental evaluation tweak that adapts weights based on
     // simple positional cues. Disabled by default so it does not alter

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -202,6 +202,32 @@ void Search::update_online_tablebases() {
 void Search::set_chess_db_contribute(const bool chess_db_contribute) {
     _chess_db_contribute = chess_db_contribute;
 }
+#else
+void Search::set_livebook_depth(const int) {}
+
+void Search::set_proxy_url(const std::string&) {}
+
+void Search::set_proxy_diversity(const bool) {}
+
+void Search::set_use_lichess_games(const bool) {}
+
+void Search::set_use_lichess_masters(const bool) {}
+
+void Search::set_lichess_player(const std::string&) {}
+
+void Search::set_lichess_player_color(const std::string&) {}
+
+void Search::set_use_chess_db(const bool) {}
+
+void Search::set_use_chess_db_tablebase(const bool) {}
+
+void Search::set_use_lichess_tablebase(const bool) {}
+
+void Search::update_livebooks() {}
+
+void Search::update_online_tablebases() {}
+
+void Search::set_chess_db_contribute(const bool) {}
 #endif
 
 void Search::set_variety(const std::string& varietyOption) {

--- a/src/search.h
+++ b/src/search.h
@@ -372,7 +372,6 @@ struct ConthistBonus {
     int weight;
 };
 
-#ifdef USE_LIVEBOOK
 void set_livebook_depth(int book_depth);
 void set_proxy_url(const std::string& proxy_url);
 void set_proxy_diversity(bool proxy_diversity);
@@ -386,7 +385,6 @@ void set_use_lichess_tablebase(bool lichess_tablebase);
 void update_livebooks();
 void update_online_tablebases();
 void set_chess_db_contribute(bool chess_db_contribute);
-#endif
 
 void set_variety(const std::string& varietyOption);
 


### PR DESCRIPTION
## Summary
- always register LiveBook-related UCI options so they are visible to frontends
- add no-op Search setters when the live book module is not compiled in to keep builds working

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e477c1b248327b047d6326c071aa1)