### PR TITLE
Update README highlights and harden option comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,14 @@
 
 ## Overview
 
-Wordfish is a Universal Chess Interface (UCI) engine derived from Stockfish. It retains the parent engine's search strength while adding dual-network neural evaluation, a persistent experience store, and configurable Monte Carlo search. The codebase is engineered for reproducible testing, efficient NUMA-aware threading, and transparent diagnostics.
+Wordfish is a Universal Chess Interface (UCI) engine derived from Stockfish. It retains the parent engine's search strength while adding dual-network neural evaluation, a persistent experience store, and configurable Monte Carlo search. The current release is **Wordfish-3.60-021225**, tuned around the latest Stockfish evaluation networks. The codebase is engineered for reproducible testing, efficient NUMA-aware threading, and transparent diagnostics.
+
+## What's new in 3.60-021225
+
+- Updated the main NNUE evaluator to `nn-2962dca31855.nnue` from Stockfish dev 20251130, keeping the paired small network in sync for dual-network evaluation.
+- Emphasized king safety, rook coordination, and supervised endgame patterns in recent network training and handcrafted heuristics.
+- Tightened king-safety heuristics around open files, rook lifts, and dark-square weaknesses while rewarding coordinated rooks and discouraging premature flank pawn storms.
+- Reduced aggressive pruning in sharp positions and introduced a verification search to confirm large swings in evaluation, improving stability in complicated lines.
 
 ## Architecture and integrated modules
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -33,8 +33,12 @@ namespace Stockfish {
 bool CaseInsensitiveLess::operator()(const std::string& s1, const std::string& s2) const {
 
     return std::lexicographical_compare(
-      s1.begin(), s1.end(), s2.begin(), s2.end(),
-      [](char c1, char c2) { return std::tolower(c1) < std::tolower(c2); });
+      s1.begin(), s1.end(), s2.begin(), s2.end(), [](char c1, char c2) {
+          const auto c1Lower = std::tolower(static_cast<unsigned char>(c1));
+          const auto c2Lower = std::tolower(static_cast<unsigned char>(c2));
+
+          return c1Lower < c2Lower;
+      });
 }
 
 void OptionsMap::add_info_listener(InfoListener&& message_func) { info = std::move(message_func); }


### PR DESCRIPTION
## Summary
- refresh the README landing section with the 3.60-021225 release highlights and network update
- harden case-insensitive option comparison to avoid undefined behavior when normalizing characters

## Testing
- pytest tests/test_experience.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e1b4998d08327a4dfb23cd279b71a)