### PR TITLE
Improve resilience of Lichess tablebase integration

### DIFF
--- a/src/livebook/LichessEndgame.cpp
+++ b/src/livebook/LichessEndgame.cpp
@@ -1,49 +1,76 @@
 #ifdef USE_LIVEBOOK
-    #include "LichessEndgame.h"
-    #include "json/json.hpp"
+
+#    include "LichessEndgame.h"
+#    include "json/json.hpp"
+
+#    include <algorithm>
+#    include <cmath>
+#    include <cctype>
+#    include <cstdlib>
+#    include <string>
 
 using namespace Stockfish::Livebook;
 
+namespace {
+
+std::string to_lower_copy(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    return value;
+}
+
+int read_dtm(const nlohmann::json& node) {
+    const auto dtmIt = node.find("dtm");
+    if (dtmIt == node.end())
+        return 0;
+
+    if (dtmIt->is_number_integer())
+        return std::abs(dtmIt->get<int>());
+
+    if (dtmIt->is_number_float())
+        return std::abs(static_cast<int>(std::lround(dtmIt->get<double>())));
+
+    return 0;
+}
+
+}  // namespace
+
 std::string LichessEndgame::parse_uci(const nlohmann::json& move) {
     if (!move.contains("uci") || !move["uci"].is_string())
-    {
         return "";
-    }
 
     return move["uci"].get<std::string>();
 }
 
-inline Analysis* LichessEndgame::parse_analysis(const nlohmann::json& move) {
-    auto category = move["category"].get<std::string>();
+Analysis* LichessEndgame::parse_analysis(const nlohmann::json& move) {
+    if (!move.contains("category") || !move["category"].is_string())
+        return nullptr;
+
+    const std::string category = to_lower_copy(move["category"].get<std::string>());
 
     if (category == "unknown")
-    {
         return nullptr;
-    }
 
-    const auto win = category == "win";
+    const bool isWin  = category == "win";
+    const bool isLoss = category == "loss";
 
-    if (const auto loss = category == "loss"; !win && !loss)
-    {
+    if (!isWin && !isLoss)
         return new Analysis(new Wdl(0, 1, 0));
-    }
 
-    const auto mate      = move["dtm"].get<uint64_t>();
+    const int mate = read_dtm(move);
     const auto mate_eval = new Mate(static_cast<int32_t>(mate));
 
-    if (win)
-    {
+    if (isWin)
         return new Analysis(mate_eval);
-    }
 
     return new Analysis(mate_eval->opponent());
 }
 
 std::string LichessEndgame::format_url(const Position& position) {
     std::string fen_encoded = position.fen();
-    std::replace(fen_encoded.begin(), fen_encoded.end(), ' ', '_');  // replace all ' ' to '_'
-    const std::string full_uri = "https://tablebase.lichess.ovh/standard?fen=" + fen_encoded;
-
-    return full_uri;
+    std::replace(fen_encoded.begin(), fen_encoded.end(), ' ', '_');
+    return "https://tablebase.lichess.ovh/standard?fen=" + fen_encoded;
 }
-#endif
+
+#endif  // USE_LIVEBOOK

--- a/src/livebook/LichessEndgame.h
+++ b/src/livebook/LichessEndgame.h
@@ -1,17 +1,21 @@
 #ifndef LICHESS_ENDGAME_H
 #define LICHESS_ENDGAME_H
+
 #ifdef USE_LIVEBOOK
-    #include "LichessLivebook.h"
+
+#    include "LichessLivebook.h"
 
 namespace Stockfish::Livebook {
-class LichessEndgame final: public LichessLivebook {
+
+class LichessEndgame final : public LichessLivebook {
    public:
     std::string parse_uci(const nlohmann::json& move) override;
     Analysis*   parse_analysis(const nlohmann::json& move) override;
     std::string format_url(const Position& position) override;
 };
-}
 
+}  // namespace Stockfish::Livebook
 
-#endif  //LICHESS_ENDGAME_H
-#endif
+#endif  // USE_LIVEBOOK
+
+#endif  // LICHESS_ENDGAME_H


### PR DESCRIPTION
## Summary
- guard the Lichess endgame parser against missing or malformed JSON fields
- normalize categories and mate distances when evaluating Lichess tablebase results
- clean up the Lichess endgame header guard structure

## Testing
- make -C src build -j4

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e552305888327acc611d8d65cfd03)