### PR TITLE
Track MCTS node counts for UCI output

### DIFF
--- a/src/mcts.cpp
+++ b/src/mcts.cpp
@@ -142,6 +142,7 @@ std::optional<double> rollout(Position& pos,
                               int depthOffset,
                               int maxDepth,
                               const Budget& budget,
+                              std::uint64_t& nodesVisited,
                               const std::function<bool()>& stopRequested) {
     std::vector<Move> played;
     played.reserve(maxDepth);
@@ -182,6 +183,7 @@ std::optional<double> rollout(Position& pos,
         const Move   move  = *(legal.begin() + index);
         StateInfo& st   = stateStack[depthOffset + depth];
         pos.do_move(move, st);
+        ++nodesVisited;
         played.push_back(move);
     }
 
@@ -248,8 +250,9 @@ Result analyze(Position&                 rootPos,
     const double explorationBase = 1.41421356237;
     const double exploration     = (std::max(1, exploreSetting) / 35.0) * explorationBase;
 
-    std::uint64_t iterations = 0;
-    const TimePoint start    = now();
+    std::uint64_t iterations   = 0;
+    std::uint64_t nodesVisited = 0;
+    const TimePoint start      = now();
 
     while (!root.terminal)
     {
@@ -286,6 +289,7 @@ Result analyze(Position&                 rootPos,
 
                 StateInfo& st = stateStack[depth];
                 current.do_move(move, st);
+                ++nodesVisited;
                 moveStack.push_back(move);
                 depth++;
 
@@ -331,6 +335,7 @@ Result analyze(Position&                 rootPos,
 
             StateInfo& st = stateStack[depth];
             current.do_move(bestChild->move, st);
+            ++nodesVisited;
             moveStack.push_back(bestChild->move);
             depth++;
             nodeStack.push_back(bestChild);
@@ -344,8 +349,14 @@ Result analyze(Position&                 rootPos,
             evaluation = value_to_double(leaf->terminalValue);
         else
         {
-            std::optional<double> rolloutEval = rollout(current, rng, stateStack, depth,
-                                                        rolloutDepth - depth, budget, stopRequested);
+            std::optional<double> rolloutEval = rollout(current,
+                                                        rng,
+                                                        stateStack,
+                                                        depth,
+                                                        rolloutDepth - depth,
+                                                        budget,
+                                                        nodesVisited,
+                                                        stopRequested);
             if (!rolloutEval)
                 aborted = true;
             else
@@ -373,8 +384,9 @@ Result analyze(Position&                 rootPos,
         ++iterations;
     }
 
-    result.simulations = iterations;
-    result.elapsedMs   = now() - start;
+    result.simulations  = iterations;
+    result.nodesVisited = nodesVisited;
+    result.elapsedMs    = now() - start;
 
     if (root.visits)
     {

--- a/src/mcts.h
+++ b/src/mcts.h
@@ -31,6 +31,7 @@ struct Result {
     Value                         evaluation;
     std::vector<MoveStats>        moveStats;
     std::uint64_t                 simulations;
+    std::uint64_t                 nodesVisited;
     TimePoint                     elapsedMs;
 };
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -335,7 +335,8 @@ void Search::Worker::run_monte_carlo() {
     const auto result =
       MCTS::analyze(rootPos, rootPos.side_to_move(), options, limits, stopRequested, depthHint);
 
-    nodes.store(result.simulations, std::memory_order_relaxed);
+    nodes.store(result.nodesVisited ? result.nodesVisited : result.simulations,
+               std::memory_order_relaxed);
     tbHits.store(0, std::memory_order_relaxed);
 
     completedDepth = rootDepth = Depth(depthHint);
@@ -407,8 +408,9 @@ void Search::Worker::run_monte_carlo() {
     pvIdx  = 0;
     pvLast = rootMoves.size();
 
-    const TimePoint elapsed = std::max<TimePoint>(TimePoint(1), result.elapsedMs);
-    const uint64_t  nps     = result.elapsedMs ? (result.simulations * 1000 / elapsed) : 0;
+    const TimePoint elapsed   = std::max<TimePoint>(TimePoint(1), result.elapsedMs);
+    const uint64_t  nodeCount = result.nodesVisited ? result.nodesVisited : result.simulations;
+    const uint64_t  nps       = result.elapsedMs ? (nodeCount * 1000 / elapsed) : 0;
     const bool      showWdl = bool(options["UCI_ShowWDL"]);
 
     const size_t multiPV = std::min<size_t>(options["MultiPV"], rootMoves.size());
@@ -439,7 +441,7 @@ void Search::Worker::run_monte_carlo() {
         info.wdl      = wdl;
         info.bound    = "";
         info.timeMs   = elapsed;
-        info.nodes    = result.simulations;
+        info.nodes    = result.nodesVisited ? result.nodesVisited : result.simulations;
         info.nps      = nps;
         info.tbHits   = 0;
         info.pv       = pv;


### PR DESCRIPTION
## Summary
- count node visits during MCTS selection and rollouts
- expose visited-node totals in MCTS results and UCI output so nodes/nps are populated

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69321b4b22d08327b050c759df243a4a)