### PR TITLE
Initialize experience load stats to avoid garbage counters

### DIFF
--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -453,7 +453,7 @@ void load_table_unlocked(const std::string& file) {
 
     std::istringstream in(data);
 
-    Stats loadStats;
+    Stats loadStats{};
     bool  loaded = false;
 
     if (load_hypnos_binary(in, loadStats))


### PR DESCRIPTION
## Summary
- initialize experience loading statistics to a known zero state before parsing
- preserve accurate duplicate/unique move counters when loading experience data

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69205a0c1b2c8327b588e5bce24655ea)