### PR TITLE
Fix engine metadata reporting

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -122,11 +122,15 @@ std::string engine_version_info() {
 }
 
 std::string engine_info(bool to_uci) {
-    return engine_version_info();
+    if (to_uci)
+        return engine_version_info();
+
+    return std::string(engine_name) + "\n" + std::string(engine_author_prefix) +
+           std::string(engine_author_name);
 }
 
 std::string engine_author_info() {
-    return engine_version_info();
+    return std::string(engine_author_name);
 }
 
 


### PR DESCRIPTION
## Summary
- return the actual author string instead of the version when reporting engine metadata
- format non-UCI engine info to include the author line and remove the unused parameter warning

## Testing
- pytest -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921587ccd308327b208be50d77aabb7)