### PR TITLE
Honor full MCTS rollout depth range

### DIFF
--- a/src/mcts.cpp
+++ b/src/mcts.cpp
@@ -232,7 +232,7 @@ Result analyze(Position&                 rootPos,
 
     Budget budget = compute_budget(options, limits, rootColor);
 
-    const int rolloutDepth = std::clamp(rolloutDepthHint, 4, 64);
+    const int rolloutDepth = std::clamp(rolloutDepthHint, 4, 128);
 
     Position& pos = rootPos;
 


### PR DESCRIPTION
## Summary
- allow MCTS analysis to use rollout depths up to the configured 128-ply ceiling instead of truncating at 64

## Testing
- pytest -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69321ef02c84832786596117dcbdd9fe)