### PR TITLE
Add configurable controls for MCTS analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Wordfish exposes its capabilities through UCI options. The following overview li
 | `Ponder` | `false` | Allows the engine to think on the opponent's time. |
 | `MultiPV` | `1` | Requests multiple principal variations for analysis sessions. |
 | `Search Strategy` | `AlphaBeta` (from `AlphaBeta MCTS Montecarlo`) | Switches between the traditional alpha-beta searcher and the integrated MCTS driver (the `Montecarlo` alias also selects MCTS). |
+| `MCTS Rollout Depth` | `12` | Preferred playout depth when running Monte Carlo mode without an explicit depth limit. |
+| `MCTS Simulations` | `5000` | Default number of MCTS playouts when no `nodes` limit is supplied (set `0` to rely entirely on time controls). |
 | `Skill Level` | `20` | Limits playing strength by reducing tactical depth. |
 | `Move Overhead` | `10` | Reserves milliseconds per move to avoid time losses. |
 | `Minimum Thinking Time` | `100` | Guarantees a minimal allocation of milliseconds per move. |

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -108,6 +108,9 @@ Engine::Engine(std::optional<std::string> path) :
 
     options.add("Search Strategy", Option("AlphaBeta MCTS Montecarlo", "AlphaBeta"));
 
+    options.add("MCTS Rollout Depth", Option(12, 4, 128));
+    options.add("MCTS Simulations", Option(5000, 0, 1000000));
+
     options.add("Skill Level", Option(20, 0, 20));
 
     options.add("Move Overhead", Option(10, 0, 5000));

--- a/src/mcts.cpp
+++ b/src/mcts.cpp
@@ -73,7 +73,9 @@ Budget compute_budget(const OptionsMap& options,
                       Color rootColor) {
     Budget budget{};
 
-    budget.maxIterations = limits.nodes ? limits.nodes : 5000;
+    const int defaultPlayouts = options.count("MCTS Simulations") ? int(options["MCTS Simulations"]) : 5000;
+
+    budget.maxIterations = limits.nodes ? limits.nodes : defaultPlayouts;
     budget.useTime       = false;
     budget.endTime       = 0;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -307,7 +307,9 @@ void Search::Worker::run_monte_carlo() {
 
     auto stopRequested = [&]() { return threads.stop.load(std::memory_order_relaxed); };
 
-    const int depthHint = limits.depth ? std::clamp<int>(2 * limits.depth, 4, MAX_PLY - 1) : 12;
+    const int defaultDepth = options.count("MCTS Rollout Depth") ? int(options["MCTS Rollout Depth"]) : 12;
+    const int depthHint = limits.depth ? std::clamp<int>(2 * limits.depth, 4, MAX_PLY - 1)
+                                       : std::clamp<int>(defaultDepth, 4, MAX_PLY - 1);
 
     const auto result =
       MCTS::analyze(rootPos, rootPos.side_to_move(), options, limits, stopRequested, depthHint);


### PR DESCRIPTION
## Summary
- introduce MCTS rollout depth and simulation count UCI options alongside the search strategy toggle
- use the new knobs when deriving Monte Carlo depth hints and playout budgets
- document the configurable Monte Carlo parameters in the README

## Testing
- cd src && make build ARCH=x86-64


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cc0f2208c832785ea8ade5a4094e9)