### PR TITLE
Handle experience status when loading fails

### DIFF
--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -419,11 +419,17 @@ void load_table_unlocked(const std::string& file) {
     lastStatus.clear();
 
     if (file.empty())
+    {
+        lastStatus = format_status_unlocked();
         return;
+    }
 
     std::ifstream fileStream(file, std::ios::binary);
     if (!fileStream)
+    {
+        lastStatus = format_status_unlocked();
         return;
+    }
 
     const std::string rawData{std::istreambuf_iterator<char>(fileStream),
                               std::istreambuf_iterator<char>()};
@@ -437,7 +443,10 @@ void load_table_unlocked(const std::string& file) {
     {
         auto decompressed = decompress_gzip(data);
         if (!decompressed)
+        {
+            lastStatus = format_status_unlocked();
             return;
+        }
 
         data = std::move(*decompressed);
     }


### PR DESCRIPTION
## Summary
- ensure experience status text is refreshed when experience files are missing, empty, or fail gzip decompression

## Testing
- pytest -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692049616c0c83279090a8d5b34916aa)