### PR TITLE
Handle empty build tags in version extractor

### DIFF
--- a/scripts/extract_version.py
+++ b/scripts/extract_version.py
@@ -8,8 +8,8 @@ import re
 import sys
 
 HEADER_MACROS = {
-    "ENGINE_NAME": re.compile(r"#define\s+ENGINE_NAME\s+\"([^\"]+)\""),
-    "ENGINE_BUILD_DATE": re.compile(r"#define\s+ENGINE_BUILD_DATE\s+\"([^\"]+)\"")
+    "ENGINE_NAME": re.compile(r"#define\s+ENGINE_NAME\s+\"([^\"]*)\""),
+    "ENGINE_BUILD_DATE": re.compile(r"#define\s+ENGINE_BUILD_DATE\s+\"([^\"]*)\"")
 }
 
 


### PR DESCRIPTION
## Summary
- allow the version extraction regex to capture empty macro values
- ensure version.mk is generated even when ENGINE_BUILD_DATE is blank

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911806f0fd083278d75fa64e597ac60)