### PR TITLE
Update main NNUE network to nn-2962dca31855.nnue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Tightened king-safety heuristics for open files, rook lifts, and dark-square weaknesses.
 - Reduced aggressive pruning in sharp positions and added verification search for large evaluation swings.
 - Rewarded connected rooks while penalizing premature flank pawn storms in the handcrafted evaluation.
+- Updated the main NNUE network to `nn-2962dca31855.nnue` from Stockfish dev 20251130.
 
 ## [3.50]
 ### Changed

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -33,7 +33,7 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultNameBig "nn-c0ae49f08b40.nnue"
+#define EvalFileDefaultNameBig "nn-2962dca31855.nnue"
 #define EvalFileDefaultNameSmall "nn-37f18f62d772.nnue"
 
 namespace NNUE {


### PR DESCRIPTION
## Summary
- update the default big NNUE reference to nn-2962dca31855.nnue from the latest Stockfish development release
- document the network refresh in the unreleased changelog

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e188e0a488327b9769c2ba2c235cf)