### PR TITLE
Simplify engine identification output

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -122,27 +122,11 @@ std::string engine_version_info() {
 }
 
 std::string engine_info(bool to_uci) {
-    std::string info = engine_version_info();
-
-    if (to_uci)
-    {
-        info += " ";
-        info += engine_author_prefix;
-        info += engine_author_name;
-    }
-    else
-    {
-        info += " by ";
-        info += engine_author_name;
-    }
-
-    return info;
+    return engine_version_info();
 }
 
 std::string engine_author_info() {
-    std::string info = std::string(engine_author_prefix);
-    info += engine_author_name;
-    return info;
+    return engine_version_info();
 }
 
 


### PR DESCRIPTION
## Summary
- return only the engine name for UCI `id name` responses
- align author information with the simplified branding string

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920596cea608327bd67efc81b0d26f2)