### PR TITLE
Avoid duplicate MCTS experience writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,26 @@ Use `make help` for platform-specific targets. Bundled binaries embed default NN
 3. Provide a position via `position` (FEN or move list) and start calculation with `go` plus the desired limits.
 4. During analysis, monitor `info` strings for depth, score, nodes per second, and—when enabled—win/draw/loss figures.
 
+## Suggested MCTS evaluation profile
+
+For Monte Carlo analysis sessions, start from the following balanced configuration and adjust to taste:
+
+- `Search Strategy`: `MCTS`
+- `MCTS Rollout Depth`: `20` (keeps playouts tactical without drifting too far from the frontier)
+- `MCTS Simulations`: `8000` (set to `0` to let the clock dictate stopping conditions)
+- `MCTS Explore`: `40` (slightly more exploratory than the default for broader coverage)
+- `Move Overhead`: `30` (ms buffer on fixed `movetime` runs to avoid time forfeits)
+
+Example commands:
+
+```bash
+setoption name Search Strategy value MCTS
+setoption name MCTS Rollout Depth value 20
+setoption name MCTS Simulations value 8000
+setoption name MCTS Explore value 40
+setoption name Move Overhead value 30
+```
+
 ## Validation and release discipline
 
 Candidate changes are measured with Sequential Probability Ratio Tests (SPRT) on FastChess at short (`10s + 0.1`) and longer (`60s + 0.1`) controls. Patches that return `h = 1` are merged with their recorded Elo gains so that the performance history remains auditable.

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -402,13 +402,6 @@ void Search::Worker::run_monte_carlo() {
 
         main_manager()->bestPreviousScore        = rootMoves[0].score;
         main_manager()->bestPreviousAverageScore = rootMoves[0].averageScore;
-
-        Experience::on_search_complete(rootPos,
-                                       rootMoves,
-                                       rootMoves.front().score,
-                                       rootMoves.front().averageScore,
-                                       Depth(depthHint),
-                                       limits);
     }
 
     pvIdx  = 0;


### PR DESCRIPTION
## Summary
- prevent Monte Carlo searches from writing to the experience file twice by relying on the common completion hook
- document a balanced MCTS evaluation profile with recommended option values and example setoption commands

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932150663888327881199a88db4aca9)