### PR TITLE
Ensure experience file flushes after deep searches

### DIFF
--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -713,7 +713,13 @@ void on_search_complete(const Position& pos,
     stats.totalPositions = table.size();
 
     dirty = true;
-    if (++pendingFlush >= FlushInterval)
+
+    bool shouldFlush = ++pendingFlush >= FlushInterval;
+
+    if (!shouldFlush && searchedDepth >= Depth(27))
+        shouldFlush = true;
+
+    if (shouldFlush)
         flush_unlocked();
 
     lastStatus = format_status_unlocked();


### PR DESCRIPTION
## Summary
- ensure experience data flushes immediately whenever a completed search meets or exceeds the default depth threshold
- retain the periodic flush safeguard for other updates to avoid losing experience data

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918921a8cc48327ada5dfd4dc714c91)