### PR TITLE
Add Lichess tablebase HTTP probing

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -81,7 +81,7 @@ SRCS = benchmark.cpp bitboard.cpp evaluate.cpp main.cpp \
         misc.cpp movegen.cpp movepick.cpp polybook.cpp position.cpp \
         search.cpp thread.cpp timeman.cpp tt.cpp uci.cpp ucioption.cpp tune.cpp syzygy/tbprobe.cpp \
         nnue/nnue_accumulator.cpp nnue/nnue_misc.cpp nnue/features/half_ka_v2_hm.cpp nnue/network.cpp \
-        engine.cpp score.cpp memory.cpp experience.cpp \
+        engine.cpp score.cpp memory.cpp experience.cpp lichess_tablebase.cpp \
         livebook/BaseLivebook.cpp livebook/ChessDb.cpp livebook/ChessDBContributor.cpp \
         livebook/LichessEndgame.cpp livebook/LichessGames.cpp livebook/LichessLivebook.cpp \
         livebook/LichessMaster.cpp livebook/LichessOpening.cpp livebook/LichessPlayer.cpp \
@@ -101,7 +101,7 @@ HEADERS = benchmark.h bitboard.h evaluate.h misc.h movegen.h movepick.h history.
                 livebook/LichessGames.h livebook/LichessLivebook.h livebook/LichessMaster.h \
                 livebook/LichessOpening.h livebook/LichessPlayer.h livebook/LichessUsers.h \
                 livebook/Proxy.h livebook/analysis/Analysis.h livebook/analysis/Cp.h \
-                livebook/analysis/Mate.h livebook/analysis/Wdl.h
+                livebook/analysis/Mate.h livebook/analysis/Wdl.h lichess_tablebase.h
 
 OBJS = $(notdir $(SRCS:.cpp=.o))
 

--- a/src/lichess_tablebase.cpp
+++ b/src/lichess_tablebase.cpp
@@ -1,0 +1,148 @@
+#include "lichess_tablebase.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "position.h"
+#include "uci.h"
+
+#ifdef USE_LIVEBOOK
+    #include "livebook/BaseLivebook.h"
+    #include "livebook/json/json.hpp"
+#endif
+
+namespace Stockfish {
+namespace LichessTB {
+
+namespace {
+
+#ifdef USE_LIVEBOOK
+class CurlHelper : public Livebook::BaseLivebook {
+   public:
+    std::vector<std::pair<std::string, Analysis>> lookup(const Position&) override {
+        return {};
+    }
+
+    bool get(const std::string& url, std::string& out) {
+        const CURLcode code = do_request(url);
+        if (code != CURLE_OK)
+            return false;
+
+        clean_buffer_from_terminator();
+        out = readBuffer;
+        return true;
+    }
+};
+#endif
+
+}  // namespace
+
+bool probe(const Position& pos, Value& outScore, Move& outBestMove) {
+#ifdef USE_LIVEBOOK
+    if (pos.is_chess960())
+        return false;
+
+    if (pos.count<ALL_PIECES>() > 7)
+        return false;
+
+    std::string fen = pos.fen();
+    std::replace(fen.begin(), fen.end(), ' ', '_');
+
+    static CurlHelper helper;
+    std::string       payload;
+    if (!helper.get("https://tablebase.lichess.ovh/standard?fen=" + fen, payload))
+        return false;
+
+    auto json = nlohmann::json::parse(payload, nullptr, false);
+    if (json.is_discarded())
+        return false;
+
+    const auto movesIt = json.find("moves");
+    if (movesIt == json.end() || !movesIt->is_array() || movesIt->empty())
+        return false;
+
+    const auto& best = (*movesIt)[0];
+    if (!best.contains("uci") || !best["uci"].is_string())
+        return false;
+
+    const std::string uciMove = best["uci"].get<std::string>();
+    Move              move    = UCIEngine::to_move(pos, uciMove);
+    if (move == Move::none())
+        return false;
+
+    auto to_lower = [](std::string value) {
+        std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+            return static_cast<char>(std::tolower(c));
+        });
+        return value;
+    };
+
+    std::string category;
+    if (json.contains("category") && json["category"].is_string())
+        category = json["category"].get<std::string>();
+    else if (best.contains("category") && best["category"].is_string())
+        category = best["category"].get<std::string>();
+    else
+        return false;
+
+    category = to_lower(category);
+
+    auto read_dtm = [](const nlohmann::json& node) -> int {
+        if (!node.contains("dtm"))
+            return 0;
+
+        const auto& value = node["dtm"];
+        if (value.is_number_integer())
+            return value.get<int>();
+        if (value.is_number_float())
+            return static_cast<int>(std::round(value.get<double>()));
+        return 0;
+    };
+
+    int dtm = read_dtm(json);
+    if (dtm == 0)
+        dtm = read_dtm(best);
+
+    dtm = std::abs(dtm);
+
+    const auto contains = [](const std::string& text, const std::string& needle) {
+        return text.find(needle) != std::string::npos;
+    };
+
+    Value score = VALUE_NONE;
+
+    if (contains(category, "win"))
+    {
+        int plies = std::max(1, dtm);
+        score     = mate_in(plies);
+    }
+    else if (contains(category, "loss"))
+    {
+        int plies = std::max(1, dtm);
+        score     = mated_in(plies);
+    }
+    else if (contains(category, "draw") || contains(category, "stalemate"))
+    {
+        score = VALUE_DRAW;
+    }
+    else
+        return false;
+
+    outScore    = score;
+    outBestMove = move;
+    return true;
+#else
+    (void) pos;
+    (void) outScore;
+    (void) outBestMove;
+    return false;
+#endif
+}
+
+}  // namespace LichessTB
+}  // namespace Stockfish

--- a/src/lichess_tablebase.h
+++ b/src/lichess_tablebase.h
@@ -1,0 +1,18 @@
+#ifndef LICHESS_TABLEBASE_H_INCLUDED
+#define LICHESS_TABLEBASE_H_INCLUDED
+
+#include "types.h"
+
+namespace Stockfish {
+
+class Position;
+
+namespace LichessTB {
+
+bool probe(const Position& pos, Value& outScore, Move& outBestMove);
+
+}  // namespace LichessTB
+
+}  // namespace Stockfish
+
+#endif  // #ifndef LICHESS_TABLEBASE_H_INCLUDED

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -46,6 +46,8 @@
 #include "nnue/nnue_accumulator.h"
 #include "polybook.h"
 #include "experience.h"
+#include "lichess_tablebase.h"
+#include "score.h"
 #ifdef USE_LIVEBOOK
 #    include "livebook/BaseLivebook.h"
 #    include "livebook/ChessDBContributor.h"
@@ -646,6 +648,40 @@ void Search::Worker::start_searching() {
         }
         else
         {
+            if ((bool) options["Lichess Tablebase"] && !tbConfig.rootInTB
+                && !rootPos.is_chess960() && rootPos.count<ALL_PIECES>() <= 7)
+            {
+                Value tbScore = VALUE_ZERO;
+                Move  tbMove  = Move::none();
+
+                if (LichessTB::probe(rootPos, tbScore, tbMove)
+                    && std::find(rootMoves.begin(), rootMoves.end(), tbMove) != rootMoves.end())
+                {
+                    static std::atomic_bool announced{false};
+
+                    if (!announced.exchange(true))
+                        sync_cout << "info string Lichess tablebase hit" << sync_endl;
+
+                    const std::string moveStr = UCIEngine::move(tbMove, rootPos.is_chess960());
+                    const Score       display(tbScore, rootPos);
+                    const std::string scoreStr = UCIEngine::format_score(display);
+
+                    sync_cout << "info depth 0 score " << scoreStr << " pv " << moveStr << sync_endl;
+
+                    threads.stop = true;
+
+                    if (auto* mainMgr = main_manager())
+                    {
+                        mainMgr->bestPreviousScore        = tbScore;
+                        mainMgr->bestPreviousAverageScore = tbScore;
+                        mainMgr->updates.onBestmove(moveStr, "");
+                    }
+                    else
+                        sync_cout << "bestmove " << moveStr << sync_endl;
+
+                    return;
+                }
+            }
             if ((bool) options["MCTS by Shashin"]) {
                 // Placeholder: Monte Carlo Tree Search integration point.
                 // Current build continues with standard alpha-beta search.


### PR DESCRIPTION
## Summary
- add a dedicated `lichess_tablebase` module that reuses the livebook cURL helper to call the Lichess Syzygy API and translate the JSON reply into moves and scores
- hook the remote probe into the main search so that, when the option is enabled and no local Syzygy hit exists, the engine prints a depth-0 info line and immediately returns the tablebase move
- add the new source/header to the build configuration so the feature builds on all targets

## Testing
- make -C src build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e50f9882c8327b539f67ff0dc2bfd)