### PR TITLE
Handle missing visits in experience imports

### DIFF
--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -295,10 +295,15 @@ bool load_text_format(std::istream& in, Stats& loadStats) {
         unsigned           rawMove;
         int                score, eval;
         int                depth;
-        unsigned           visits = 0;
+        unsigned           visits = 1;
 
-        if (!(iss >> key >> rawMove >> score >> eval >> depth >> visits))
+        if (!(iss >> key >> rawMove >> score >> eval >> depth))
             continue;
+
+        // Older text experience files did not include an explicit visit count.
+        // Treat missing values as a single visit so those files remain usable.
+        if (!(iss >> visits))
+            visits = 1;
 
         Entry entry;
         entry.bestMove = Move(static_cast<std::uint16_t>(rawMove));

--- a/tests/test_experience.py
+++ b/tests/test_experience.py
@@ -166,6 +166,18 @@ class ExperienceFileTests(EngineTestCase):
         entries = self._dump_entries()
         self.assertEqual(entries, [(self.KEY, self.MOVE, self.SCORE, self.DEPTH, 7)])
 
+    def test_text_experience_without_visits_defaults_to_single_visit(self):
+        header = "# Wordfish experience format v1\n".encode()
+        entry  = f"{self.KEY} {self.MOVE} {self.SCORE} {self.SCORE} {self.DEPTH}\n".encode()
+
+        exp_path = self._write_experience_file(".exp", lambda handle: handle.write(header + entry))
+        self.addCleanup(lambda: os.remove(exp_path))
+
+        self._load_experience(exp_path)
+
+        entries = self._dump_entries()
+        self.assertEqual(entries, [(self.KEY, self.MOVE, self.SCORE, self.DEPTH, 1)])
+
 
 class PolyglotBookTests(EngineTestCase):
     STARTPOS_MOVE = (12 << 6) + 28  # e2e4 in Polyglot encoding


### PR DESCRIPTION
## Summary
- allow text experience entries that omit the visit count to load with a default of one visit
- document the expected visit fallback so older experience files remain usable
- add regression coverage to verify loading text experience files without an explicit visit count

## Testing
- make build -j2
- pytest -q --disable-warnings --maxfail=1

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69440d4bf4b08327a5d42f4004ecadc3)