### PR TITLE
Add configurable polyglot book options

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -175,8 +175,19 @@ Engine::Engine(std::optional<std::string> path) :
         return Experience::status_summary();
     }));
 
+    options.add("Book1", Option(false, updatePolyBook));
     options.add("Book1 File", Option("", updatePolyBook));
+    options.add("Book1 BestBookMove", Option(false, updatePolyBook));
+    options.add("Book1 Depth", Option(255, 1, 350, updatePolyBook));
+    options.add("Book1 Width", Option(1, 1, 10, updatePolyBook));
+
+    options.add("Book2", Option(false, updatePolyBook));
     options.add("Book2 File", Option("", updatePolyBook));
+    options.add("Book2 BestBookMove", Option(false, updatePolyBook));
+    options.add("Book2 Depth", Option(255, 1, 350, updatePolyBook));
+    options.add("Book2 Width", Option(1, 1, 10, updatePolyBook));
+
+    PolyBook::init(options);
 
     options.add(  //
       "EvalFile", Option(EvalFileDefaultNameBig, [this](const Option& o) {
@@ -204,6 +215,27 @@ std::uint64_t Engine::perft(const std::string& fen, Depth depth, bool isChess960
 void Engine::go(Search::LimitsType& limits) {
     assert(limits.perft == 0);
     verify_networks();
+
+    const bool searchRequested = limits.depth || limits.nodes || limits.mate || limits.infinite
+                                 || limits.ponderMode || !limits.searchmoves.empty();
+
+    if (!searchRequested)
+    {
+        Move bookMove = polybook[0].probe(pos);
+
+        if (bookMove == Move::none())
+            bookMove = polybook[1].probe(pos);
+
+        if (bookMove != Move::none())
+        {
+            const auto bestmove = UCIEngine::move(bookMove, options["UCI_Chess960"]);
+
+            if (updateContext.onBestmove)
+                updateContext.onBestmove(bestmove, std::string_view{});
+
+            return;
+        }
+    }
 
     threads.start_thinking(options, pos, states, limits);
 }

--- a/src/polybook.cpp
+++ b/src/polybook.cpp
@@ -328,22 +328,69 @@ PolyBook::PolyBook() {
     keycount = 0;
     polyhash = NULL;
     enabled  = false;
+    active   = false;
+    bestOnly = false;
+    maxDepth = 255;
+    width    = 1;
+    bookPath = "";
 
     index_first = index_best = index_rand = 0;
     index_count = index_weight_count = 0;
 }
 
 PolyBook::~PolyBook() {
+    unload();
+}
+
+void PolyBook::unload() {
+    keycount = 0;
+
     if (polyhash != NULL)
     {
         free(polyhash);
         polyhash = nullptr;
     }
+
+    enabled = false;
 }
 
 void PolyBook::init(const OptionsMap& options) {
-    polybook[0].init(options["Book1 File"]);
-    polybook[1].init(options["Book2 File"]);
+    auto configure = [](PolyBook& slot,
+                        const std::string& file,
+                        bool               slotEnabled,
+                        bool               bestBookMove,
+                        int                depthLimit,
+                        int                widthSetting) {
+        const std::string previousPath = slot.bookPath;
+
+        slot.active   = slotEnabled;
+        slot.bestOnly = bestBookMove;
+        slot.maxDepth = depthLimit;
+        slot.width    = widthSetting;
+
+        if (file.empty())
+        {
+            slot.init(file);
+            return;
+        }
+
+        if (!slot.enabled || file != previousPath)
+            slot.init(file);
+    };
+
+    configure(polybook[0],
+              options["Book1 File"],
+              static_cast<bool>(options["Book1"]),
+              static_cast<bool>(options["Book1 BestBookMove"]),
+              int(options["Book1 Depth"]),
+              int(options["Book1 Width"]));
+
+    configure(polybook[1],
+              options["Book2 File"],
+              static_cast<bool>(options["Book2"]),
+              static_cast<bool>(options["Book2 BestBookMove"]),
+              int(options["Book2 Depth"]),
+              int(options["Book2 Width"]));
 }
 
 bool PolyBook::generate(const std::string& bookfile, const Position& pos,
@@ -391,20 +438,27 @@ bool PolyBook::generate(const std::string& bookfile, const Position& pos,
 
 void PolyBook::init(const std::string& bookfile) {
     enabled = false;
+
     if (bookfile.empty())
+    {
+        unload();
+        bookPath.clear();
         return;
+    }
+
+    if (bookfile == bookPath && polyhash != nullptr)
+    {
+        enabled = true;
+        return;
+    }
+
+    unload();
 
     FILE* fpt = fopen(bookfile.c_str(), "rb");
     if (fpt == NULL)
     {
         sync_cout << "info string Could not open " << bookfile << sync_endl;
         return;
-    }
-
-    if (polyhash)
-    {
-        free(polyhash);
-        polyhash = NULL;
     }
 
     fseek(fpt, 0L, SEEK_END);
@@ -415,7 +469,7 @@ void PolyBook::init(const std::string& bookfile) {
     polyhash = (PolyHash*) malloc(filesize);
     if (!polyhash)
     {
-        sync_cout << "info string Memory allocation failed" << bookfile << sync_endl;
+        sync_cout << "info string Memory allocation failed " << bookfile << sync_endl;
         return;
     }
 
@@ -424,8 +478,7 @@ void PolyBook::init(const std::string& bookfile) {
 
     if (readSize != filesize)
     {
-        free(polyhash);
-        polyhash = NULL;
+        unload();
 
         sync_cout << "info string Could not read " << bookfile << sync_endl;
         return;
@@ -436,11 +489,16 @@ void PolyBook::init(const std::string& bookfile) {
 
     sync_cout << "info string Book loaded: " << bookfile << sync_endl;
 
-    enabled = true;
+    bookPath = bookfile;
+    enabled  = true;
 }
 
-Move PolyBook::probe(Position& pos, bool bestBookMove, int width) {
-    if (!enabled)
+Move PolyBook::probe(Position& pos, bool forceEnabled) {
+    if (!enabled || (!active && !forceEnabled))
+        return Move::none();
+
+    const int depthLimit = std::max(1, maxDepth);
+    if (pos.game_ply() >= depthLimit)
         return Move::none();
 
     Key key = polyglot_key(pos);
@@ -450,7 +508,7 @@ Move PolyBook::probe(Position& pos, bool bestBookMove, int width) {
 
     Move m;
 
-    if (bestBookMove || n == 1)
+    if (bestOnly || n == 1)
     {
         int idx = index_best;
         m = pg_move_to_sf_move(pos, polyhash[idx].move);
@@ -458,22 +516,23 @@ Move PolyBook::probe(Position& pos, bool bestBookMove, int width) {
     else
     {
         // Smooth mapping: from width=1 (free/random) to width=10 (selective/strict)
-        double exponent = 1.0 + (std::clamp(width, 1, 10) - 1) * 0.5;
+        const int bookWidth = std::clamp(width, 1, 10);
+        double     exponent = 1.0 + (bookWidth - 1) * 0.5;
 
         std::vector<double> scores(n);
-        double total = 0.0;
+        double              total = 0.0;
 
         for (int i = 0; i < n; ++i)
         {
-            int w = polyhash[index_first + i].weight;
-            double s = std::pow(static_cast<double>(w), exponent);
-            scores[i] = s;
+            int w      = polyhash[index_first + i].weight;
+            double s   = std::pow(static_cast<double>(w), exponent);
+            scores[i]  = s;
             total += s;
         }
 
-        double r = (double)(rng.rand<uint32_t>() % 1000000) / 1000000.0 * total;
+        double r   = (double)(rng.rand<uint32_t>() % 1000000) / 1000000.0 * total;
         double sum = 0.0;
-        int idx = index_first;
+        int    idx = index_first;
 
         for (int i = 0; i < n; ++i)
         {

--- a/src/polybook.h
+++ b/src/polybook.h
@@ -22,6 +22,7 @@
 #include "bitboard.h"
 #include "position.h"
 #include "string.h"
+#include <string>
 #include "ucioption.h"
 #include <vector>
 
@@ -45,12 +46,14 @@ class PolyBook {
     static bool     generate(const std::string& bookfile, const Stockfish::Position& pos,
                              const std::vector<Stockfish::Move>& moves, uint16_t weight = 1,
                              uint32_t learn = 0);
-    Stockfish::Move probe(Stockfish::Position& pos, bool bestBookMove, int width = 10);
+    Stockfish::Move probe(Stockfish::Position& pos, bool forceEnabled = false);
 
    private:
     static Stockfish::Key  polyglot_key(const Stockfish::Position& pos);
     static uint16_t        sf_move_to_pg_move(const Stockfish::Position& pos, Stockfish::Move move);
     Stockfish::Move        pg_move_to_sf_move(const Stockfish::Position& pos, unsigned short pg_move);
+
+    void unload();
 
     int find_first_key(uint64_t key);
     int get_key_data();
@@ -60,6 +63,11 @@ class PolyBook {
     int       keycount;
     PolyHash* polyhash;
     bool      enabled;
+    bool      active;
+    bool      bestOnly;
+    int       maxDepth;
+    int       width;
+    std::string bookPath;
 
     int index_first;
     int index_best;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -163,6 +163,9 @@ void UCIEngine::loop() {
                 Move bookMove = polybook[0].probe(engine.access_position(), true);
 
                 if (bookMove == Move::none())
+                    bookMove = polybook[1].probe(engine.access_position(), true);
+
+                if (bookMove == Move::none())
                     sync_cout << "nobook" << sync_endl;
                 else
                     sync_cout << "bestmove "
@@ -237,6 +240,9 @@ void UCIEngine::loop() {
             else
             {
                 Move bookMove = polybook[0].probe(engine.access_position(), true);
+
+                if (bookMove == Move::none())
+                    bookMove = polybook[1].probe(engine.access_position(), true);
 
                 if (bookMove == Move::none())
                     sync_cout << "nobook" << sync_endl;


### PR DESCRIPTION
## Summary
- add Book1/Book2 toggles plus best-move, depth, and width controls to the UCI surface
- refresh polyglot slot state from options, tracking activation, width, depth, and cached book loads
- consult configured polyglot books before searching and allow the CLI book command to fall back across slots

## Testing
- python -m pytest tests/test_experience.py::PolyglotBookTests::test_polyglot_book_generated_in_test (skipped: Wordfish binary not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69441b3ecb4483278ffa2e73e8674fab)