### PR TITLE
Accumulate experience visit counts

### DIFF
--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -175,7 +175,11 @@ void merge_entry_for_load(std::uint64_t key, const Entry& entry, Stats& loadStat
             existing->eval  = entry.eval;
         }
 
-        existing->visits = std::max(existing->visits, entry.visits);
+        const auto combinedVisits = static_cast<std::uint32_t>(existing->visits)
+                                   + static_cast<std::uint32_t>(entry.visits);
+
+        existing->visits = static_cast<std::uint16_t>(std::min<std::uint32_t>(
+          combinedVisits, std::numeric_limits<std::uint16_t>::max()));
     }
     else
     {

--- a/tests/test_experience.py
+++ b/tests/test_experience.py
@@ -151,6 +151,19 @@ class ExperienceFileTests(unittest.TestCase):
         entries = self._dump_entries()
         self.assertEqual(entries, [(self.KEY, self.MOVE, self.SCORE, self.DEPTH, self.COUNT)])
 
+    def test_duplicate_entries_accumulate_visit_count(self):
+        header = "# Wordfish experience format v1\n".encode()
+        first  = f"{self.KEY} {self.MOVE} {self.SCORE} {self.SCORE} {self.DEPTH} 2\n".encode()
+        second = f"{self.KEY} {self.MOVE} {self.SCORE} {self.SCORE} {self.DEPTH} 5\n".encode()
+
+        exp_path = self._write_experience_file(".exp", lambda handle: handle.write(header + first + second))
+        self.addCleanup(lambda: os.remove(exp_path))
+
+        self._load_experience(exp_path)
+
+        entries = self._dump_entries()
+        self.assertEqual(entries, [(self.KEY, self.MOVE, self.SCORE, self.DEPTH, 7)])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- accumulate visit counts when loading duplicate experience entries so frequency data is preserved
- add regression coverage to ensure duplicate text entries aggregate their visit counts

## Testing
- python -m pytest tests/test_experience.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931f85a60108327833d419331544bc6)