### PR TITLE
Sort MCTS root moves by evaluation

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -372,6 +372,10 @@ void Search::Worker::run_monte_carlo() {
         rm.pv.assign(1, move);
     }
 
+    // Bring the highest scoring moves to the front so the reported best move
+    // matches the MCTS evaluation instead of the generator's default order.
+    std::stable_sort(rootMoves.begin(), rootMoves.end());
+
     if (!result.principalVariation.empty() && result.principalVariation[0].is_ok())
     {
         auto bestIt = std::find_if(rootMoves.begin(), rootMoves.end(), [&](const RootMove& rm) {


### PR DESCRIPTION
## Summary
- sort MCTS root moves by their Monte Carlo scores so the best move is reported first
- keep principal variation reporting aligned with the reordered root move list

## Testing
- make -C src build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693223630e1c8327b9d66f5a7d1ddedd)