### PR TITLE
Document online time-control ranges for Playchess and Lichess in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ Wordfish is a Universal Chess Interface (UCI) engine derived from Stockfish. It 
 - **Neural networks**: `EvalFile` and `EvalFileSmall` accept external NNUE files and reload replicas on all threads.
 - **Tablebases**: `SyzygyPath`, `SyzygyProbeDepth`, `Syzygy50MoveRule`, and `SyzygyProbeLimit` configure probing depth, scope, and rule enforcement.
 
+## Settings: online time-control ranges (main page)
+
+Use the following ranges to set the **time control** values in the Settings section for popular online servers. Times are expressed as *base time + increment*.
+
+- **Playchess.com**
+  - **Bullet**: 60s + 0s up to 120s + 1s
+  - **Blitz**: 180s + 0s up to 16 minutes + 3s
+  - **Classical**: 16 minutes + 0s up to 120 minutes + 15s
+- **Lichess.org**
+  - **Bullet**: 60s + 0s up to 120s + 1s
+  - **Blitz**: 180s + 0s up to 16 minutes + 3s
+  - **Classical**: 16 minutes + 0s up to 120 minutes + 15s
+
 ## Uso de libros Polyglot (alineado con Pullfish)
 
 Wordfish expone dos ranuras configurables de libros Polyglot, `Book1` y `Book2`, para mezclar repertorios o mantener un respaldo. Cada ranura ofrece los mismos controles:


### PR DESCRIPTION
### Motivation
- Provide clear, user-facing guidance for configuring the engine’s `Settings` time-control values on popular online servers.
- Make ranges explicit and expressed as `base time + increment` so users can set appropriate controls for Bullet, Blitz, and Classical games.
- Improve the main README so the information is discoverable from the project’s primary documentation.

### Description
- Added a new section titled `Settings: online time-control ranges (main page)` to `README.md`.
- Documented time-control ranges for both Playchess and Lichess in English, listing `Bullet`, `Blitz`, and `Classical` with the `base + increment` format:
  - `Bullet`: `60s + 0s` up to `120s + 1s`
  - `Blitz`: `180s + 0s` up to `16 minutes + 3s`
  - `Classical`: `16 minutes + 0s` up to `120 minutes + 15s`
- This change is documentation-only and affects `README.md`.

### Testing
- No automated tests were executed for this change (documentation-only update).
- No build or runtime validation was required; change limited to `README.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69451877afbc8327bd3b54019e925edc)