### PR TITLE
Track duplicate experience updates

### DIFF
--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -714,6 +714,8 @@ void on_search_complete(const Position& pos,
     Entry* existing = find_entry(entries, move);
     if (existing)
     {
+        ++stats.duplicateMoves;
+
         existing->score = bestScore;
         existing->eval  = evalScore;
         existing->depth = std::max(existing->depth, searchedDepth);


### PR DESCRIPTION
## Summary
- increment the duplicate move counter when refreshing existing experience entries so statistics reflect repeated moves

## Testing
- make build
- pytest -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e1d183238832797196ae2561b3b52)