### PR TITLE
Record MCTS search results in experience store

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -381,6 +381,13 @@ void Search::Worker::run_monte_carlo() {
 
         main_manager()->bestPreviousScore        = rootMoves[0].score;
         main_manager()->bestPreviousAverageScore = rootMoves[0].averageScore;
+
+        Experience::on_search_complete(rootPos,
+                                       rootMoves,
+                                       rootMoves.front().score,
+                                       rootMoves.front().averageScore,
+                                       Depth(depthHint),
+                                       limits);
     }
 
     pvIdx  = 0;


### PR DESCRIPTION
## Summary
- call `Experience::on_search_complete` after MCTS searches to persist best move data
- reuse existing root move ordering and scores when recording MCTS results for the experience book

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920460eaeb88327b1146991fc4414e6)