### PR TITLE
Flush experience data after each search

### DIFF
--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -693,6 +693,14 @@ void on_search_complete(const Position& pos,
         flush_unlocked();
 
     lastStatus = format_status_unlocked();
+
+    // Make sure the experience file is persisted after each completed search so
+    // external GUIs that immediately inspect the file (e.g. after the "go"
+    // command finishes) observe the freshly recorded moves.  DeepAlienist writes
+    // the updated data eagerly and Wordfish needs to match that behaviour so the
+    // experience file is kept in sync even when the engine is stopped before the
+    // periodic flush threshold is reached.
+    flush_unlocked();
 }
 
 void new_game() {


### PR DESCRIPTION
## Summary
- flush the experience table immediately after each completed search to mirror DeepAlienist behaviour
- document why the flush is triggered eagerly so GUI sessions see freshly saved moves

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69189a1383f883278c70306eb9866705)