### PR TITLE
Fix time management panic mode

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -2164,8 +2164,15 @@ void SearchManager::check_time(Search::Worker& worker) {
     const TimePoint timeToMoveTime  = remaining_or_max(worker.limits.movetime);
     const TimePoint timeToMaxBudget = worker.limits.use_time_management() ? remaining_or_max(tm.maximum())
                                                                           : std::numeric_limits<TimePoint>::max();
-    const TimePoint timeToPanic     = worker.limits.use_time_management() ? remaining_or_max(tm.panic())
-                                                                          : std::numeric_limits<TimePoint>::max();
+
+    TimePoint panicLimit = TimePoint(0);
+    if (worker.limits.use_time_management() && tm.panic())
+        panicLimit = std::max(TimePoint(0), tm.available_time() - tm.panic_reserve());
+
+    const TimePoint timeToPanic =
+      panicLimit ? std::max<TimePoint>(TimePoint(0), panicLimit - elapsed)
+                 : std::numeric_limits<TimePoint>::max();
+
     const TimePoint nearestDeadline = std::min({timeToMoveTime, timeToMaxBudget, timeToPanic});
     constexpr TimePoint urgentWindow = 50;
 
@@ -2203,7 +2210,6 @@ void SearchManager::check_time(Search::Worker& worker) {
     if (ponder)
         return;
 
-codex/add-panic-mode-for-low-time-management
     if (worker.limits.use_time_management() && tm.panic())
     {
         TimePoint remaining = std::max(TimePoint(0), tm.available_time() - elapsed);
@@ -2212,30 +2218,19 @@ codex/add-panic-mode-for-low-time-management
             worker.threads.stop = worker.threads.abortedSearch = true;
     }
 
-    if (
-      // Later we rely on the fact that we can at least use the mainthread previous
-      // root-search score and PV in a multithreaded environment to prove mated-in scores.
-      worker.completedDepth >= 1
-      && ((worker.limits.use_time_management() && (elapsed > tm.maximum() || stopOnPonderhit))
-          || (worker.limits.movetime && elapsed >= worker.limits.movetime)
-          || (worker.limits.nodes && worker.threads.nodes_searched() >= worker.limits.nodes)))
-=======
     const bool timeLimit =
       worker.limits.use_time_management() && (elapsed > tm.maximum() || stopOnPonderhit);
     const bool moveTimeLimit = worker.limits.movetime && elapsed >= worker.limits.movetime;
     const bool nodeLimit     =
       worker.limits.nodes && worker.threads.nodes_searched() >= worker.limits.nodes;
-    const bool panicTime =
-      worker.limits.use_time_management() && elapsed >= tm.panic() && worker.completedDepth == 0;
 
     // Later we rely on the fact that we can at least use the mainthread previous
     // root-search score and PV in a multithreaded environment to prove mated-in scores.
     const bool completedIteration = worker.completedDepth >= 1;
     const bool exceededTimeBudget = timeLimit || moveTimeLimit || nodeLimit;
-    const bool exceededHardBudget = moveTimeLimit || nodeLimit || panicTime;
+    const bool exceededHardBudget = moveTimeLimit || nodeLimit;
 
     if ((completedIteration && exceededTimeBudget) || (!completedIteration && exceededHardBudget))
- main
         worker.threads.stop = worker.threads.abortedSearch = true;
 }
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -30,18 +30,15 @@ namespace Stockfish {
 
 TimePoint TimeManagement::optimum() const { return optimumTime; }
 TimePoint TimeManagement::maximum() const { return maximumTime; }
- codex/add-panic-mode-for-low-time-management
 TimePoint TimeManagement::available_time() const { return availableTime; }
 TimePoint TimeManagement::panic_buffer() const { return panicTimeBuffer; }
 TimePoint TimeManagement::panic_reserve() const { return panicReserve; }
 bool      TimeManagement::panic() const { return panicMode; }
-=======
-TimePoint TimeManagement::panic() const { return panicTime; }
- main
 
 void TimeManagement::clear() {
     availableNodes = -1;  // When in 'nodes as time' mode
-    optimumTime    = maximumTime = panicTime = TimePoint(0);
+    optimumTime    = maximumTime = availableTime = panicTimeBuffer = panicReserve = TimePoint(0);
+    panicMode      = false;
 }
 
 void TimeManagement::advance_nodes_time(std::int64_t nodes) {
@@ -64,12 +61,8 @@ void TimeManagement::init(Search::LimitsType& limits,
     // startTime is used by movetime and useNodesTime is used in elapsed calls.
     startTime    = limits.startTime;
     useNodesTime = npmsec != 0;
- codex/add-panic-mode-for-low-time-management
     panicMode    = false;
-    panicTimeBuffer = panicReserve = availableTime = 0;
-=======
-    panicTime    = TimePoint(0);
- main
+    panicTimeBuffer = panicReserve = availableTime = TimePoint(0);
 
     if (limits.time[us] == 0)
         return;
@@ -165,7 +158,6 @@ void TimeManagement::init(Search::LimitsType& limits,
     if (options["Ponder"])
         optimumTime += optimumTime / 4;
 
- codex/add-panic-mode-for-low-time-management
     if (panicMode)
     {
         TimePoint panicFractionCap = limits.time[us] / 4;
@@ -178,11 +170,6 @@ void TimeManagement::init(Search::LimitsType& limits,
     }
 
     panicReserve = panicTimeBuffer + moveOverhead;
-=======
-    panicTime =
-      std::max(maximumTime + scaledMinimumTime / 4,
-               std::max(TimePoint(1), limits.time[us] - moveOverhead));
- main
 }
 
 }  // namespace Stockfish

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -44,14 +44,10 @@ class TimeManagement {
 
     TimePoint optimum() const;
     TimePoint maximum() const;
- codex/add-panic-mode-for-low-time-management
     TimePoint available_time() const;
     TimePoint panic_buffer() const;
     TimePoint panic_reserve() const;
     bool      panic() const;
-=======
-    TimePoint panic() const;
- main
     template<typename FUNC>
     TimePoint elapsed(FUNC nodes) const {
         return useNodesTime ? TimePoint(nodes()) : elapsed_time();
@@ -65,13 +61,9 @@ class TimeManagement {
     TimePoint startTime;
     TimePoint optimumTime;
     TimePoint maximumTime;
-codex/add-panic-mode-for-low-time-management
     TimePoint availableTime   = 0;
     TimePoint panicTimeBuffer = 0;
     TimePoint panicReserve    = 0;
-=======
-    TimePoint panicTime;
- main
 
     std::int64_t availableNodes = -1;     // When in 'nodes as time' mode
     bool         useNodesTime   = false;  // True if we are in 'nodes as time' mode


### PR DESCRIPTION
## Summary
- resolve merge conflict remnants in time management and search logic
- restore panic-mode tracking fields and accessors for time control
- adjust search time checks to use panic reserve thresholds instead of obsolete panic timers

## Testing
- make build ARCH=x86-64


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944044938d08327bc368ff5722d7f0d)