### PR TITLE
Add toggle to enable MCTS search

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -107,6 +107,7 @@ Engine::Engine(std::optional<std::string> path) :
       "MultiPV", Option(1, 1, MAX_MOVES));
 
     options.add("Search Strategy", Option("AlphaBeta MCTS Montecarlo", "AlphaBeta"));
+    options.add("MCTS Enabled", Option(false));
 
     options.add("MCTS Rollout Depth", Option(12, 4, 128));
     options.add("MCTS Simulations", Option(5000, 0, 1000000));

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -224,7 +224,8 @@ void Search::Worker::start_searching() {
                             main_manager()->originalTimeAdjust);
     tt.new_search();
 
-    const bool useMcts = options.count("Search Strategy")
+    const bool mctsEnabled = options.count("MCTS Enabled") ? int(options["MCTS Enabled"]) : false;
+    const bool useMcts = mctsEnabled && options.count("Search Strategy")
                          && (options["Search Strategy"] == "MCTS"
                              || options["Search Strategy"] == "Montecarlo");
 


### PR DESCRIPTION
## Summary
- add a dedicated UCI option to explicitly enable MCTS usage
- gate Monte Carlo search so it only runs when the new toggle is turned on

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920586aae288327bf66ac373baf9648)