### PR TITLE
Handle uppercase Wordfish binary name in tests

### DIFF
--- a/tests/test_experience.py
+++ b/tests/test_experience.py
@@ -48,8 +48,8 @@ class ExperienceFileTests(unittest.TestCase):
         search_dirs = [root, root / "build", root / "src"]
         for directory in search_dirs:
             if directory.is_dir():
-                candidates.extend(sorted(directory.glob("wordfish*")))
-                candidates.extend(sorted(directory.glob("stockfish*")))
+                candidates.extend(sorted(directory.glob("[Ww]ordfish*")))
+                candidates.extend(sorted(directory.glob("[Ss]tockfish*")))
 
         for candidate in candidates:
             if candidate and candidate.is_file() and os.access(candidate, os.X_OK):


### PR DESCRIPTION
## Summary
- update the experience file tests to look for both lowercase and uppercase Wordfish/Stockfish binaries

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e57c487c08327b49405709cccc60e)