### PR TITLE
Honor movetime overhead in MCTS budget

### DIFF
--- a/src/mcts.cpp
+++ b/src/mcts.cpp
@@ -104,13 +104,13 @@ Budget compute_budget(const OptionsMap& options,
 
     if (limits.movetime)
     {
-        TimePoint available = std::max(TimePoint(0), limits.movetime - overhead);
+        budget.useTime = true;
 
-        if (available)
-        {
-            budget.useTime = true;
-            budget.endTime = start + available;
-        }
+        // Honor Move Overhead even under fixed time controls. If the overhead
+        // exceeds movetime we still arm the timer so the search exits
+        // immediately instead of running a full batch of simulations.
+        const TimePoint available = std::max(TimePoint(0), limits.movetime - overhead);
+        budget.endTime            = start + available;
     }
     else if (limits.time[rootColor])
     {


### PR DESCRIPTION
## Summary
- ensure MCTS movetime budgets always subtract Move Overhead so searches stop on time

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931f60dc1548327a2d69f8c9250fb29)