### PR TITLE
Add configurable MCTS exploration and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Wordfish exposes its capabilities through UCI options. The following overview li
 | `Search Strategy` | `AlphaBeta` (from `AlphaBeta MCTS Montecarlo`) | Switches between the traditional alpha-beta searcher and the integrated MCTS driver (the `Montecarlo` alias also selects MCTS). |
 | `MCTS Rollout Depth` | `12` | Preferred playout depth when running Monte Carlo mode without an explicit depth limit. |
 | `MCTS Simulations` | `5000` | Default number of MCTS playouts when no `nodes` limit is supplied (set `0` to rely entirely on time controls). |
+| `MCTS Explore` | `35` | Balances exploitation versus exploration in Monte Carlo mode; higher values widen the tree while lower values extend existing lines. |
 | `Skill Level` | `20` | Limits playing strength by reducing tactical depth. |
 | `Move Overhead` | `10` | Reserves milliseconds per move to avoid time losses. |
 | `Minimum Thinking Time` | `100` | Guarantees a minimal allocation of milliseconds per move. |
@@ -49,6 +50,9 @@ Wordfish exposes its capabilities through UCI options. The following overview li
 
 - The `Search Strategy` option toggles between `AlphaBeta`, `MCTS`, and the alias `Montecarlo`. Selecting either Monte Carlo mode routes move selection through the integrated tree searcher while preserving UCI output such as nodes, NPS, and PVs.
 - In Monte Carlo mode the engine reports simulated playouts as nodes, applies the `MultiPV` limit when formatting principal variations, and still honours UCI flags such as `ponder` and `infinite`.
+- The `MCTS Explore` parameter adjusts how aggressively the search alternates between widening the tree and deepening promising moves. The shipped default of `35` mirrors the engine's baseline exploration constant; increase the value to encourage broader coverage, or lower it to focus the playouts along the current best lines.
+- Because MCTS stores visit counts and averages for every root move, `MultiPV` output is inexpensive compared to alpha-beta search: the engine can emit multiple principal variations without restarting the root search for each line.
+- Unlike alpha-beta's iterative deepening, MCTS estimates depth from the number of playouts performed and typically performs better with time-based limits rather than fixed depths. Longer time controls and multiple threads give the search more room to build a useful Monte Carlo tree.
 - The `Contemp` and `Contempt` settings can bias the Monte Carlo evaluator towards or away from draws, while `King Safety` scales how aggressively the search protects each monarch across both strategies.
 
 ### Neural evaluation management

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -110,6 +110,7 @@ Engine::Engine(std::optional<std::string> path) :
 
     options.add("MCTS Rollout Depth", Option(12, 4, 128));
     options.add("MCTS Simulations", Option(5000, 0, 1000000));
+    options.add("MCTS Explore", Option(35, 1, 200));
 
     options.add("Skill Level", Option(20, 0, 20));
 

--- a/src/mcts.cpp
+++ b/src/mcts.cpp
@@ -212,7 +212,9 @@ Result analyze(Position&                 rootPos,
 
     std::array<StateInfo, MAX_PLY> stateStack{};
 
-    const double exploration = 1.41421356237;
+    const int exploreSetting = options.count("MCTS Explore") ? int(options["MCTS Explore"]) : 35;
+    const double explorationBase = 1.41421356237;
+    const double exploration     = (std::max(1, exploreSetting) / 35.0) * explorationBase;
 
     std::uint64_t iterations = 0;
     const TimePoint start    = now();


### PR DESCRIPTION
## Summary
- add a UCI option to tune the MCTS exploration constant
- scale the Monte Carlo exploration term based on the new option’s value
- document the new control and refresh MCTS usage guidance in the README


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cc6cb6f78832784192d1508f5514f)