### PR TITLE
Add Contemp UCI option and document Monte Carlo mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,17 @@ Wordfish exposes its capabilities through UCI options. The following overview li
 | `nodestime` | `0` | Sets a node-based time limit for debugging scenarios. |
 | `UCI_Chess960` | `false` | Enables Chess960 (Fischer Random) support. |
 | `UCI_LimitStrength` | `false` | Activates Elo-limited play in conjunction with `UCI_Elo`. |
+| `Contemp` | `0` | Legacy-compatible draw bias that mirrors `Contempt` for existing GUI profiles. |
 | `Contempt` | `0` | Biases evaluations toward or against draws. Use `default` to reset to the shipped value. |
 | `King Safety` | `100` | Tunes the relative importance of king safety heuristics. Use `default` to reset to the shipped value. |
 | `UCI_Elo` | `1320` (range `1320` – `3190`) | Specifies the target Elo when strength limiting is enabled. |
 | `UCI_ShowWDL` | `false` | Adds win/draw/loss probabilities to info output. |
+
+### Search strategy and Monte Carlo mode
+
+- The `Search Strategy` option toggles between `AlphaBeta`, `MCTS`, and the alias `Montecarlo`. Selecting either Monte Carlo mode routes move selection through the integrated tree searcher while preserving UCI output such as nodes, NPS, and PVs.
+- In Monte Carlo mode the engine reports simulated playouts as nodes, applies the `MultiPV` limit when formatting principal variations, and still honours UCI flags such as `ponder` and `infinite`.
+- The `Contemp` and `Contempt` settings can bias the Monte Carlo evaluator towards or away from draws, while `King Safety` scales how aggressively the search protects each monarch across both strategies.
 
 ### Neural evaluation management
 

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -121,6 +121,7 @@ Engine::Engine(std::optional<std::string> path) :
     options.add("UCI_LimitStrength", Option(false));
 
     options.add("Contempt", Option(0, -200, 200));
+    options.add("Contemp", Option(0, -200, 200));
 
     options.add("King Safety", Option(100, 0, 200));
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -205,7 +205,10 @@ void Search::Worker::ensure_network_replicated() {
 
 void Search::Worker::start_searching() {
 
-    contemptValue     = Value(int(options["Contempt"]) * PawnValue / 100);
+    const bool hasContempOption = options.count("Contemp");
+    const int  contemptSetting  = hasContempOption ? int(options["Contemp"]) : int(options["Contempt"]);
+
+    contemptValue     = Value(contemptSetting * PawnValue / 100);
     kingSafetySetting = int(options["King Safety"]);
 
     accumulatorStack.reset();


### PR DESCRIPTION
## Summary
- add a UCI-visible `Contemp` option aligned with the existing contempt setting
- ensure the searcher honours the new alias when computing contempt bias
- refresh the README with Monte Carlo usage notes and the new option listing

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cbfd7023483279539e63aa9ef9d22)