### PR TITLE
Add runtime polyglot book test

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -54,13 +54,13 @@ PGOBENCH = $(WINE_PATH) ./$(EXE) bench
 
 ### Source and object files
 SRCS = benchmark.cpp bitboard.cpp evaluate.cpp experience.cpp main.cpp \
-        misc.cpp movegen.cpp movepick.cpp mcts.cpp position.cpp \
+        misc.cpp movegen.cpp movepick.cpp mcts.cpp polybook.cpp position.cpp \
         search.cpp thread.cpp timeman.cpp tt.cpp uci.cpp ucioption.cpp tune.cpp syzygy/tbprobe.cpp \
         nnue/nnue_accumulator.cpp nnue/nnue_misc.cpp nnue/network.cpp \
         nnue/features/half_ka_v2_hm.cpp nnue/features/full_threats.cpp \
         engine.cpp score.cpp memory.cpp
 
-HEADERS = benchmark.h bitboard.h evaluate.h experience.h experience_compat.h Wordfish_zobrist.h misc.h movegen.h movepick.h mcts.h history.h \
+HEADERS = benchmark.h bitboard.h evaluate.h experience.h experience_compat.h Wordfish_zobrist.h misc.h movegen.h movepick.h mcts.h history.h polybook.h \
                 nnue/nnue_misc.h nnue/features/half_ka_v2_hm.h nnue/features/full_threats.h \
                 nnue/layers/affine_transform.h nnue/layers/affine_transform_sparse_input.h \
                 nnue/layers/clipped_relu.h nnue/layers/sqr_clipped_relu.h nnue/nnue_accumulator.h \

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -37,6 +37,7 @@
 #include "nnue/nnue_misc.h"
 #include "numa.h"
 #include "perft.h"
+#include "polybook.h"
 #include "position.h"
 #include "search.h"
 #include "shm.h"
@@ -152,6 +153,11 @@ Engine::Engine(std::optional<std::string> path) :
         return Experience::update_settings(options);
     };
 
+    const auto updatePolyBook = [this](const Option&) {
+        PolyBook::init(options);
+        return std::nullopt;
+    };
+
     options.add("Experience Enabled", Option(true, updateExperience));
     options.add("Experience File", Option("Wordfish.exp", updateExperience));
     options.add("Experience Readonly", Option(false, updateExperience));
@@ -167,6 +173,9 @@ Engine::Engine(std::optional<std::string> path) :
         Experience::flush();
         return Experience::status_summary();
     }));
+
+    options.add("Book1 File", Option("", updatePolyBook));
+    options.add("Book2 File", Option("", updatePolyBook));
 
     options.add(  //
       "EvalFile", Option(EvalFileDefaultNameBig, [this](const Option& o) {

--- a/src/engine.h
+++ b/src/engine.h
@@ -106,6 +106,7 @@ class Engine {
     std::string                            numa_config_information_as_string() const;
     std::string                            thread_allocation_information_as_string() const;
     std::string                            thread_binding_information_as_string() const;
+    Position&                              access_position() { return pos; }
 
    private:
     const std::string binaryDirectory;

--- a/src/polybook.cpp
+++ b/src/polybook.cpp
@@ -468,6 +468,10 @@ Key PolyBook::polyglot_key(const Position& pos) {
     return key;
 }
 
+Key PolyBook::current_key(const Position& pos) {
+    return polyglot_key(pos);
+}
+
 // A PolyGlot book move is encoded as follows:
 //
 // bit  0- 5: destination square (from 0 to 63)
@@ -588,7 +592,7 @@ int PolyBook::get_key_data() {
 bool PolyBook::check_draw(Position& pos, Move m) {
     StateInfo st;
 
-    pos.do_move(m, st, pos.gives_check(m), nullptr);
+    pos.do_move(m, st, nullptr);
     bool draw = pos.is_draw(pos.game_ply());
     pos.undo_move(m);
 

--- a/src/polybook.h
+++ b/src/polybook.h
@@ -40,6 +40,7 @@ class PolyBook {
 
     static void     init(const OptionsMap&);
     void            init(const std::string& bookfile);
+    Stockfish::Key  current_key(const Stockfish::Position& pos);
     Stockfish::Move probe(Stockfish::Position& pos, bool bestBookMove, int width = 10);
 
    private:

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -35,6 +35,7 @@
 #include "memory.h"
 #include "movegen.h"
 #include "position.h"
+#include "polybook.h"
 #include "score.h"
 #include "search.h"
 #include "types.h"
@@ -153,6 +154,24 @@ void UCIEngine::loop() {
 
         // Add custom non-UCI commands, mainly for debugging purposes.
         // These commands must not be used during a search!
+        else if (token == "book")
+        {
+            std::string bookCommand;
+
+            if (is >> bookCommand && bookCommand == "key")
+                sync_cout << "info string polyglot key "
+                          << polybook[0].current_key(engine.access_position()) << sync_endl;
+            else
+            {
+                Move bookMove = polybook[0].probe(engine.access_position(), true);
+
+                if (bookMove == Move::none())
+                    sync_cout << "nobook" << sync_endl;
+                else
+                    sync_cout << "bestmove "
+                              << move(bookMove, engine.get_options()["UCI_Chess960"]) << sync_endl;
+            }
+        }
         else if (token == "flip")
             engine.flip();
         else if (token == "bench")

--- a/tests/test_experience.py
+++ b/tests/test_experience.py
@@ -23,38 +23,32 @@ if "requests" not in sys.modules:
 from testing import Stockfish
 
 
-class ExperienceFileTests(unittest.TestCase):
-    KEY = 0x123456789ABCDEF0
-    MOVE = (12 << 6) + 28  # e2e4 in Stockfish's internal representation
-    SCORE = 37
-    DEPTH = 16
-    COUNT = 3
+def find_engine_binary():
+    candidates = []
 
+    env_path = os.environ.get("STOCKFISH_BINARY")
+    if env_path:
+        candidates.append(pathlib.Path(env_path))
+
+    root = pathlib.Path(__file__).resolve().parent.parent
+    search_dirs = [root, root / "build", root / "src"]
+    for directory in search_dirs:
+        if directory.is_dir():
+            candidates.extend(sorted(directory.glob("[Ww]ordfish*")))
+            candidates.extend(sorted(directory.glob("[Ss]tockfish*")))
+
+    for candidate in candidates:
+        if candidate and candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate)
+    return None
+
+
+class EngineTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.binary = cls._find_binary()
+        cls.binary = find_engine_binary()
         if cls.binary is None:
             raise unittest.SkipTest("Wordfish binary not available")
-
-    @staticmethod
-    def _find_binary():
-        candidates = []
-
-        env_path = os.environ.get("STOCKFISH_BINARY")
-        if env_path:
-            candidates.append(pathlib.Path(env_path))
-
-        root = pathlib.Path(__file__).resolve().parent.parent
-        search_dirs = [root, root / "build", root / "src"]
-        for directory in search_dirs:
-            if directory.is_dir():
-                candidates.extend(sorted(directory.glob("[Ww]ordfish*")))
-                candidates.extend(sorted(directory.glob("[Ss]tockfish*")))
-
-        for candidate in candidates:
-            if candidate and candidate.is_file() and os.access(candidate, os.X_OK):
-                return str(candidate)
-        return None
 
     def setUp(self):
         self.engine = Stockfish([], self.binary)
@@ -68,6 +62,14 @@ class ExperienceFileTests(unittest.TestCase):
                 self.engine.quit()
             finally:
                 self.engine.close()
+
+
+class ExperienceFileTests(EngineTestCase):
+    KEY = 0x123456789ABCDEF0
+    MOVE = (12 << 6) + 28  # e2e4 in Stockfish's internal representation
+    SCORE = 37
+    DEPTH = 16
+    COUNT = 3
 
     @classmethod
     def _experience_payload(cls):
@@ -163,6 +165,61 @@ class ExperienceFileTests(unittest.TestCase):
 
         entries = self._dump_entries()
         self.assertEqual(entries, [(self.KEY, self.MOVE, self.SCORE, self.DEPTH, 7)])
+
+
+class PolyglotBookTests(EngineTestCase):
+    STARTPOS_MOVE = (12 << 6) + 28  # e2e4 in Polyglot encoding
+
+    def _read_polyglot_key(self):
+        key_line = None
+
+        def parser(output):
+            nonlocal key_line
+            if output.startswith("info string polyglot key "):
+                key_line = output
+                return True
+
+        self.engine.send_command("position startpos")
+        self.engine.send_command("book key")
+        self.engine.check_output(parser)
+        self.engine.clear_output()
+
+        if key_line is None:
+            self.fail("Engine did not report a polyglot key")
+
+        return int(key_line.rsplit(" ", 1)[-1])
+
+    def _write_book(self, key):
+        with tempfile.NamedTemporaryFile("wb", suffix=".bin", delete=False) as handle:
+            entry = struct.pack(">QHHI", key, self.STARTPOS_MOVE, 1, 0)
+            handle.write(entry)
+            return handle.name
+
+    def _load_book(self, path):
+        self.engine.setoption("Book1 File", path)
+        self.engine.send_command("isready")
+
+        lines = []
+
+        def parser(output):
+            lines.append(output)
+            return output == "readyok"
+
+        self.engine.check_output(parser)
+        self.engine.clear_output()
+        return lines
+
+    def test_polyglot_book_generated_in_test(self):
+        key       = self._read_polyglot_key()
+        book_path = self._write_book(key)
+        self.addCleanup(lambda: os.remove(book_path))
+
+        info_lines = self._load_book(book_path)
+        self.assertTrue(any(f"Book loaded: {book_path}" in line for line in info_lines))
+
+        self.engine.send_command("position startpos")
+        self.engine.send_command("book")
+        self.engine.starts_with("bestmove e2e4")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- compile polybook support, expose book file options, and add a debug `book` command for probing moves or keys
- generate the polyglot start-position book on the fly in tests and verify the engine consumes it

## Testing
- make build -j2
- python -m unittest tests/test_experience.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943fbda2c74832791d7be1393d28f1c)