### PR TITLE
Document online time-control ranges and recommended UCI defaults in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,32 @@ Wordfish is a Universal Chess Interface (UCI) engine derived from Stockfish. It 
 - **Neural networks**: `EvalFile` and `EvalFileSmall` accept external NNUE files and reload replicas on all threads.
 - **Tablebases**: `SyzygyPath`, `SyzygyProbeDepth`, `Syzygy50MoveRule`, and `SyzygyProbeLimit` configure probing depth, scope, and rule enforcement.
 
+## Settings: online time-control ranges (main page)
+
+Use the following ranges to set the **time control** values in the Settings section for popular online servers. Times are expressed as *base time + increment*.
+
+- **Playchess.com**
+  - **Bullet**: 60s + 0s up to 120s + 1s
+  - **Blitz**: 180s + 0s up to 16 minutes + 3s
+  - **Classical**: 16 minutes + 0s up to 120 minutes + 15s
+
+### Recommended UCI values for these time controls
+
+These baseline values are tuned for online play and are safe defaults across the Bullet, Blitz, and Classical ranges above. Apply them in your GUI’s engine options (UCI `setoption`).
+
+- `Hash`: **256** (MB)
+- `Move Overhead`: **100** (ms)
+- `Contempt`: **0**
+- `Contemp`: **0**
+- `King Safety`: **100**
+- `SyzygyProbeDepth`: **1**
+- `Syzygy50MoveRule`: **true**
+- `SyzygyProbeLimit`: **7**
+- **Lichess.org**
+  - **Bullet**: 60s + 0s up to 120s + 1s
+  - **Blitz**: 180s + 0s up to 16 minutes + 3s
+  - **Classical**: 16 minutes + 0s up to 120 minutes + 15s
+
 ## Uso de libros Polyglot (alineado con Pullfish)
 
 Wordfish expone dos ranuras configurables de libros Polyglot, `Book1` y `Book2`, para mezclar repertorios o mantener un respaldo. Cada ranura ofrece los mismos controles:


### PR DESCRIPTION
### Motivation

- Provide clear, user-facing guidance in the main README for configuring the engine’s Settings time-control values for popular online servers.
- Express ranges in `base + increment` format so users can map server time controls to the engine’s UCI options.
- Offer a set of recommended baseline UCI option values that are safe defaults across Bullet, Blitz, and Classical online play.

### Description

- Added a new section `Settings: online time-control ranges (main page)` to `README.md` that lists Playchess and Lichess ranges for:
  - `Bullet`: `60s + 0s` up to `120s + 1s`
  - `Blitz`: `180s + 0s` up to `16 minutes + 3s`
  - `Classical`: `16 minutes + 0s` up to `120 minutes + 15s`
- Added `Recommended UCI values for these time controls` with suggested defaults to apply via UCI `setoption`: `Hash: 256`, `Move Overhead: 100`, `Contempt: 0`, `Contemp: 0`, `King Safety: 100`, `SyzygyProbeDepth: 1`, `Syzygy50MoveRule: true`, `SyzygyProbeLimit: 7`.
- Change is documentation-only and touches only `README.md`.

### Testing

- No automated tests were executed — documentation-only update.
- No build or runtime validation required; change limited to `README.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69451877afbc8327bd3b54019e925edc)