### PR TITLE
Initialize evaluation default in MCTS rollout

### DIFF
--- a/src/mcts.cpp
+++ b/src/mcts.cpp
@@ -328,7 +328,7 @@ Result analyze(Position&                 rootPos,
 
         Node* leaf = nodeStack.back();
 
-        double evaluation;
+        double evaluation = 0.0;
         bool   aborted = false;
         if (leaf->terminal)
             evaluation = value_to_double(leaf->terminalValue);


### PR DESCRIPTION
## Summary
- initialize the evaluation variable in the MCTS analysis loop to avoid conditional uninitialized usage warnings

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69204e688b388327948a7cab382d6583)