### PR TITLE
Update experience subsystem naming to Wordfish and ensure book creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ the [UCI commands][wiki-uci-link] supported by Stockfish.
 
 ## Self-learning
 
-Wordfish integra el sistema de experiencia `Deepalienist` para permitir que el
+Wordfish integra el sistema de experiencia `Wordfish` para permitir que el
 motor aprenda de sus propias búsquedas y genere un libro personalizado. El
 módulo se controla mediante opciones UCI y trabaja sobre archivos `.exp` que
 almacenan las posiciones analizadas.
@@ -117,7 +117,7 @@ almacenan las posiciones analizadas.
    autoaprendizaje y **Experience Book** si desea que el motor utilice las
    jugadas almacenadas al ordenar los movimientos en la raíz.
 2. Ajuste **Experience File** con la ruta al archivo de experiencia que quiera
-   usar; por defecto se crea `Deepalienist.exp` en el directorio del motor.
+   usar; por defecto se crea `Wordfish.exp` en el directorio del motor.
 3. Si solo desea consultar la información sin modificar el archivo, habilite
    **Experience Readonly**.
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -59,7 +59,7 @@ SRCS = benchmark.cpp bitboard.cpp evaluate.cpp experience.cpp main.cpp \
         nnue/features/half_ka_v2_hm.cpp nnue/features/full_threats.cpp \
         engine.cpp score.cpp memory.cpp
 
-HEADERS = benchmark.h bitboard.h evaluate.h experience.h experience_compat.h deepalienist_zobrist.h misc.h movegen.h movepick.h mcts.h history.h \
+HEADERS = benchmark.h bitboard.h evaluate.h experience.h experience_compat.h Wordfish_zobrist.h misc.h movegen.h movepick.h mcts.h history.h \
                 nnue/nnue_misc.h nnue/features/half_ka_v2_hm.h nnue/features/full_threats.h \
                 nnue/layers/affine_transform.h nnue/layers/affine_transform_sparse_input.h \
                 nnue/layers/clipped_relu.h nnue/layers/sqr_clipped_relu.h nnue/nnue_accumulator.h \

--- a/src/Wordfish_zobrist.h
+++ b/src/Wordfish_zobrist.h
@@ -1,5 +1,5 @@
 /*
-  Deepalienist experience hashing utilities
+  Wordfish experience hashing utilities
   Copyright (C) 2025
 
   This file defines helper routines used by the self-learning subsystem to
@@ -9,8 +9,8 @@
   project.
 */
 
-#ifndef DEEPALIENIST_ZOBRIST_H_INCLUDED
-#define DEEPALIENIST_ZOBRIST_H_INCLUDED
+#ifndef WORDFISH_ZOBRIST_H_INCLUDED
+#define WORDFISH_ZOBRIST_H_INCLUDED
 
 #include <cstdint>
 
@@ -38,4 +38,4 @@ inline std::uint64_t mix(std::uint64_t value) { return splitmix64(value); }
 
 }  // namespace Stockfish::Experience::Zobrist
 
-#endif  // #ifndef DEEPALIENIST_ZOBRIST_H_INCLUDED
+#endif  // #ifndef WORDFISH_ZOBRIST_H_INCLUDED

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -147,7 +147,7 @@ Engine::Engine(std::optional<std::string> path) :
     };
 
     options.add("Experience Enabled", Option(true, updateExperience));
-    options.add("Experience File", Option("Deepalienist.exp", updateExperience));
+    options.add("Experience File", Option("Wordfish.exp", updateExperience));
     options.add("Experience Readonly", Option(false, updateExperience));
     options.add("Experience Book", Option(false, updateExperience));
     options.add("Experience Book Width", Option(1, 1, 32, updateExperience));

--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -22,7 +22,7 @@
 #include <cstdlib>
 #include <system_error>
 
-#include "deepalienist_zobrist.h"
+#include "Wordfish_zobrist.h"
 #include "experience_compat.h"
 #include "misc.h"
 #include "position.h"
@@ -50,7 +50,7 @@ struct Settings {
     int         bookEvalImportance = 5;
     Depth       bookMinDepth       = 27;
     int         bookMaxMoves       = 16;
-    std::string file               = "Deepalienist.exp";
+    std::string file               = "Wordfish.exp";
     std::size_t maxEntries         = 200000;
     Value       minScore           = Value(20);
 };
@@ -72,6 +72,8 @@ constexpr std::size_t                                 FlushInterval        = 64;
 Stats                                                 stats;
 std::string                                           lastStatus;
 bool                                                  settingsInitialized = false;
+
+void ensure_file_exists_unlocked();
 
 std::uint64_t compute_key(const Position& pos) {
     using namespace Experience::Zobrist;
@@ -222,7 +224,7 @@ void save_table_unlocked(const std::string& file) {
     if (!out)
         return;
 
-    out << "# Deepalienist experience format v1\n";
+    out << "# Wordfish experience format v1\n";
     for (const auto key : lru)
     {
         const auto it = table.find(key);
@@ -238,6 +240,18 @@ void save_table_unlocked(const std::string& file) {
                 << int(e.eval) << ' ' << int(e.depth) << ' ' << unsigned(e.visits) << '\n';
         }
     }
+}
+
+void ensure_file_exists_unlocked() {
+    if (settings.readonly || settings.file.empty())
+        return;
+
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    if (fs::exists(settings.file, ec))
+        return;
+
+    save_table_unlocked(settings.file);
 }
 
 bool load_text_format(std::istream& in, Stats& loadStats) {
@@ -435,15 +449,24 @@ void load_table_unlocked(const std::string& file) {
 }
 
 void flush_unlocked() {
-    if (!dirty)
-        return;
-
     if (settings.readonly)
     {
         dirty        = false;
         pendingFlush = 0;
         return;
     }
+
+    bool shouldSave = dirty;
+
+    if (!shouldSave && !settings.file.empty())
+    {
+        namespace fs = std::filesystem;
+        std::error_code ec;
+        shouldSave = !fs::exists(settings.file, ec);
+    }
+
+    if (!shouldSave)
+        return;
 
     save_table_unlocked(settings.file);
     dirty        = false;
@@ -463,7 +486,7 @@ std::optional<std::string> update_settings(const OptionsMap& options) {
     if (options.count("Experience File"))
         newSettings.file = std::string(options["Experience File"]);
     else if (newSettings.file.empty())
-        newSettings.file = "Deepalienist.exp";
+        newSettings.file = "Wordfish.exp";
 
     if (options.count("Experience Readonly"))
         newSettings.readonly = bool(int(options["Experience Readonly"]));
@@ -530,6 +553,8 @@ std::optional<std::string> update_settings(const OptionsMap& options) {
         load_table_unlocked(settings.file);
     else
         lastStatus = format_status_unlocked();
+
+    ensure_file_exists_unlocked();
 
     settingsInitialized = true;
     return lastStatus;

--- a/src/experience.h
+++ b/src/experience.h
@@ -1,5 +1,5 @@
 /*
-  Deepalienist self learning public interface
+  Wordfish self learning public interface
 */
 
 #ifndef EXPERIENCE_H_INCLUDED

--- a/src/experience_compat.h
+++ b/src/experience_compat.h
@@ -1,5 +1,5 @@
 /*
-  Deepalienist self learning compatibility helpers
+  Wordfish self learning compatibility helpers
   This header exposes helpers to import legacy experience book formats.
 */
 

--- a/src/sparsehash/dense_hash_map
+++ b/src/sparsehash/dense_hash_map
@@ -98,7 +98,7 @@
 
 #if 0 //Original code
 #include <sparsehash/internal/sparseconfig.h>
-#else //Deepalienist
+#else //Wordfish
 #include "internal/sparseconfig.h"
 #endif
 #include <algorithm>                        // needed by stl_alloc
@@ -108,7 +108,7 @@
 #if 0 //Original code
 #include <sparsehash/internal/densehashtable.h>        // IWYU pragma: export
 #include <sparsehash/internal/libc_allocator_with_realloc.h>
-#else //Deepalienist
+#else //Wordfish
 #include "internal/densehashtable.h"
 #include "internal/libc_allocator_with_realloc.h"
 #endif

--- a/src/sparsehash/dense_hash_set
+++ b/src/sparsehash/dense_hash_set
@@ -102,7 +102,7 @@
 
 #if 0 //Original code
 #include <sparsehash/internal/sparseconfig.h>
-#else //Deepalienist
+#else //Wordfish
 #include "internal/sparseconfig.h"
 #endif
 #include <algorithm>                        // needed by stl_alloc
@@ -112,7 +112,7 @@
 #if 0 //Original code
 #include <sparsehash/internal/densehashtable.h>        // IWYU pragma: export
 #include <sparsehash/internal/libc_allocator_with_realloc.h>
-#else //Deepalienist
+#else //Wordfish
 #include "internal/densehashtable.h"
 #include "internal/libc_allocator_with_realloc.h"
 #endif

--- a/src/sparsehash/internal/densehashtable.h
+++ b/src/sparsehash/internal/densehashtable.h
@@ -91,7 +91,7 @@
 
 #if 0 //Original code
 #include <sparsehash/internal/sparseconfig.h>
-#else //Deepalienist
+#else //Wordfish
 #include "sparseconfig.h"
 #endif
 #include <assert.h>
@@ -105,7 +105,7 @@
 #include <sparsehash/internal/hashtable-common.h>
 #include <sparsehash/internal/libc_allocator_with_realloc.h>
 #include <sparsehash/type_traits.h>
-#else //Deepalienist
+#else //Wordfish
 #include "hashtable-common.h"
 #include "libc_allocator_with_realloc.h"
 #include "../type_traits.h"
@@ -588,7 +588,7 @@ class dense_hashtable {
         (std::numeric_limits<size_type>::max)() - delta) {
 #if 0 //Original code
 	  throw std::length_error("resize overflow");
-#else //Deepalienist
+#else //Wordfish
       exit(EXIT_FAILURE);
 #endif
     }
@@ -929,7 +929,7 @@ class dense_hashtable {
     if (size() >= max_size()) {
 #if 0 //Original code
 	  throw std::length_error("insert overflow");
-#else //Deepalienist
+#else //Wordfish
       exit(EXIT_FAILURE);
 #endif
     }
@@ -972,7 +972,7 @@ class dense_hashtable {
     if (dist >= (std::numeric_limits<size_type>::max)()) {
 #if 0 //Original code
 	  throw std::length_error("insert-range overflow");
-#else //Deepalienist
+#else //Wordfish
       exit(EXIT_FAILURE);
 #endif
     }

--- a/src/sparsehash/internal/hashtable-common.h
+++ b/src/sparsehash/internal/hashtable-common.h
@@ -42,7 +42,7 @@
 
 #if 0 //Original code
 #include <sparsehash/internal/sparseconfig.h>
-#else //Deepalienist
+#else //Wordfish
 #include "sparseconfig.h"
 #endif
 #include <assert.h>
@@ -340,7 +340,7 @@ class sh_hashtable_settings : public HashFunc {
       if (static_cast<size_type>(sz * 2) < sz) {
 #if 0 //Original code
         throw std::length_error("resize overflow");  // protect against overflow
-#else //Deepalienist
+#else //Wordfish
         exit(EXIT_FAILURE);
 #endif
       }

--- a/src/sparsehash/internal/libc_allocator_with_realloc.h
+++ b/src/sparsehash/internal/libc_allocator_with_realloc.h
@@ -34,7 +34,7 @@
 
 #if 0 //Original code
 #include <sparsehash/internal/sparseconfig.h>
-#else //Deepalienist
+#else //Wordfish
 #include "sparseconfig.h"
 #endif
 #include <stdlib.h>           // for malloc/realloc/free
@@ -69,14 +69,14 @@ class libc_allocator_with_realloc {
     free(p);
   }
   pointer reallocate(pointer p, size_type n) {
-#if 1 //Deepalienist
+#if 1 //Wordfish
 #if __GNUC__ > 7
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wclass-memaccess"
 #endif
 #endif
     return static_cast<pointer>(realloc(p, n * sizeof(value_type)));
-#if 1 //Deepalienist
+#if 1 //Wordfish
 #if __GNUC__ > 7
 #pragma GCC diagnostic pop
 #endif

--- a/src/sparsehash/internal/sparsehashtable.h
+++ b/src/sparsehash/internal/sparsehashtable.h
@@ -97,7 +97,7 @@
 
 #if 0 //Original code
 #include <sparsehash/internal/sparseconfig.h>
-#else //Deepalienist
+#else //Wordfish
 #include "sparseconfig.h"
 #endif
 #include <assert.h>
@@ -109,7 +109,7 @@
 #include <sparsehash/type_traits.h>        // for remove_const
 #include <sparsehash/internal/hashtable-common.h>
 #include <sparsehash/sparsetable>    // IWYU pragma: export
-#else //Deepalienist
+#else //Wordfish
 #include "../type_traits.h"          // for remove_const
 #include "hashtable-common.h"
 #include "../sparsetable"    // IWYU pragma: export
@@ -627,7 +627,7 @@ class sparse_hashtable {
         (std::numeric_limits<size_type>::max)() - delta) {
 #if 0 //Original code
 	  throw std::length_error("resize overflow");
-#else //Deepalienist
+#else //Wordfish
       exit(EXIT_FAILURE);
 #endif
     }
@@ -941,7 +941,7 @@ class sparse_hashtable {
     if (size() >= max_size()) {
 #if 0 //Original code
 	  throw std::length_error("insert overflow");
-#else //Deepalienist
+#else //Wordfish
       exit(EXIT_FAILURE);
 #endif
     }
@@ -977,7 +977,7 @@ class sparse_hashtable {
     if (dist >= (std::numeric_limits<size_type>::max)()) {
 #if 0 //Original code
 	  throw std::length_error("insert-range overflow");
-#else //Deepalienist
+#else //Wordfish
       exit(EXIT_FAILURE);
 #endif
     }

--- a/src/sparsehash/sparse_hash_map
+++ b/src/sparsehash/sparse_hash_map
@@ -86,7 +86,7 @@
 
 #if 0 //Original code
 #include <sparsehash/internal/sparseconfig.h>
-#else //Deepalienist
+#else //Wordfish
 #include "internal/sparseconfig.h"
 #endif
 #include <algorithm>                        // needed by stl_alloc
@@ -96,7 +96,7 @@
 #if 0 //Original code
 #include <sparsehash/internal/libc_allocator_with_realloc.h>
 #include <sparsehash/internal/sparsehashtable.h>       // IWYU pragma: export
-#else //Deepalienist
+#else //Wordfish
 #include "internal/libc_allocator_with_realloc.h"
 #include "internal/sparsehashtable.h"       // IWYU pragma: export
 #endif

--- a/src/sparsehash/sparse_hash_set
+++ b/src/sparsehash/sparse_hash_set
@@ -100,7 +100,7 @@
 #if 0 //Original code
 #include <sparsehash/internal/libc_allocator_with_realloc.h>
 #include <sparsehash/internal/sparsehashtable.h>      // IWYU pragma: export
-#else //Deepalienist
+#else //Wordfish
 #include "internal/libc_allocator_with_realloc.h"
 #include "internal/sparsehashtable.h"      // IWYU pragma: export
 #endif

--- a/src/sparsehash/sparsetable
+++ b/src/sparsehash/sparsetable
@@ -226,7 +226,7 @@
 
 #if 0 //Original code
 #include <sparsehash/internal/sparseconfig.h>
-#else //Deepalienist
+#else //Wordfish
 #include "internal/sparseconfig.h"
 #endif
 #include <stdlib.h>             // for malloc/free
@@ -250,7 +250,7 @@
 #include <sparsehash/type_traits.h>
 #include <sparsehash/internal/hashtable-common.h>
 #include <sparsehash/internal/libc_allocator_with_realloc.h>
-#else //Deepalienist
+#else //Wordfish
 #include "type_traits.h"
 #include "internal/hashtable-common.h"
 #include "internal/libc_allocator_with_realloc.h"
@@ -1075,7 +1075,7 @@ class sparsegroup {
     return group[pos_to_offset(bitmap, i)];
   }
 
-  // Syntactic Deepalienist.  It's easy to return a const reference.  To
+  // Syntactic Wordfish.  It's easy to return a const reference.  To
   // return a non-const reference, we need to use the assigner adaptor.
   const_reference operator[](size_type i) const {
     return get(i);
@@ -1572,7 +1572,7 @@ class sparsetable {
     return retval;
   }
 
-  // Syntactic Deepalienist.  As in sparsegroup, the non-const version is harder
+  // Syntactic Wordfish.  As in sparsegroup, the non-const version is harder
   const_reference operator[](size_type i) const {
     return get(i);
   }

--- a/src/sparsehash/template_util.h
+++ b/src/sparsehash/template_util.h
@@ -51,7 +51,7 @@
 
 #if 0 //Original code
 #include <sparsehash/internal/sparseconfig.h>
-#else //Deepalienist
+#else //Wordfish
 #include "internal/sparseconfig.h"
 #endif
 _START_GOOGLE_NAMESPACE_

--- a/src/sparsehash/type_traits.h
+++ b/src/sparsehash/type_traits.h
@@ -59,14 +59,14 @@
 
 #if 0 //Original code
 #include <sparsehash/internal/sparseconfig.h>
-#else //Deepalienist
+#else //Wordfish
 #include "internal/sparseconfig.h"
 #endif
 #include <utility>                  // For pair
 
 #if 0 //Original code
 #include <sparsehash/template_util.h>     // For true_type and false_type
-#else //Deepalienist
+#else //Wordfish
 #include "template_util.h"          // For true_type and false_type
 #endif
 


### PR DESCRIPTION
## Summary
- rename the experience hashing header and all related references from Deepalienist to Wordfish
- update defaults, documentation, and experience file metadata to use Wordfish branding
- ensure the experience module creates the configured book file even when no data has been written yet

## Testing
- make -C src build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918888b42408327a78b7d8887f8cfa2)