### PR TITLE
Add helper to sync main branch with work

### DIFF
--- a/docs/branch_migration.md
+++ b/docs/branch_migration.md
@@ -13,8 +13,37 @@ Este repositorio ha sido preparado para que el trabajo realizado en la rama `wor
 2. Se conservó el historial existente para que cualquier seguimiento sea transparente.
 3. Se dejó constancia de la migración mediante este documento.
 
+## Cómo garantizar que no haya conflictos con `main`
+
+Para evitar que el historial anterior de `main` introduzca conflictos al
+fusionar los trabajos de `work`, se puede alinear directamente el contenido de
+ambas ramas. El repositorio incluye ahora un script que automatiza el proceso:
+
+```bash
+./scripts/reset_main_to_work.sh
+```
+
+El script:
+
+1. Verifica que el árbol de trabajo esté limpio.
+2. Crea la rama `main` (si aún no existe) o se cambia a ella.
+3. Restablece `main` para que sea idéntica a `work`, eliminando cualquier
+   archivo rastreado que pudiese generar conflictos.
+4. Devuelve al usuario a la rama original en la que estaba trabajando.
+
+Si se prefiere realizar los pasos manualmente, se puede ejecutar la siguiente
+secuencia de comandos:
+
+```bash
+git checkout main        # o git checkout -b main work si aún no existe
+git reset --hard work    # descarta cualquier cambio previo en main
+git clean -fd            # elimina archivos/directorios rastreados obsoletos
+git checkout work        # vuelve a la rama de trabajo
+```
+
 ## Próximos pasos sugeridos
 
+- Ejecutar el script anterior antes de publicar `main` como rama predeterminada.
 - Establecer `main` como la rama por defecto en el repositorio remoto.
 - Eliminar la rama `work` cuando ya no sea necesaria.
 - Continuar con el desarrollo habitual tomando `main` como base.

--- a/scripts/reset_main_to_work.sh
+++ b/scripts/reset_main_to_work.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script resets the local "main" branch so that it matches "work" exactly.
+# It removes any tracked files from "main" that could conflict with "work".
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "Este script debe ejecutarse dentro de un repositorio Git." >&2
+  exit 1
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "El árbol de trabajo debe estar limpio antes de continuar." >&2
+  echo "Por favor, commitea o descarta los cambios pendientes." >&2
+  exit 1
+fi
+
+if ! git show-ref --quiet refs/heads/work; then
+  echo "La rama 'work' no existe en este repositorio." >&2
+  exit 1
+fi
+
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+
+cleanup() {
+  # Intenta volver a la rama original para no interrumpir el flujo del usuario.
+  git checkout "$current_branch" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# Crea "main" si no existe y cambia a ella.
+if git show-ref --quiet refs/heads/main; then
+  git checkout main >/dev/null 2>&1
+else
+  git checkout -b main work >/dev/null 2>&1
+fi
+
+# Alinea "main" con "work", eliminando cualquier contenido previo.
+git reset --hard work >/dev/null 2>&1
+git clean -fd >/dev/null 2>&1
+
+echo "La rama 'main' ahora es idéntica a 'work'."
+
+trap - EXIT
+git checkout "$current_branch" >/dev/null 2>&1


### PR DESCRIPTION
## Summary
- add a `reset_main_to_work.sh` helper that resets the local `main` branch to match `work`
- document the automated and manual steps to wipe conflicting content from `main`

## Testing
- bash -n scripts/reset_main_to_work.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69189e45c89c83279da181e82debbda7)