### PR TITLE
Add defaults reset and Montecarlo search alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Wordfish exposes its capabilities through UCI options. The following overview li
 | `Clear Hash` | button | Clears cached search data and resets experience buffers for a fresh session. |
 | `Ponder` | `false` | Allows the engine to think on the opponent's time. |
 | `MultiPV` | `1` | Requests multiple principal variations for analysis sessions. |
-| `Search Strategy` | `AlphaBeta` (from `AlphaBeta MCTS`) | Switches between the traditional alpha-beta searcher and the integrated MCTS driver. |
+| `Search Strategy` | `AlphaBeta` (from `AlphaBeta MCTS Montecarlo`) | Switches between the traditional alpha-beta searcher and the integrated MCTS driver (the `Montecarlo` alias also selects MCTS). |
 | `Skill Level` | `20` | Limits playing strength by reducing tactical depth. |
 | `Move Overhead` | `10` | Reserves milliseconds per move to avoid time losses. |
 | `Minimum Thinking Time` | `100` | Guarantees a minimal allocation of milliseconds per move. |
@@ -37,8 +37,8 @@ Wordfish exposes its capabilities through UCI options. The following overview li
 | `nodestime` | `0` | Sets a node-based time limit for debugging scenarios. |
 | `UCI_Chess960` | `false` | Enables Chess960 (Fischer Random) support. |
 | `UCI_LimitStrength` | `false` | Activates Elo-limited play in conjunction with `UCI_Elo`. |
-| `Contempt` | `0` | Biases evaluations toward or against draws. |
-| `King Safety` | `100` | Tunes the relative importance of king safety heuristics. |
+| `Contempt` | `0` | Biases evaluations toward or against draws. Use `default` to reset to the shipped value. |
+| `King Safety` | `100` | Tunes the relative importance of king safety heuristics. Use `default` to reset to the shipped value. |
 | `UCI_Elo` | `1320` (range `1320` – `3190`) | Specifies the target Elo when strength limiting is enabled. |
 | `UCI_ShowWDL` | `false` | Adds win/draw/loss probabilities to info output. |
 

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -106,7 +106,7 @@ Engine::Engine(std::optional<std::string> path) :
     options.add(  //
       "MultiPV", Option(1, 1, MAX_MOVES));
 
-    options.add("Search Strategy", Option("AlphaBeta MCTS", "AlphaBeta"));
+    options.add("Search Strategy", Option("AlphaBeta MCTS Montecarlo", "AlphaBeta"));
 
     options.add("Skill Level", Option(20, 0, 20));
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -222,7 +222,8 @@ void Search::Worker::start_searching() {
     tt.new_search();
 
     const bool useMcts = options.count("Search Strategy")
-                         && options["Search Strategy"] == "MCTS";
+                         && (options["Search Strategy"] == "MCTS"
+                             || options["Search Strategy"] == "Montecarlo");
 
     if (rootMoves.empty())
     {

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -154,7 +154,8 @@ Option& Option::operator=(const std::string& v) {
 
     if ((type != "button" && type != "string" && v.empty())
         || (type == "check" && v != "true" && v != "false")
-        || (type == "spin" && (std::stoi(v) < min || std::stoi(v) > max)))
+        || (type == "spin" && v != "default"
+            && (std::stoi(v) < min || std::stoi(v) > max)))
         return *this;
 
     if (type == "combo")
@@ -170,6 +171,8 @@ Option& Option::operator=(const std::string& v) {
 
     if (type == "string")
         currentValue = v == "<empty>" ? "" : v;
+    else if (type == "spin" && v == "default")
+        currentValue = defaultValue;
     else if (type != "button")
         currentValue = v;
 


### PR DESCRIPTION
## Summary
- allow spin options to accept the `default` keyword, letting Contempt and King Safety reset to their shipped values
- add a Montecarlo alias for the MCTS search strategy
- document the updated option behaviors in the README

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cbe1c4b048327bca8a420706c453e)