### PR TITLE
Add SSE41 default and panic time limit

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -20,7 +20,8 @@
 ### ==========================================================================
 
 ### Establish the operating system name
-KERNEL := $(shell uname -s)
+KERNEL  := $(shell uname -s)
+MACHINE := $(shell uname -m)
 ifeq ($(KERNEL),Linux)
 	OS := $(shell uname -o)
 endif
@@ -119,7 +120,11 @@ VPATH = syzygy:nnue:nnue/features
 ### 2.1. General and architecture defaults
 
 ifeq ($(ARCH),)
-   ARCH = native
+	ifneq (,$(filter x86_64,$(MACHINE)))
+	   ARCH = x86-64-sse41-popcnt
+	else
+	   ARCH = native
+	endif
 endif
 
 ifeq ($(ARCH), native)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -2162,13 +2162,21 @@ void SearchManager::check_time(Search::Worker& worker) {
     if (ponder)
         return;
 
-    if (
-      // Later we rely on the fact that we can at least use the mainthread previous
-      // root-search score and PV in a multithreaded environment to prove mated-in scores.
-      worker.completedDepth >= 1
-      && ((worker.limits.use_time_management() && (elapsed > tm.maximum() || stopOnPonderhit))
-          || (worker.limits.movetime && elapsed >= worker.limits.movetime)
-          || (worker.limits.nodes && worker.threads.nodes_searched() >= worker.limits.nodes)))
+    const bool timeLimit =
+      worker.limits.use_time_management() && (elapsed > tm.maximum() || stopOnPonderhit);
+    const bool moveTimeLimit = worker.limits.movetime && elapsed >= worker.limits.movetime;
+    const bool nodeLimit     =
+      worker.limits.nodes && worker.threads.nodes_searched() >= worker.limits.nodes;
+    const bool panicTime =
+      worker.limits.use_time_management() && elapsed >= tm.panic() && worker.completedDepth == 0;
+
+    // Later we rely on the fact that we can at least use the mainthread previous
+    // root-search score and PV in a multithreaded environment to prove mated-in scores.
+    const bool completedIteration = worker.completedDepth >= 1;
+    const bool exceededTimeBudget = timeLimit || moveTimeLimit || nodeLimit;
+    const bool exceededHardBudget = moveTimeLimit || nodeLimit || panicTime;
+
+    if ((completedIteration && exceededTimeBudget) || (!completedIteration && exceededHardBudget))
         worker.threads.stop = worker.threads.abortedSearch = true;
 }
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -30,9 +30,11 @@ namespace Stockfish {
 
 TimePoint TimeManagement::optimum() const { return optimumTime; }
 TimePoint TimeManagement::maximum() const { return maximumTime; }
+TimePoint TimeManagement::panic() const { return panicTime; }
 
 void TimeManagement::clear() {
     availableNodes = -1;  // When in 'nodes as time' mode
+    optimumTime    = maximumTime = panicTime = TimePoint(0);
 }
 
 void TimeManagement::advance_nodes_time(std::int64_t nodes) {
@@ -55,6 +57,7 @@ void TimeManagement::init(Search::LimitsType& limits,
     // startTime is used by movetime and useNodesTime is used in elapsed calls.
     startTime    = limits.startTime;
     useNodesTime = npmsec != 0;
+    panicTime    = TimePoint(0);
 
     if (limits.time[us] == 0)
         return;
@@ -141,6 +144,10 @@ void TimeManagement::init(Search::LimitsType& limits,
 
     if (options["Ponder"])
         optimumTime += optimumTime / 4;
+
+    panicTime =
+      std::max(maximumTime + scaledMinimumTime / 4,
+               std::max(TimePoint(1), limits.time[us] - moveOverhead));
 }
 
 }  // namespace Stockfish

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -44,6 +44,7 @@ class TimeManagement {
 
     TimePoint optimum() const;
     TimePoint maximum() const;
+    TimePoint panic() const;
     template<typename FUNC>
     TimePoint elapsed(FUNC nodes) const {
         return useNodesTime ? TimePoint(nodes()) : elapsed_time();
@@ -57,6 +58,7 @@ class TimeManagement {
     TimePoint startTime;
     TimePoint optimumTime;
     TimePoint maximumTime;
+    TimePoint panicTime;
 
     std::int64_t availableNodes = -1;     // When in 'nodes as time' mode
     bool         useNodesTime   = false;  // True if we are in 'nodes as time' mode


### PR DESCRIPTION
## Summary
- default the x86_64 build to the portable sse41-popcnt profile when no ARCH is provided, while keeping native detection for other hosts
- add tracked panic time thresholds in time management and stop the search when limits are exceeded even before the first completed iteration
- reset timing fields on clear to avoid stale values when switching limits

## Testing
- make -j2 build
- ./Wordfish-3.60-021225 bench | tail -n 8

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943c4736f70832783c6e0519b3e6312)