### PR TITLE
Integrate Deepalienist self-learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,39 @@ Detailed compilation instructions for all platforms can be found in our
 [documentation][wiki-compile-link]. Our wiki also has information about
 the [UCI commands][wiki-uci-link] supported by Stockfish.
 
+## Self-learning
+
+Wordfish integra el sistema de experiencia `Deepalienist` para permitir que el
+motor aprenda de sus propias búsquedas y genere un libro personalizado. El
+módulo se controla mediante opciones UCI y trabaja sobre archivos `.exp` que
+almacenan las posiciones analizadas.
+
+### Configuración básica
+
+1. Active la opción **Experience Enabled** (true por defecto) para permitir el
+   autoaprendizaje y **Experience Book** si desea que el motor utilice las
+   jugadas almacenadas al ordenar los movimientos en la raíz.
+2. Ajuste **Experience File** con la ruta al archivo de experiencia que quiera
+   usar; por defecto se crea `Deepalienist.exp` en el directorio del motor.
+3. Si solo desea consultar la información sin modificar el archivo, habilite
+   **Experience Readonly**.
+
+### Ajustes del libro de experiencia
+
+* **Experience Book Width** controla cuántas jugadas candidatas se importan del
+  libro (1-32).
+* **Experience Book Eval Importance** equilibra la influencia de la evaluación
+  frente al número de visitas (0-10).
+* **Experience Book Min Depth** establece la profundidad mínima que debe tener
+  una entrada para ser considerada.
+* **Experience Book Max Moves** limita los movimientos totales jugados de una
+  partida antes de dejar de consultar la experiencia.
+
+Puede consultar el estado actual mediante el botón **Experience Status** y
+forzar un volcado inmediato del archivo con **Experience Sync**. El módulo
+guardará automáticamente los nuevos datos cada cierto número de posiciones y se
+sincronizará cuando reciba `ucinewgame`.
+
 ## Terms of use
 
 Stockfish is free and distributed under the

--- a/src/Makefile
+++ b/src/Makefile
@@ -52,18 +52,18 @@ BINDIR = $(PREFIX)/bin
 PGOBENCH = $(WINE_PATH) ./$(EXE) bench
 
 ### Source and object files
-SRCS = benchmark.cpp bitboard.cpp evaluate.cpp main.cpp \
-	misc.cpp movegen.cpp movepick.cpp position.cpp \
-	search.cpp thread.cpp timeman.cpp tt.cpp uci.cpp ucioption.cpp tune.cpp syzygy/tbprobe.cpp \
-	nnue/nnue_accumulator.cpp nnue/nnue_misc.cpp nnue/network.cpp \
-	nnue/features/half_ka_v2_hm.cpp nnue/features/full_threats.cpp \
-	engine.cpp score.cpp memory.cpp
+SRCS = benchmark.cpp bitboard.cpp evaluate.cpp experience.cpp main.cpp \
+        misc.cpp movegen.cpp movepick.cpp position.cpp \
+        search.cpp thread.cpp timeman.cpp tt.cpp uci.cpp ucioption.cpp tune.cpp syzygy/tbprobe.cpp \
+        nnue/nnue_accumulator.cpp nnue/nnue_misc.cpp nnue/network.cpp \
+        nnue/features/half_ka_v2_hm.cpp nnue/features/full_threats.cpp \
+        engine.cpp score.cpp memory.cpp
 
-HEADERS = benchmark.h bitboard.h evaluate.h misc.h movegen.h movepick.h history.h \
-		nnue/nnue_misc.h nnue/features/half_ka_v2_hm.h nnue/features/full_threats.h \
-		nnue/layers/affine_transform.h nnue/layers/affine_transform_sparse_input.h \
-		nnue/layers/clipped_relu.h nnue/layers/sqr_clipped_relu.h nnue/nnue_accumulator.h \
-		nnue/nnue_architecture.h nnue/nnue_common.h nnue/nnue_feature_transformer.h nnue/simd.h \
+HEADERS = benchmark.h bitboard.h evaluate.h experience.h experience_compat.h deepalienist_zobrist.h misc.h movegen.h movepick.h history.h \
+                nnue/nnue_misc.h nnue/features/half_ka_v2_hm.h nnue/features/full_threats.h \
+                nnue/layers/affine_transform.h nnue/layers/affine_transform_sparse_input.h \
+                nnue/layers/clipped_relu.h nnue/layers/sqr_clipped_relu.h nnue/nnue_accumulator.h \
+                nnue/nnue_architecture.h nnue/nnue_common.h nnue/nnue_feature_transformer.h nnue/simd.h \
 		position.h search.h syzygy/tbprobe.h thread.h thread_win32_osx.h timeman.h \
 		tt.h tune.h types.h uci.h ucioption.h perft.h nnue/network.h engine.h score.h numa.h memory.h
 

--- a/src/deepalienist_zobrist.h
+++ b/src/deepalienist_zobrist.h
@@ -1,16 +1,16 @@
 /*
-  Woordfish experience hashing utilities
+  Deepalienist experience hashing utilities
   Copyright (C) 2025
 
-  This file defines helper routines used by the self learning subsystem to
+  This file defines helper routines used by the self-learning subsystem to
   generate stable pseudo-random numbers for hashing. The implementation is
   intentionally lightweight so it can be used in constexpr contexts when
   possible, but also keeps the interface header-only as in the upstream
   project.
 */
 
-#ifndef Wordfish_ZOBRIST_H_INCLUDED
-#define Wordfish_ZOBRIST_H_INCLUDED
+#ifndef DEEPALIENIST_ZOBRIST_H_INCLUDED
+#define DEEPALIENIST_ZOBRIST_H_INCLUDED
 
 #include <cstdint>
 
@@ -38,4 +38,4 @@ inline std::uint64_t mix(std::uint64_t value) { return splitmix64(value); }
 
 }  // namespace Stockfish::Experience::Zobrist
 
-#endif  // #ifndef Woordfish_ZOBRIST_H_INCLUDED
+#endif  // #ifndef DEEPALIENIST_ZOBRIST_H_INCLUDED

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -30,6 +30,7 @@
 #include <vector>
 
 #include "evaluate.h"
+#include "experience.h"
 #include "misc.h"
 #include "nnue/network.h"
 #include "nnue/nnue_common.h"
@@ -135,6 +136,26 @@ Engine::Engine(std::optional<std::string> path) :
 
     options.add("SyzygyProbeLimit", Option(7, 0, 7));
 
+    const auto updateExperience = [this](const Option&) {
+        return Experience::update_settings(options);
+    };
+
+    options.add("Experience Enabled", Option(true, updateExperience));
+    options.add("Experience File", Option("Deepalienist.exp", updateExperience));
+    options.add("Experience Readonly", Option(false, updateExperience));
+    options.add("Experience Book", Option(false, updateExperience));
+    options.add("Experience Book Width", Option(1, 1, 32, updateExperience));
+    options.add("Experience Book Eval Importance", Option(5, 0, 10, updateExperience));
+    options.add("Experience Book Min Depth", Option(27, 0, 128, updateExperience));
+    options.add("Experience Book Max Moves", Option(16, 1, 128, updateExperience));
+    options.add("Experience Status", Option([&](const Option&) {
+        return Experience::status_summary();
+    }));
+    options.add("Experience Sync", Option([&](const Option&) {
+        Experience::flush();
+        return Experience::status_summary();
+    }));
+
     options.add(  //
       "EvalFile", Option(EvalFileDefaultNameBig, [this](const Option& o) {
           load_big_network(o);
@@ -148,6 +169,7 @@ Engine::Engine(std::optional<std::string> path) :
       }));
 
     load_networks();
+    Experience::update_settings(options);
     resize_threads();
 }
 
@@ -173,6 +195,8 @@ void Engine::search_clear() {
 
     // @TODO wont work with multiple instances
     Tablebases::init(options["SyzygyPath"]);  // Free mapped files
+
+    Experience::new_game();
 }
 
 void Engine::set_on_update_no_moves(std::function<void(const Engine::InfoShort&)>&& f) {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -35,6 +35,7 @@
 
 #include "bitboard.h"
 #include "evaluate.h"
+#include "experience.h"
 #include "history.h"
 #include "misc.h"
 #include "movegen.h"
@@ -233,6 +234,18 @@ void Search::Worker::start_searching() {
     if (bestThread->rootMoves[0].pv.size() > 1
         || bestThread->rootMoves[0].extract_ponder_from_tt(tt, rootPos))
         ponder = UCIEngine::move(bestThread->rootMoves[0].pv[1], rootPos.is_chess960());
+
+    const Value bestScore = bestThread->rootMoves[0].score;
+    const Value evalScore = bestThread->rootMoves[0].averageScore == -VALUE_INFINITE
+                              ? bestScore
+                              : bestThread->rootMoves[0].averageScore;
+
+    Experience::on_search_complete(bestThread->rootPos,
+                                   bestThread->rootMoves,
+                                   bestScore,
+                                   evalScore,
+                                   bestThread->completedDepth,
+                                   bestThread->limits);
 
     auto bestmove = UCIEngine::move(bestThread->rootMoves[0].pv[0], rootPos.is_chess960());
     main_manager()->updates.onBestmove(bestmove, ponder);

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -26,6 +26,7 @@
 #include <unordered_map>
 #include <utility>
 
+#include "experience.h"
 #include "memory.h"
 #include "movegen.h"
 #include "search.h"
@@ -266,6 +267,8 @@ void ThreadPool::start_thinking(const OptionsMap&  options,
             rootMoves.emplace_back(m);
 
     Tablebases::Config tbConfig = Tablebases::rank_root_moves(options, pos, rootMoves);
+
+    Experience::on_new_position(pos, rootMoves);
 
     // After ownership transfer 'states' becomes empty, so if we stop the search
     // and call 'go' again without setting a new position states.get() == nullptr.


### PR DESCRIPTION
## Summary
- wire the Deepalienist experience module into the engine options, search lifecycle, and self-learning hooks
- document the self-learning configuration and expose UCI controls for experience files and book usage
- rename the Zobrist helper to the Deepalienist variant and ensure the build compiles the new sources

## Testing
- make -C src build ARCH=x86-64-modern

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69187b264c6c83278d0c79831364751d)