### PR TITLE
Sync: Stockfish PR #6499 (Remove -Wstack-usage on (apple) clang)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -476,7 +476,7 @@ endif
 ifeq ($(COMP),gcc)
 	comp=gcc
 	CXX=g++
-	CXXFLAGS += -pedantic -Wextra -Wshadow -Wmissing-declarations -Wstack-usage=128000
+	CXXFLAGS += -pedantic -Wextra -Wshadow -Wmissing-declarations
 
 	ifeq ($(arch),$(filter $(arch),armv7 armv8 riscv64))
 		ifeq ($(OS),Android)
@@ -647,6 +647,8 @@ ifeq ($(COMP),gcc)
 	ifneq ($(gccisclang),)
 		profile_make = clang-profile-make
 		profile_use = clang-profile-use
+	else
+		CXXFLAGS += -Wstack-usage=128000
 	endif
 endif
 


### PR DESCRIPTION
Cherry-pick/apply Stockfish commit 44d5467bbe06789e8a3cbaee87e699e033b3081a. No functional change; adjusts Makefile flags to avoid Apple clang error on -Wstack-usage.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69540aafd3c08327baaf6b91fff9701a)