### PR TITLE
Add Monte Carlo Tree Search mode

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -53,13 +53,13 @@ PGOBENCH = $(WINE_PATH) ./$(EXE) bench
 
 ### Source and object files
 SRCS = benchmark.cpp bitboard.cpp evaluate.cpp experience.cpp main.cpp \
-        misc.cpp movegen.cpp movepick.cpp position.cpp \
+        misc.cpp movegen.cpp movepick.cpp mcts.cpp position.cpp \
         search.cpp thread.cpp timeman.cpp tt.cpp uci.cpp ucioption.cpp tune.cpp syzygy/tbprobe.cpp \
         nnue/nnue_accumulator.cpp nnue/nnue_misc.cpp nnue/network.cpp \
         nnue/features/half_ka_v2_hm.cpp nnue/features/full_threats.cpp \
         engine.cpp score.cpp memory.cpp
 
-HEADERS = benchmark.h bitboard.h evaluate.h experience.h experience_compat.h deepalienist_zobrist.h misc.h movegen.h movepick.h history.h \
+HEADERS = benchmark.h bitboard.h evaluate.h experience.h experience_compat.h deepalienist_zobrist.h misc.h movegen.h movepick.h mcts.h history.h \
                 nnue/nnue_misc.h nnue/features/half_ka_v2_hm.h nnue/features/full_threats.h \
                 nnue/layers/affine_transform.h nnue/layers/affine_transform_sparse_input.h \
                 nnue/layers/clipped_relu.h nnue/layers/sqr_clipped_relu.h nnue/nnue_accumulator.h \

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -106,6 +106,8 @@ Engine::Engine(std::optional<std::string> path) :
     options.add(  //
       "MultiPV", Option(1, 1, MAX_MOVES));
 
+    options.add("Search Strategy", Option("AlphaBeta MCTS", "AlphaBeta"));
+
     options.add("Skill Level", Option(20, 0, 20));
 
     options.add("Move Overhead", Option(10, 0, 5000));

--- a/src/mcts.cpp
+++ b/src/mcts.cpp
@@ -1,0 +1,377 @@
+#include "mcts.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <vector>
+
+#include "evaluate.h"
+#include "movegen.h"
+#include "position.h"
+#include "ucioption.h"
+
+namespace Stockfish {
+namespace MCTS {
+
+namespace {
+
+struct Node {
+    Move                                move = Move::none();
+    Color                               toMove = WHITE;
+    bool                                terminal = false;
+    Value                               terminalValue = VALUE_ZERO;
+    std::vector<Move>                   unexpandedMoves;
+    std::vector<std::unique_ptr<Node>>  children;
+    double                              totalValue = 0.0;
+    std::uint64_t                       visits     = 0;
+};
+
+std::vector<Move> generate_moves(const Position& pos, PRNG& rng) {
+    std::vector<Move> moves;
+    moves.reserve(MoveList<LEGAL>(pos).size());
+
+    for (Move m : MoveList<LEGAL>(pos))
+        moves.push_back(m);
+
+    for (size_t i = moves.size(); i > 1; --i)
+    {
+        const size_t j = size_t(rng.rand<std::uint32_t>()) % i;
+        std::swap(moves[i - 1], moves[j]);
+    }
+
+    return moves;
+}
+
+Value terminal_evaluation(const Position& pos) {
+    if (pos.checkers())
+        return VALUE_MATED_IN_MAX_PLY;
+
+    return VALUE_DRAW;
+}
+
+double value_to_double(Value v) {
+    return double(v) / PawnValue;
+}
+
+Value double_to_value(double v) {
+    const double clamped = std::clamp(v, -double(VALUE_MATE), double(VALUE_MATE));
+    const int    scaled  = int(std::round(clamped * PawnValue));
+    return Value(std::clamp(scaled, -VALUE_MATE, VALUE_MATE));
+}
+
+struct Budget {
+    std::uint64_t maxIterations;
+    TimePoint     endTime;
+    bool          useTime;
+};
+
+Budget compute_budget(const OptionsMap& options,
+                      const Search::LimitsType& limits,
+                      Color rootColor) {
+    Budget budget{};
+
+    budget.maxIterations = limits.nodes ? limits.nodes : 5000;
+    budget.useTime       = false;
+    budget.endTime       = 0;
+
+    if (limits.infinite)
+        return budget;
+
+    const TimePoint start       = now();
+    const int       overhead    = int(options["Move Overhead"]);
+    const int       minThinking = int(options["Minimum Thinking Time"]);
+
+    auto compute_available_time = [&](TimePoint time, TimePoint inc, int movesToGo) {
+        if (!time)
+            return TimePoint(0);
+
+        TimePoint available = time;
+        if (inc)
+            available += inc / 2;
+
+        int divisor = movesToGo ? movesToGo : 30;
+        available   = std::max(TimePoint(0), available - overhead);
+        available   = available / divisor;
+        available   = std::max(available, TimePoint(minThinking));
+        return available;
+    };
+
+    if (limits.movetime)
+    {
+        budget.useTime = true;
+        budget.endTime = start + limits.movetime;
+    }
+    else if (limits.time[rootColor])
+    {
+        const TimePoint available = compute_available_time(limits.time[rootColor], limits.inc[rootColor],
+                                                           limits.movestogo);
+        if (available)
+        {
+            budget.useTime = true;
+            budget.endTime = start + available;
+        }
+    }
+
+    return budget;
+}
+
+double rollout(Position& pos,
+               PRNG& rng,
+               std::array<StateInfo, MAX_PLY>& stateStack,
+               int depthOffset,
+               int maxDepth) {
+    std::vector<Move> played;
+    played.reserve(maxDepth);
+
+    for (int depth = 0; depth < maxDepth; ++depth)
+    {
+        if (pos.is_draw(0))
+        {
+            for (int i = depth - 1; i >= 0; --i)
+                pos.undo_move(played[i]);
+            return value_to_double(VALUE_DRAW);
+        }
+
+        MoveList<LEGAL> legal(pos);
+        if (legal.size() == 0)
+        {
+            Value terminal = pos.checkers() ? VALUE_MATED_IN_MAX_PLY : VALUE_DRAW;
+            for (int i = depth - 1; i >= 0; --i)
+                pos.undo_move(played[i]);
+            return value_to_double(terminal);
+        }
+
+        const Move move = legal[size_t(rng.rand<std::uint32_t>()) % legal.size()];
+        StateInfo& st   = stateStack[depthOffset + depth];
+        pos.do_move(move, st);
+        played.push_back(move);
+    }
+
+    Value eval = Value(Eval::simple_eval(pos));
+
+    for (int i = int(played.size()) - 1; i >= 0; --i)
+        pos.undo_move(played[i]);
+
+    return value_to_double(eval);
+}
+
+Node* best_child_for_player(Node& node) {
+    Node*  best      = nullptr;
+    double bestScore = -std::numeric_limits<double>::infinity();
+
+    for (auto& childPtr : node.children)
+    {
+        Node* child = childPtr.get();
+        if (!child->visits)
+            continue;
+
+        const double mean = child->totalValue / std::max<std::uint64_t>(1, child->visits);
+        const double score = -mean;
+
+        if (score > bestScore)
+        {
+            bestScore = score;
+            best      = child;
+        }
+    }
+
+    return best;
+}
+
+}  // namespace
+
+Result analyze(Position&                 rootPos,
+               Color                     rootColor,
+               const OptionsMap&         options,
+               const Search::LimitsType& limits,
+               std::function<bool()>     stopRequested,
+               int                       rolloutDepthHint) {
+    Result result{};
+
+    PRNG rng(std::max<uint64_t>(1, uint64_t(now()) | 1));
+
+    Budget budget = compute_budget(options, limits, rootColor);
+
+    const int rolloutDepth = std::clamp(rolloutDepthHint, 4, 64);
+
+    Position pos = rootPos;
+
+    Node root;
+    root.move          = Move::none();
+    root.toMove        = rootColor;
+    root.unexpandedMoves = generate_moves(pos, rng);
+    root.terminal      = root.unexpandedMoves.empty();
+    if (root.terminal)
+        root.terminalValue = terminal_evaluation(pos);
+
+    std::array<StateInfo, MAX_PLY> stateStack{};
+
+    const double exploration = 1.41421356237;
+
+    std::uint64_t iterations = 0;
+    const TimePoint start    = now();
+
+    while (!root.terminal)
+    {
+        if (stopRequested())
+            break;
+
+        if (budget.useTime && now() >= budget.endTime)
+            break;
+
+        if (budget.maxIterations && iterations >= budget.maxIterations)
+            break;
+
+        std::vector<Node*> nodeStack;
+        nodeStack.reserve(rolloutDepth + 1);
+        nodeStack.push_back(&root);
+
+        std::vector<Move> moveStack;
+        moveStack.reserve(rolloutDepth + 1);
+
+        Position current = pos;
+        int      depth   = 0;
+
+        while (true)
+        {
+            Node* node = nodeStack.back();
+
+            if (node->terminal)
+                break;
+
+            if (!node->unexpandedMoves.empty())
+            {
+                const Move move = node->unexpandedMoves.back();
+                node->unexpandedMoves.pop_back();
+
+                StateInfo& st = stateStack[depth];
+                current.do_move(move, st);
+                moveStack.push_back(move);
+                depth++;
+
+                auto child       = std::make_unique<Node>();
+                child->move      = move;
+                child->toMove    = current.side_to_move();
+                child->unexpandedMoves = generate_moves(current, rng);
+                child->terminal  = child->unexpandedMoves.empty();
+                if (child->terminal)
+                    child->terminalValue = terminal_evaluation(current);
+
+                Node* childPtr = child.get();
+                node->children.push_back(std::move(child));
+                nodeStack.push_back(childPtr);
+                break;
+            }
+
+            if (node->children.empty())
+                break;
+
+            const double logVisits = std::log(std::max<std::uint64_t>(1, node->visits));
+            Node*        bestChild = nullptr;
+            double       bestScore = -std::numeric_limits<double>::infinity();
+
+            for (auto& childPtr : node->children)
+            {
+                Node* child = childPtr.get();
+                const double mean = child->visits ? child->totalValue / child->visits : 0.0;
+                const double exploitation = -mean;
+                const double explorationTerm = exploration
+                                               * std::sqrt(logVisits
+                                                           / (child->visits + 1.0));
+                const double score = exploitation + explorationTerm;
+                if (score > bestScore)
+                {
+                    bestScore = score;
+                    bestChild = child;
+                }
+            }
+
+            if (!bestChild)
+                break;
+
+            StateInfo& st = stateStack[depth];
+            current.do_move(bestChild->move, st);
+            moveStack.push_back(bestChild->move);
+            depth++;
+            nodeStack.push_back(bestChild);
+        }
+
+        Node* leaf = nodeStack.back();
+
+        double evaluation;
+        if (leaf->terminal)
+            evaluation = value_to_double(leaf->terminalValue);
+        else
+            evaluation = rollout(current, rng, stateStack, depth, rolloutDepth - depth);
+
+        for (int i = int(nodeStack.size()) - 1; i >= 0; --i)
+        {
+            Node* node = nodeStack[size_t(i)];
+            node->visits++;
+            node->totalValue += evaluation;
+            evaluation = -evaluation;
+        }
+
+        for (int i = int(moveStack.size()) - 1; i >= 0; --i)
+            current.undo_move(moveStack[size_t(i)]);
+
+        ++iterations;
+    }
+
+    result.simulations = iterations;
+    result.elapsedMs   = now() - start;
+
+    if (root.visits)
+    {
+        const double mean = root.totalValue / root.visits;
+        result.evaluation = double_to_value(mean);
+    }
+    else
+        result.evaluation = VALUE_ZERO;
+
+    result.moveStats.reserve(root.children.size());
+
+    Node* best = nullptr;
+    double bestScore = -std::numeric_limits<double>::infinity();
+
+    for (auto& childPtr : root.children)
+    {
+        Node* child = childPtr.get();
+        const double mean   = child->visits ? child->totalValue / child->visits : 0.0;
+        const double score  = -mean;
+        result.moveStats.push_back({child->move, score, child->visits});
+        if (score > bestScore)
+        {
+            bestScore = score;
+            best      = child;
+        }
+    }
+
+    if (best)
+    {
+        result.bestMove = best->move;
+        result.principalVariation.push_back(best->move);
+
+        Node* current = best;
+        int   depth   = 1;
+        while (current && depth < rolloutDepth)
+        {
+            current = best_child_for_player(*current);
+            if (!current)
+                break;
+            result.principalVariation.push_back(current->move);
+            ++depth;
+        }
+    }
+
+    if (result.principalVariation.empty())
+        result.principalVariation.push_back(Move::none());
+
+    return result;
+}
+
+}  // namespace MCTS
+}  // namespace Stockfish
+

--- a/src/mcts.h
+++ b/src/mcts.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+#include "misc.h"
+#include "types.h"
+
+namespace Stockfish {
+
+class OptionsMap;
+class Position;
+
+namespace Search {
+struct LimitsType;
+struct RootMove;
+}
+
+namespace MCTS {
+
+struct MoveStats {
+    Move           move;
+    double         averageValue;
+    std::uint64_t  visits;
+};
+
+struct Result {
+    Move                          bestMove;
+    std::vector<Move>             principalVariation;
+    Value                         evaluation;
+    std::vector<MoveStats>        moveStats;
+    std::uint64_t                 simulations;
+    TimePoint                     elapsedMs;
+};
+
+Result analyze(Position&                    rootPos,
+               Color                        rootColor,
+               const OptionsMap&            options,
+               const Search::LimitsType&    limits,
+               std::function<bool()>        stopRequested,
+               int                          rolloutDepthHint = 12);
+
+}  // namespace MCTS
+
+}  // namespace Stockfish
+

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -40,6 +40,7 @@
 #include "misc.h"
 #include "movegen.h"
 #include "movepick.h"
+#include "mcts.h"
 #include "nnue/network.h"
 #include "nnue/nnue_accumulator.h"
 #include "position.h"
@@ -220,12 +221,17 @@ void Search::Worker::start_searching() {
                             main_manager()->originalTimeAdjust);
     tt.new_search();
 
+    const bool useMcts = options.count("Search Strategy")
+                         && options["Search Strategy"] == "MCTS";
+
     if (rootMoves.empty())
     {
         rootMoves.emplace_back(Move::none());
         main_manager()->updates.onUpdateNoMoves(
           {0, {rootPos.checkers() ? -VALUE_MATE : VALUE_DRAW, rootPos}});
     }
+    else if (useMcts)
+        run_monte_carlo();
     else
     {
         threads.start_searching();  // start non-main threads
@@ -293,6 +299,129 @@ void Search::Worker::start_searching() {
 // Main iterative deepening loop. It calls search()
 // repeatedly with increasing depth until the allocated thinking time has been
 // consumed, the user stops the search, or the maximum search depth is reached.
+void Search::Worker::run_monte_carlo() {
+
+    auto stopRequested = [&]() { return threads.stop.load(std::memory_order_relaxed); };
+
+    const int depthHint = limits.depth ? std::clamp<int>(2 * limits.depth, 4, MAX_PLY - 1) : 12;
+
+    const auto result =
+      MCTS::analyze(rootPos, rootPos.side_to_move(), options, limits, stopRequested, depthHint);
+
+    nodes.store(result.simulations, std::memory_order_relaxed);
+    tbHits.store(0, std::memory_order_relaxed);
+
+    completedDepth = rootDepth = Depth(depthHint);
+    selDepth       = depthHint;
+
+    auto to_value = [](double pawns) {
+        const double limit   = double(VALUE_MATE) / PawnValue;
+        const double clamped = std::clamp(pawns, -limit, limit);
+        const int    scaled  = int(std::round(clamped * PawnValue));
+        return Value(std::clamp(scaled, -VALUE_MATE, VALUE_MATE));
+    };
+
+    for (auto& rm : rootMoves)
+    {
+        const Move move = rm.pv.empty() ? Move::none() : rm.pv[0];
+        const auto statIt = std::find_if(result.moveStats.begin(), result.moveStats.end(),
+                                         [&](const MCTS::MoveStats& s) { return s.move == move; });
+
+        const Value score = statIt != result.moveStats.end() ? to_value(statIt->averageValue)
+                                                             : -VALUE_INFINITE;
+
+        rm.score            = score;
+        rm.previousScore    = score;
+        rm.averageScore     = score;
+        rm.meanSquaredScore = (score == -VALUE_INFINITE) ? score : Value(int(score) * int(score));
+        rm.uciScore         = score;
+        rm.scoreLowerbound  = false;
+        rm.scoreUpperbound  = false;
+        rm.selDepth         = depthHint;
+        rm.tbRank           = 0;
+        rm.tbScore          = score;
+        rm.effort           = statIt != result.moveStats.end() ? statIt->visits : 0;
+        rm.pv.assign(1, move);
+    }
+
+    if (!result.principalVariation.empty() && result.principalVariation[0].is_ok())
+    {
+        auto bestIt = std::find_if(rootMoves.begin(), rootMoves.end(), [&](const RootMove& rm) {
+            return !rm.pv.empty() && rm.pv[0] == result.principalVariation[0];
+        });
+
+        if (bestIt != rootMoves.end())
+        {
+            bestIt->pv.clear();
+            for (Move m : result.principalVariation)
+            {
+                if (!m.is_ok())
+                    break;
+                bestIt->pv.push_back(m);
+            }
+        }
+    }
+
+    std::sort(rootMoves.begin(), rootMoves.end());
+
+    if (!rootMoves.empty())
+    {
+        if (rootMoves[0].score == -VALUE_INFINITE)
+        {
+            rootMoves[0].score        = VALUE_ZERO;
+            rootMoves[0].averageScore = VALUE_ZERO;
+            rootMoves[0].uciScore     = VALUE_ZERO;
+        }
+
+        main_manager()->bestPreviousScore        = rootMoves[0].score;
+        main_manager()->bestPreviousAverageScore = rootMoves[0].averageScore;
+    }
+
+    pvIdx  = 0;
+    pvLast = rootMoves.size();
+
+    const TimePoint elapsed = std::max<TimePoint>(TimePoint(1), result.elapsedMs);
+    const uint64_t  nps     = result.elapsedMs ? (result.simulations * 1000 / elapsed) : 0;
+    const bool      showWdl = bool(options["UCI_ShowWDL"]);
+
+    const size_t multiPV = std::min<size_t>(options["MultiPV"], rootMoves.size());
+
+    for (size_t i = 0; i < multiPV; ++i)
+    {
+        RootMove& rm = rootMoves[i];
+
+        std::string pv;
+        for (Move m : rm.pv)
+        {
+            if (!m.is_ok())
+                break;
+            pv += UCIEngine::move(m, rootPos.is_chess960()) + " ";
+        }
+        if (!pv.empty())
+            pv.pop_back();
+
+        std::string wdl;
+        if (showWdl && rm.score != -VALUE_INFINITE)
+            wdl = UCIEngine::wdl(rm.score, rootPos);
+
+        InfoFull info;
+        info.depth    = depthHint;
+        info.selDepth = depthHint;
+        info.multiPV  = i + 1;
+        info.score    = {rm.score, rootPos};
+        info.wdl      = wdl;
+        info.bound    = "";
+        info.timeMs   = elapsed;
+        info.nodes    = result.simulations;
+        info.nps      = nps;
+        info.tbHits   = 0;
+        info.pv       = pv;
+        info.hashfull = tt.hashfull();
+
+        main_manager()->updates.onUpdateFull(info);
+    }
+}
+
 void Search::Worker::iterative_deepening() {
 
     SearchManager* mainThread = (is_mainthread() ? main_manager() : nullptr);

--- a/src/search.h
+++ b/src/search.h
@@ -272,7 +272,7 @@ class Worker {
 
     // Called when the program receives the UCI 'go' command.
     // It searches from the root position and outputs the "bestmove".
-    void start_searching();
+   void start_searching();
 
     bool is_mainthread() const { return threadIdx == 0; }
 
@@ -294,7 +294,8 @@ class Worker {
     TTMoveHistory ttMoveHistory;
 
    private:
-    void iterative_deepening();
+   void iterative_deepening();
+    void run_monte_carlo();
 
     void do_move(Position& pos, const Move move, StateInfo& st, Stack* const ss);
     void


### PR DESCRIPTION
## Summary
- add a Monte Carlo Tree Search analysis module with budgeting, selection, rollout, and statistics reporting
- expose a new "Search Strategy" UCI option and route main-thread search through the MCTS pipeline when selected
- update build configuration to compile the new module

## Testing
- ninja *(fails: build.ninja is not present in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918820fd5488327bb8886154d145b1a)