### PR TITLE
Add runtime polyglot book generation

### DIFF
--- a/src/polybook.cpp
+++ b/src/polybook.cpp
@@ -21,6 +21,10 @@
 #include "movegen.h"
 #include "thread.h"
 #include <iostream>
+#include <algorithm>
+#include <cstdio>
+#include <limits>
+#include <vector>
 #include "misc.h"
 #include <sys/timeb.h>
 #include <cmath>
@@ -298,6 +302,28 @@ void byteswap_polyhash(PolyHash* ph) {
 }
 }
 
+uint16_t PolyBook::sf_move_to_pg_move(const Position& pos, Move move) {
+    if (move == Move::none())
+        return 0;
+
+    for (const auto& legal : MoveList<LEGAL>(pos))
+    {
+        if (legal == move)
+        {
+            uint16_t from      = move.from_sq();
+            uint16_t to        = move.to_sq();
+            uint16_t promotion = 0;
+
+            if (move.type_of() == PROMOTION)
+                promotion = static_cast<uint16_t>(move.promotion_type() - 1);
+
+            return static_cast<uint16_t>((promotion << 12) | (from << 6) | to);
+        }
+    }
+
+    return 0;
+}
+
 PolyBook::PolyBook() {
     keycount = 0;
     polyhash = NULL;
@@ -318,6 +344,49 @@ PolyBook::~PolyBook() {
 void PolyBook::init(const OptionsMap& options) {
     polybook[0].init(options["Book1 File"]);
     polybook[1].init(options["Book2 File"]);
+}
+
+bool PolyBook::generate(const std::string& bookfile, const Position& pos,
+                        const std::vector<Move>& moves, uint16_t weight, uint32_t learn) {
+    if (bookfile.empty() || moves.empty())
+        return false;
+
+    std::vector<PolyHash> entries;
+    entries.reserve(moves.size());
+
+    Key key = polyglot_key(pos);
+
+    uint16_t clampedWeight = static_cast<uint16_t>(
+      std::clamp<uint32_t>(weight, 1u, static_cast<uint32_t>(std::numeric_limits<uint16_t>::max())));
+
+    for (Move move : moves)
+    {
+        uint16_t pgMove = sf_move_to_pg_move(pos, move);
+        if (!pgMove)
+            return false;
+
+        entries.push_back({key, pgMove, clampedWeight, learn});
+    }
+
+    std::sort(entries.begin(), entries.end(), [](const PolyHash& lhs, const PolyHash& rhs) {
+        if (lhs.key != rhs.key)
+            return lhs.key < rhs.key;
+        if (lhs.weight != rhs.weight)
+            return lhs.weight > rhs.weight;
+        return lhs.move < rhs.move;
+    });
+
+    for (auto& entry : entries)
+        byteswap_polyhash(&entry);
+
+    FILE* fpt = fopen(bookfile.c_str(), "wb");
+    if (!fpt)
+        return false;
+
+    size_t written = fwrite(entries.data(), sizeof(PolyHash), entries.size(), fpt);
+    fclose(fpt);
+
+    return written == entries.size();
 }
 
 void PolyBook::init(const std::string& bookfile) {

--- a/src/polybook.h
+++ b/src/polybook.h
@@ -23,6 +23,7 @@
 #include "position.h"
 #include "string.h"
 #include "ucioption.h"
+#include <vector>
 
 namespace Stockfish {
 
@@ -41,11 +42,15 @@ class PolyBook {
     static void     init(const OptionsMap&);
     void            init(const std::string& bookfile);
     Stockfish::Key  current_key(const Stockfish::Position& pos);
+    static bool     generate(const std::string& bookfile, const Stockfish::Position& pos,
+                             const std::vector<Stockfish::Move>& moves, uint16_t weight = 1,
+                             uint32_t learn = 0);
     Stockfish::Move probe(Stockfish::Position& pos, bool bestBookMove, int width = 10);
 
    private:
-    Stockfish::Key  polyglot_key(const Stockfish::Position& pos);
-    Stockfish::Move pg_move_to_sf_move(const Stockfish::Position& pos, unsigned short pg_move);
+    static Stockfish::Key  polyglot_key(const Stockfish::Position& pos);
+    static uint16_t        sf_move_to_pg_move(const Stockfish::Position& pos, Stockfish::Move move);
+    Stockfish::Move        pg_move_to_sf_move(const Stockfish::Position& pos, unsigned short pg_move);
 
     int find_first_key(uint64_t key);
     int get_key_data();

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -158,9 +158,82 @@ void UCIEngine::loop() {
         {
             std::string bookCommand;
 
-            if (is >> bookCommand && bookCommand == "key")
+            if (!(is >> bookCommand))
+            {
+                Move bookMove = polybook[0].probe(engine.access_position(), true);
+
+                if (bookMove == Move::none())
+                    sync_cout << "nobook" << sync_endl;
+                else
+                    sync_cout << "bestmove "
+                              << move(bookMove, engine.get_options()["UCI_Chess960"]) << sync_endl;
+            }
+            else if (bookCommand == "key")
                 sync_cout << "info string polyglot key "
                           << polybook[0].current_key(engine.access_position()) << sync_endl;
+            else if (bookCommand == "generate")
+            {
+                std::string       bookPath;
+                std::vector<Move> moves;
+                std::string       tokenMove;
+                uint16_t          weight = 1;
+                uint32_t          learn  = 0;
+
+                if (!(is >> bookPath))
+                {
+                    sync_cout << "info string Usage: book generate <path> <moves...> [weight <n>] "
+                              << "[learn <n>]" << sync_endl;
+                    continue;
+                }
+
+                const Position& pos = engine.access_position();
+
+                while (is >> tokenMove)
+                {
+                    if (tokenMove == "weight")
+                    {
+                        int parsedWeight = 0;
+                        if (is >> parsedWeight)
+                            weight = static_cast<uint16_t>(std::max(parsedWeight, 0));
+                        continue;
+                    }
+
+                    if (tokenMove == "learn")
+                    {
+                        uint32_t parsedLearn = 0;
+                        if (is >> parsedLearn)
+                            learn = parsedLearn;
+                        continue;
+                    }
+
+                    Move parsedMove = to_move(pos, tokenMove);
+                    if (parsedMove == Move::none())
+                    {
+                        sync_cout << "info string Invalid book move: " << tokenMove << sync_endl;
+                        moves.clear();
+                        break;
+                    }
+
+                    moves.push_back(parsedMove);
+                }
+
+                if (moves.empty())
+                {
+                    sync_cout << "info string No valid moves provided for book generation"
+                              << sync_endl;
+                    continue;
+                }
+
+                if (PolyBook::generate(bookPath, pos, moves, weight, learn))
+                {
+                    polybook[0].init(bookPath);
+                    sync_cout << "info string Generated polyglot book at " << bookPath
+                              << sync_endl;
+                }
+                else
+                    sync_cout << "info string Failed to generate polyglot book at " << bookPath
+                              << sync_endl;
+            }
             else
             {
                 Move bookMove = polybook[0].probe(engine.access_position(), true);

--- a/tests/test_experience.py
+++ b/tests/test_experience.py
@@ -221,6 +221,25 @@ class PolyglotBookTests(EngineTestCase):
         self.engine.send_command("book")
         self.engine.starts_with("bestmove e2e4")
 
+    def test_polyglot_book_generated_by_engine(self):
+        self.engine.send_command("position startpos")
+
+        with tempfile.NamedTemporaryFile("wb", suffix=".bin", delete=False) as handle:
+            book_path = handle.name
+
+        self.addCleanup(lambda: os.path.exists(book_path) and os.remove(book_path))
+
+        os.remove(book_path)
+        self.engine.send_command(f"book generate {book_path} e2e4")
+        self.engine.starts_with(f"info string Generated polyglot book at {book_path}")
+
+        info_lines = self._load_book(book_path)
+        self.assertTrue(any(f"Book loaded: {book_path}" in line for line in info_lines))
+
+        self.engine.send_command("position startpos")
+        self.engine.send_command("book")
+        self.engine.starts_with("bestmove e2e4")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add a `PolyBook::generate` helper to create polyglot books from the current position and encode legal moves
- expose book generation through a new `book generate` console command that reloads the created book immediately
- cover runtime book creation with a dedicated regression test alongside the existing polyglot key checks

## Testing
- make build ARCH=x86-64 -j2
- python -m pytest tests/test_experience.py -k polyglot -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944077d3c1c8327b49f85f0dc2170b1)