### PR TITLE
Fix qsearch bestValue monotonicity

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1855,7 +1855,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
                 // we can prune this move.
                 if (!pos.see_ge(move, alpha - futilityBase))
                 {
-                    bestValue = std::min(alpha, futilityBase);
+                    bestValue = std::max(bestValue, std::min(alpha, futilityBase));
                     continue;
                 }
             }


### PR DESCRIPTION
### Motivation
- Quiescence search (`qsearch`) could sometimes reduce `bestValue` during SEE-based pruning, producing non-monotonic best-score updates.
- The change mirrors the upstream Stockfish fix to prevent `bestValue` from decreasing unexpectedly.

### Description
- In `src/search.cpp` inside `Search::Worker::qsearch`, replace `bestValue = std::min(alpha, futilityBase)` with `bestValue = std::max(bestValue, std::min(alpha, futilityBase))` to avoid lowering `bestValue` when pruning.
- This change clamps the pruning update to never drop below the current `bestValue` while preserving the original pruning logic.
- Only `src/search.cpp` was modified and the commit message is `Fix qsearch bestValue monotonicity`.

### Testing
- No automated tests were executed for this change.
- No test failures were reported (tests not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e9cf6feac83278596db5aae6d8453)