### PR TITLE
Add panic time buffer for low clock situations

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Wordfish is a Universal Chess Interface (UCI) engine derived from Stockfish. It 
 ## UCI surface and principal options
 
 - **Session control**: `uci` announces identity and options; `isready` synchronises threads; `ucinewgame` clears experience buffers; `stop` halts search; `ponderhit` resumes after pondering; `quit` exits cleanly.
-- **Core options**: `Hash` (MB for the transposition table), `Clear Hash` (button), `Ponder`, `MultiPV`, `Skill Level`, `Move Overhead`, `Minimum Thinking Time`, `Slow Mover`, `nodestime`, `UCI_Chess960`, `UCI_LimitStrength` and `UCI_Elo`, `Contempt`/`Contemp`, and `King Safety`.
+- **Core options**: `Hash` (MB for the transposition table), `Clear Hash` (button), `Ponder`, `MultiPV`, `Skill Level`, `Move Overhead`, `Minimum Thinking Time`, `Panic Time Buffer`, `Slow Mover`, `nodestime`, `UCI_Chess960`, `UCI_LimitStrength` and `UCI_Elo`, `Contempt`/`Contemp`, and `King Safety`.
+- **Short-clock safety**: when the active clock drops under a second, the engine enters a panic regime that boosts `Move Overhead`, clamps thinking time to a fraction of the remaining clock, and caps it by `Panic Time Buffer` (default 200 ms). Raising `Minimum Thinking Time` or `Panic Time Buffer` increases the cushion for sudden disconnections or lag.
 - **Monte Carlo tuning**: `Search Strategy` accepts `AlphaBeta`, `MCTS`, or the alias `Montecarlo`. When a clock-based limit is provided (`wtime`, `btime`, or `movetime`), the MCTS driver prioritises that timer over the default simulation cap unless `nodes` is explicitly requested.
 - **MCTS configuration**: Enable the MCTS driver with `MCTS Enabled` or by selecting it via `Search Strategy`. Fine-tune behaviour with:
   - `MCTS Rollout Depth`: Maximum plies explored during each rollout (default 12, range 4–128).

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -117,6 +117,7 @@ Engine::Engine(std::optional<std::string> path) :
 
     options.add("Move Overhead", Option(10, 0, 5000));
     options.add("Minimum Thinking Time", Option(100, 0, 5000));
+    options.add("Panic Time Buffer", Option(200, 0, 5000));
     options.add("Slow Mover", Option(100, 10, 1000));
 
     options.add("nodestime", Option(0, 0, 10000));

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -705,6 +705,15 @@ void Search::Worker::iterative_deepening() {
 
             auto elapsedTime = elapsed();
 
+            if (mainThread->tm.panic())
+            {
+                TimePoint remainingTime =
+                  std::max(TimePoint(0), mainThread->tm.available_time() - elapsedTime);
+
+                if (remainingTime <= mainThread->tm.panic_reserve())
+                    threads.stop = true;
+            }
+
             // Stop the search if we have exceeded the totalTime or maximum
             if (elapsedTime > std::min(totalTime, double(mainThread->tm.maximum())))
             {
@@ -2161,6 +2170,14 @@ void SearchManager::check_time(Search::Worker& worker) {
     // We should not stop pondering until told so by the GUI
     if (ponder)
         return;
+
+    if (worker.limits.use_time_management() && tm.panic())
+    {
+        TimePoint remaining = std::max(TimePoint(0), tm.available_time() - elapsed);
+
+        if (remaining <= tm.panic_reserve())
+            worker.threads.stop = worker.threads.abortedSearch = true;
+    }
 
     if (
       // Later we rely on the fact that we can at least use the mainthread previous

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -30,6 +30,10 @@ namespace Stockfish {
 
 TimePoint TimeManagement::optimum() const { return optimumTime; }
 TimePoint TimeManagement::maximum() const { return maximumTime; }
+TimePoint TimeManagement::available_time() const { return availableTime; }
+TimePoint TimeManagement::panic_buffer() const { return panicTimeBuffer; }
+TimePoint TimeManagement::panic_reserve() const { return panicReserve; }
+bool      TimeManagement::panic() const { return panicMode; }
 
 void TimeManagement::clear() {
     availableNodes = -1;  // When in 'nodes as time' mode
@@ -55,6 +59,8 @@ void TimeManagement::init(Search::LimitsType& limits,
     // startTime is used by movetime and useNodesTime is used in elapsed calls.
     startTime    = limits.startTime;
     useNodesTime = npmsec != 0;
+    panicMode    = false;
+    panicTimeBuffer = panicReserve = availableTime = 0;
 
     if (limits.time[us] == 0)
         return;
@@ -62,6 +68,7 @@ void TimeManagement::init(Search::LimitsType& limits,
     TimePoint moveOverhead      = TimePoint(options["Move Overhead"]);
     const int slowMover         = options["Slow Mover"];
     const TimePoint minimumTime = TimePoint(options["Minimum Thinking Time"]);
+    panicTimeBuffer             = TimePoint(options["Panic Time Buffer"]);
 
     // optScale is a percentage of available time to use for the current move.
     // maxScale is a multiplier applied to optimumTime.
@@ -81,6 +88,7 @@ void TimeManagement::init(Search::LimitsType& limits,
         limits.inc[us] *= npmsec;
         limits.npmsec = npmsec;
         moveOverhead *= npmsec;
+        panicTimeBuffer *= npmsec;
     }
 
     // These numbers are used where multiplications, divisions or comparisons
@@ -88,6 +96,12 @@ void TimeManagement::init(Search::LimitsType& limits,
     const int64_t   scaleFactor = useNodesTime ? npmsec : 1;
     const TimePoint scaledTime  = limits.time[us] / scaleFactor;
     const TimePoint scaledMinimumTime = minimumTime * scaleFactor;
+
+    availableTime = limits.time[us];
+    panicMode     = scaledTime < 1000;
+
+    if (panicMode)
+        moveOverhead = std::max(moveOverhead, panicTimeBuffer + scaledMinimumTime / 2);
 
     // Maximum move horizon
     int centiMTG = limits.movestogo ? std::min(limits.movestogo * 100, 5000) : 5051;
@@ -141,6 +155,19 @@ void TimeManagement::init(Search::LimitsType& limits,
 
     if (options["Ponder"])
         optimumTime += optimumTime / 4;
+
+    if (panicMode)
+    {
+        TimePoint panicFractionCap = limits.time[us] / 4;
+        TimePoint panicAbsoluteCap = panicTimeBuffer ? panicTimeBuffer : maximumTime;
+        TimePoint panicCap =
+          std::max(scaledMinimumTime, std::min({maximumTime, panicFractionCap, panicAbsoluteCap}));
+
+        maximumTime = panicCap;
+        optimumTime = std::clamp(optimumTime, scaledMinimumTime, maximumTime);
+    }
+
+    panicReserve = panicTimeBuffer + moveOverhead;
 }
 
 }  // namespace Stockfish

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -44,6 +44,10 @@ class TimeManagement {
 
     TimePoint optimum() const;
     TimePoint maximum() const;
+    TimePoint available_time() const;
+    TimePoint panic_buffer() const;
+    TimePoint panic_reserve() const;
+    bool      panic() const;
     template<typename FUNC>
     TimePoint elapsed(FUNC nodes) const {
         return useNodesTime ? TimePoint(nodes()) : elapsed_time();
@@ -57,9 +61,13 @@ class TimeManagement {
     TimePoint startTime;
     TimePoint optimumTime;
     TimePoint maximumTime;
+    TimePoint availableTime   = 0;
+    TimePoint panicTimeBuffer = 0;
+    TimePoint panicReserve    = 0;
 
     std::int64_t availableNodes = -1;     // When in 'nodes as time' mode
     bool         useNodesTime   = false;  // True if we are in 'nodes as time' mode
+    bool         panicMode      = false;
 };
 
 }  // namespace Stockfish


### PR DESCRIPTION
## Summary
- add a Panic Time Buffer option and track panic/reserve data inside the time manager
- tighten low-clock behaviour by boosting overhead, capping think time, and enforcing earlier exits when under a second
- document the new option and short-clock safety expectations in the README

## Testing
- make -C src build -j4

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943c4fed3b083279152b0ad20b505c1)