### PR TITLE
Add configurable Slow Mover and Minimum Thinking Time options

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -108,6 +108,8 @@ Engine::Engine(std::optional<std::string> path) :
     options.add("Skill Level", Option(20, 0, 20));
 
     options.add("Move Overhead", Option(10, 0, 5000));
+    options.add("Minimum Thinking Time", Option(100, 0, 5000));
+    options.add("Slow Mover", Option(100, 10, 1000));
 
     options.add("nodestime", Option(0, 0, 10000));
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -59,7 +59,9 @@ void TimeManagement::init(Search::LimitsType& limits,
     if (limits.time[us] == 0)
         return;
 
-    TimePoint moveOverhead = TimePoint(options["Move Overhead"]);
+    TimePoint moveOverhead      = TimePoint(options["Move Overhead"]);
+    const int slowMover         = options["Slow Mover"];
+    const TimePoint minimumTime = TimePoint(options["Minimum Thinking Time"]);
 
     // optScale is a percentage of available time to use for the current move.
     // maxScale is a multiplier applied to optimumTime.
@@ -85,6 +87,7 @@ void TimeManagement::init(Search::LimitsType& limits,
     // with constants are involved.
     const int64_t   scaleFactor = useNodesTime ? npmsec : 1;
     const TimePoint scaledTime  = limits.time[us] / scaleFactor;
+    const TimePoint scaledMinimumTime = minimumTime * scaleFactor;
 
     // Maximum move horizon
     int centiMTG = limits.movestogo ? std::min(limits.movestogo * 100, 5000) : 5051;
@@ -132,6 +135,9 @@ void TimeManagement::init(Search::LimitsType& limits,
     optimumTime = TimePoint(optScale * timeLeft);
     maximumTime =
       TimePoint(std::min(0.825179 * limits.time[us] - moveOverhead, maxScale * optimumTime)) - 10;
+
+    optimumTime = std::max(optimumTime * slowMover / 100, scaledMinimumTime);
+    maximumTime = std::max(maximumTime * slowMover / 100, optimumTime + scaledMinimumTime / 2);
 
     if (options["Ponder"])
         optimumTime += optimumTime / 4;


### PR DESCRIPTION
## Summary
- add Slow Mover and Minimum Thinking Time UCI options to the engine configuration
- integrate the new options into time management so scaling and minimum thinking limits are enforced

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691875feec0c8327838efdedb4bfea84)