### PR TITLE
Update Wordfish branding to 3.40-181125

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = Wordfish-3.30-151125.exe
+        EXE = Wordfish-3.40-181125.exe
 else
-        EXE = Wordfish-3.30-151125
+        EXE = Wordfish-3.40-181125
 endif
 
 ### Installation dir definitions

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -40,7 +40,7 @@ namespace Stockfish {
 namespace {
 
 // Engine branding information.
-constexpr std::string_view engine_name = "Wordfish-3.30-151125";
+constexpr std::string_view engine_name = "Wordfish-3.40-181125";
 constexpr std::string_view engine_author_name =
   "Jorge Ruiz and the Stockfish developers (see AUTHORS file)";
 constexpr std::string_view engine_author_prefix = "Developed by ";
@@ -126,7 +126,7 @@ std::string engine_info(bool to_uci) {
 
     if (to_uci)
     {
-        info += "\nid author ";
+        info += " ";
         info += engine_author_prefix;
         info += engine_author_name;
     }
@@ -136,6 +136,12 @@ std::string engine_info(bool to_uci) {
         info += engine_author_name;
     }
 
+    return info;
+}
+
+std::string engine_author_info() {
+    std::string info = std::string(engine_author_prefix);
+    info += engine_author_name;
     return info;
 }
 

--- a/src/misc.h
+++ b/src/misc.h
@@ -43,6 +43,7 @@ namespace Stockfish {
 
 std::string engine_version_info();
 std::string engine_info(bool to_uci = false);
+std::string engine_author_info();
 std::string compiler_info();
 
 // Preloads the given address in L1/L2 cache. This is a non-blocking

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -116,6 +116,7 @@ void UCIEngine::loop() {
         else if (token == "uci")
         {
             sync_cout << "id name " << engine_info(true) << "\n"
+                      << "id author " << engine_author_info() << "\n"
                       << engine.get_options() << sync_endl;
 
             print_info_string(Experience::status_summary());


### PR DESCRIPTION
## Summary
- update Wordfish branding to version 3.40-181125 and adjust executable naming
- ensure UCI header displays the new branding with author credit and expose helper for author info

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c2c1c6b108327822f9041a88c45ca)