### PR TITLE
Apply movetime overhead to MCTS

### DIFF
--- a/src/mcts.cpp
+++ b/src/mcts.cpp
@@ -103,8 +103,13 @@ Budget compute_budget(const OptionsMap& options,
 
     if (limits.movetime)
     {
-        budget.useTime = true;
-        budget.endTime = start + limits.movetime;
+        TimePoint available = std::max(TimePoint(0), limits.movetime - overhead);
+
+        if (available)
+        {
+            budget.useTime = true;
+            budget.endTime = start + available;
+        }
     }
     else if (limits.time[rootColor])
     {


### PR DESCRIPTION
## Summary
- subtract move overhead from movetime allocations in MCTS budget
- align movetime handling with classical search time management to preserve safety margin

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692045dea0d88327a389be4c16293404)