### PR TITLE
Rebrand engine to Wordfish-3.30-151125

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-	EXE = stockfish.exe
+        EXE = Wordfish-3.30-151125.exe
 else
-	EXE = stockfish
+        EXE = Wordfish-3.30-151125
 endif
 
 ### Installation dir definitions

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -39,8 +39,10 @@ namespace Stockfish {
 
 namespace {
 
-// Version number or dev.
-constexpr std::string_view version = "dev";
+// Engine branding information.
+constexpr std::string_view engine_name = "Wordfish-3.30-151125";
+constexpr std::string_view engine_author =
+  "Developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file)";
 
 // Our fancy logging facility. The trick here is to replace cin.rdbuf() and
 // cout.rdbuf() with two Tie objects that tie cin and cout to a file stream. We
@@ -113,52 +115,16 @@ class Logger {
 }  // namespace
 
 
-// Returns the full name of the current Stockfish version.
-//
-// For local dev compiles we try to append the commit SHA and
-// commit date from git. If that fails only the local compilation
-// date is set and "nogit" is specified:
-//      Stockfish dev-YYYYMMDD-SHA
-//      or
-//      Stockfish dev-YYYYMMDD-nogit
-//
-// For releases (non-dev builds) we only include the version number:
-//      Stockfish version
+// Returns the branding string that identifies the current Wordfish build.
 std::string engine_version_info() {
-    std::stringstream ss;
-    ss << "Stockfish " << version << std::setfill('0');
-
-    if constexpr (version == "dev")
-    {
-        ss << "-";
-#ifdef GIT_DATE
-        ss << stringify(GIT_DATE);
-#else
-        constexpr std::string_view months("Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec");
-
-        std::string       month, day, year;
-        std::stringstream date(__DATE__);  // From compiler, format is "Sep 21 2008"
-
-        date >> month >> day >> year;
-        ss << year << std::setw(2) << std::setfill('0') << (1 + months.find(month) / 4)
-           << std::setw(2) << std::setfill('0') << day;
-#endif
-
-        ss << "-";
-
-#ifdef GIT_SHA
-        ss << stringify(GIT_SHA);
-#else
-        ss << "nogit";
-#endif
-    }
-
-    return ss.str();
+    return std::string(engine_name);
 }
 
 std::string engine_info(bool to_uci) {
-    return engine_version_info() + (to_uci ? "\nid author " : " by ")
-         + "the Stockfish developers (see AUTHORS file)";
+    std::string info = engine_version_info();
+    info += to_uci ? "\nid author " : " ";
+    info += engine_author;
+    return info;
 }
 
 


### PR DESCRIPTION
## Summary
- update the build output name to Wordfish-3.30-151125 so GUI clients display the new branding
- adjust the engine information strings so the UCI handshake advertises Wordfish-3.30-151125 and credits Jorge Ruiz alongside the Stockfish developers

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69186fc0f67883279b61fb522ea48504)