### PR TITLE
Add BrainLearn MCTS as a selectable search strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Wordfish is a Universal Chess Interface (UCI) engine derived from Stockfish. It 
 
 ## Architecture and integrated modules
 
-- **Search pipeline**: Classical alpha–beta search remains the default, with an alternative Monte Carlo Tree Search (MCTS) driver selectable through `Search Strategy`. Both strategies honour standard UCI limits (`depth`, `nodes`, `movetime`, `infinite`, and pondering) and share the same move generator and time manager.
+- **Search pipeline**: Classical alpha–beta search remains the default, with alternative Monte Carlo Tree Search (MCTS) drivers selectable through `Search Strategy`. Both strategies honour standard UCI limits (`depth`, `nodes`, `movetime`, `infinite`, and pondering) and share the same move generator and time manager.
 - **Neural evaluation**: A paired NNUE design keeps large and small networks in step. Networks are hot-swapped via `EvalFile` and `EvalFileSmall`, with `export_net` producing portable binaries. The `trace_eval` command prints a complete evaluation trace for the current position.
 - **Experience system**: Search outcomes are written to an `.exp` file when `Experience Enabled` is true. `Experience Readonly` permits analysis without mutating the store, while `Experience Sync` forces an immediate flush. Learned moves can be consulted as a lightweight book when `Experience Book` is active.
 - **NUMA and threading**: `Threads` resizes the worker pool, and `NumaPolicy` (`auto`, `system`, `hardware`, `none`, or a custom mask) governs thread placement. Changes are reflected immediately in shared network replicas and hash tables.
@@ -28,12 +28,17 @@ Wordfish is a Universal Chess Interface (UCI) engine derived from Stockfish. It 
 - **Session control**: `uci` announces identity and options; `isready` synchronises threads; `ucinewgame` clears experience buffers; `stop` halts search; `ponderhit` resumes after pondering; `quit` exits cleanly.
 - **Core options**: `Hash` (MB for the transposition table), `Clear Hash` (button), `Ponder`, `MultiPV`, `Skill Level`, `Move Overhead`, `Minimum Thinking Time`, `Panic Time Buffer`, `Slow Mover`, `nodestime`, `UCI_Chess960`, `UCI_LimitStrength` and `UCI_Elo`, `Contempt`/`Contemp`, and `King Safety`.
 - **Short-clock safety**: when the active clock drops under a second, the engine enters a panic regime that boosts `Move Overhead`, clamps thinking time to a fraction of the remaining clock, and caps it by `Panic Time Buffer` (default 200 ms). Raising `Minimum Thinking Time` or `Panic Time Buffer` increases the cushion for sudden disconnections or lag.
-- **Monte Carlo tuning**: `Search Strategy` accepts `AlphaBeta`, `MCTS`, or the alias `Montecarlo`. When a clock-based limit is provided (`wtime`, `btime`, or `movetime`), the MCTS driver prioritises that timer over the default simulation cap unless `nodes` is explicitly requested.
+- **Monte Carlo tuning**: `Search Strategy` accepts `AlphaBeta`, `MCTS`, `Montecarlo`, `BrainLearnMCTS`, or the alias `BL-MCTS`. When a clock-based limit is provided (`wtime`, `btime`, or `movetime`), the MCTS driver prioritises that timer over the default simulation cap unless `nodes` is explicitly requested.
 - **MCTS configuration**: Enable the MCTS driver with `MCTS Enabled` or by selecting it via `Search Strategy`. Fine-tune behaviour with:
   - `MCTS Rollout Depth`: Maximum plies explored during each rollout (default 12, range 4–128).
   - `MCTS Simulations`: Target number of playouts; set to `0` to run until search limits expire (default 5000, up to 1,000,000).
   - `MCTS Explore`: Exploration constant that balances exploitation of strong moves against broader sampling (default 35, range 1–200).
   - Existing time controls (`wtime`, `btime`, `movetime`) and node limits still apply when provided.
+- **BrainLearn MCTS (experimental)**: Enable `BrainLearnMCTS` and set `Search Strategy` to `BrainLearnMCTS` (or `BL-MCTS`) to activate the BrainLearn Monte Carlo Tree Search driver. It is OFF by default and does not replace the existing Wordfish MCTS implementation.
+  - `BrainLearnMCTSThreads`: Helper thread budget for BrainLearn MCTS (default 0, up to 512). The main thread remains alpha–beta unless `Search Strategy` is set to BrainLearn MCTS.
+  - `BrainLearnMultiStrategy`: Percentage threshold used by BrainLearn for mixing rollouts with minimax probes (default 20, range 0–100).
+  - `BrainLearnMultiMinVisits`: Visit threshold that unlocks expanded UCB logic in BrainLearn MCTS (default 5, range 0–1000).
+  - Note: helper-thread integration is limited to BrainLearn strategy searches and uses the engine-wide stop/ponder controls.
 - **Experience controls**: `Experience Enabled`, `Experience File`, `Experience Readonly`, `Experience Book`, `Experience Book Width`, `Experience Book Eval Importance`, `Experience Book Min Depth`, `Experience Book Max Moves`, `Experience Status`, and `Experience Sync`.
 - **Neural networks**: `EvalFile` and `EvalFileSmall` accept external NNUE files and reload replicas on all threads.
 - **Tablebases**: `SyzygyPath`, `SyzygyProbeDepth`, `Syzygy50MoveRule`, and `SyzygyProbeLimit` configure probing depth, scope, and rule enforcement.

--- a/src/Makefile
+++ b/src/Makefile
@@ -49,14 +49,14 @@ BINDIR = $(PREFIX)/bin
 PGOBENCH = $(WINE_PATH) ./$(EXE) bench
 
 ### Source and object files
-SRCS = benchmark.cpp bitboard.cpp evaluate.cpp experience.cpp main.cpp \
+SRCS = benchmark.cpp bitboard.cpp brainlearn_mcts.cpp evaluate.cpp experience.cpp main.cpp \
         misc.cpp movegen.cpp movepick.cpp mcts.cpp polybook.cpp position.cpp \
         search.cpp thread.cpp timeman.cpp tt.cpp uci.cpp ucioption.cpp tune.cpp syzygy/tbprobe.cpp \
         nnue/nnue_accumulator.cpp nnue/nnue_misc.cpp nnue/network.cpp \
         nnue/features/half_ka_v2_hm.cpp nnue/features/full_threats.cpp \
         engine.cpp score.cpp memory.cpp
 
-HEADERS = benchmark.h bitboard.h evaluate.h experience.h experience_compat.h Wordfish_zobrist.h misc.h movegen.h movepick.h mcts.h history.h polybook.h \
+HEADERS = benchmark.h bitboard.h brainlearn_mcts.h evaluate.h experience.h experience_compat.h Wordfish_zobrist.h misc.h movegen.h movepick.h mcts.h history.h polybook.h \
                 nnue/nnue_misc.h nnue/features/half_ka_v2_hm.h nnue/features/full_threats.h \
                 nnue/layers/affine_transform.h nnue/layers/affine_transform_sparse_input.h \
                 nnue/layers/clipped_relu.h nnue/layers/sqr_clipped_relu.h nnue/nnue_accumulator.h \

--- a/src/brainlearn_mcts.cpp
+++ b/src/brainlearn_mcts.cpp
@@ -1,0 +1,780 @@
+/*
+  Brainlearn, a UCI chess playing engine derived from Brainlearn
+  Copyright (C) 2004-2025 A.Manzo, F.Ferraguti, K.Kiniama and Brainlearn developers (see AUTHORS file)
+
+  Brainlearn is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Brainlearn is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "brainlearn_mcts.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <random>
+#include <sstream>
+
+#include "misc.h"
+#include "syzygy/tbprobe.h"
+#include "uci.h"
+
+namespace Stockfish::BrainLearnMCTS {
+
+inline bool comp_float(const double a, const double b, const double epsilon = 0.005) {
+    return std::fabs(a - b) < epsilon;
+}
+
+struct COMPARE_PRIOR {
+    inline bool operator()(const Edge* a, const Edge* b) const { return a->prior > b->prior; }
+} ComparePrior;
+
+struct COMPARE_VISITS {
+    inline bool operator()(const Edge* a, const Edge* b) const {
+        return a->visits > b->visits
+            || (comp_float(a->visits, b->visits, 0.005) && a->prior > b->prior);
+    }
+} CompareVisits;
+
+struct COMPARE_MEAN_ACTION {
+    inline bool operator()(const Edge* a, const Edge* b) const {
+        return a->meanActionValue > b->meanActionValue;
+    }
+} CompareMeanAction;
+
+struct COMPARE_ROBUST_CHOICE {
+    inline bool operator()(const Edge* a, const Edge* b) const {
+        return (10 * a->visits + a->prior > 10 * b->visits + b->prior);
+    }
+} CompareRobustChoice;
+
+class AutoSpinLock {
+   private:
+    const MonteCarlo* _mcts;
+    Spinlock&         _sl;
+
+   public:
+    AutoSpinLock(const MonteCarlo* mcts, mctsNodeInfo* node) :
+        AutoSpinLock(mcts, node->lock) {}
+
+    AutoSpinLock(const MonteCarlo* mcts, Spinlock& sl) :
+        _mcts(mcts),
+        _sl(sl) {
+        _sl.acquire(_mcts->thisThread->thread_index());
+    }
+
+    ~AutoSpinLock() { _sl.release(_mcts->thisThread->thread_index()); }
+};
+
+#define LOCK__(m, n, l) AutoSpinLock asl##l(m, n)
+#define LOCK_(m, n, l) LOCK__(m, n, l)
+#define LOCK(m, n) LOCK_(m, n, __LINE__)
+
+MCTSHashTable       MCTS;
+Edge                EDGE_NONE;
+Spinlock            createLock;
+size_t              mctsThreads;
+size_t              mctsMultiStrategy;
+double              mctsMultiMinVisits;
+std::atomic<size_t> MCTSNodeCount(0);
+
+template<typename T>
+T TRand(const T min, const T max) {
+    static std::random_device        rd;
+    static thread_local std::mt19937 gen(rd());
+    std::uniform_int_distribution<T> distribution(min, max);
+
+    return distribution(gen);
+}
+
+mctsNodeInfo* get_node(const MonteCarlo* mcts, const Position& p) {
+
+    Key           key1 = p.key();
+    Key           key2 = p.pawn_key();
+    mctsNodeInfo* node = nullptr;
+
+    LOCK(mcts, createLock);
+    if (MCTSNodeCount.load(std::memory_order_relaxed) >= MCTSMaxNodes)
+    {
+        return nullptr;
+    }
+    const auto [fst, snd] = MCTS.equal_range(key1);
+    auto       it1        = fst;
+    const auto it2        = snd;
+    while (it1 != it2)
+    {
+        node = *(&it1->second);
+
+        if (node->key1 == key1 && node->key2 == key2)
+            return node;
+
+        ++it1;
+    }
+
+    node = new mctsNodeInfo();
+    MCTSNodeCount.fetch_add(1, std::memory_order_relaxed);
+    node->key1           = key1;
+    node->key2           = key2;
+    node->node_visits    = 0;
+    node->number_of_sons = 0;
+    node->lastMove       = Move::none();
+    node->ttValue        = VALUE_NONE;
+    node->AB             = false;
+
+    MCTS.insert(std::make_pair(key1, node));
+
+    return node;
+}
+
+void MonteCarlo::add_prior_to_node(mctsNodeInfo* node, Move m, Reward prior) const {
+
+    LOCK(this, node);
+
+    assert(node->number_of_sons < MAX_CHILDREN);
+    assert(prior >= 0 && prior <= 1.0);
+
+    int n = node->number_of_sons;
+    if (n < MAX_CHILDREN)
+    {
+        node->children[n]->visits          = 0;
+        node->children[n]->move            = m;
+        node->children[n]->prior           = prior;
+        node->children[n]->actionValue     = 0.0;
+        node->children[n]->meanActionValue = 0.0;
+        node->number_of_sons++;
+    }
+    else
+    {
+        assert(false);
+    }
+}
+
+void MonteCarlo::search(ThreadPool&        threads,
+                        Search::LimitsType limits,
+                        bool               isMainThread,
+                        Search::Worker*    worker) {
+
+    mctsNodeInfo* node = nullptr;
+    AB_Rollout         = false;
+    Reward reward      = value_to_reward(VALUE_DRAW);
+
+    while (computational_budget(threads, limits) && (node = tree_policy(threads, limits)))
+    {
+        LOCK(this, node);
+
+        if (AB_Rollout)
+        {
+            Value value = evaluate_with_minimax(node, std::min(ply, MAX_PLY - ply - 2));
+            if (threads.stop)
+                break;
+
+            if (value == VALUE_ZERO)
+                value = node->ttValue;
+
+            if (value >= VALUE_KNOWN_WIN)
+                value = VALUE_KNOWN_WIN - ply;
+
+            if (value <= -VALUE_KNOWN_WIN)
+                value = -(VALUE_KNOWN_WIN - ply);
+
+            reward        = value_to_reward(value);
+            node->ttValue = value;
+
+            if (ply > maximumPly)
+                maximumPly = ply;
+        }
+        else
+        {
+            reward = playout_policy(node);
+        }
+
+        if (ply >= 1)
+            node->ttValue = backup(reward, AB_Rollout);
+
+        if (should_emit_pv(isMainThread))
+            emit_pv(worker, threads);
+    }
+
+    if (ply >= 1)
+        backup(reward, AB_Rollout);
+
+    if (should_emit_pv(isMainThread))
+        emit_pv(worker, threads);
+}
+
+MonteCarlo::MonteCarlo(Position& p, Search::Worker* worker, TranspositionTable& transpositionTable) :
+    pos(p),
+    thisThread(worker),
+    tt(transpositionTable) {
+    default_parameters();
+    create_root(worker);
+}
+
+void MonteCarlo::create_root(Search::Worker* worker) {
+
+    assert(ply == 0);
+    assert(nodes[1] == nullptr);
+    assert(root == nullptr);
+
+    ply            = 1;
+    maximumPly     = 1;
+    startTime      = now();
+    lastOutputTime = startTime;
+
+    for (auto& currentStack : stackBuffer)
+    {
+        currentStack = Search::Stack();
+    }
+
+    for (int i = -7; i <= MAX_PLY + 10; i++)
+    {
+        stack[i].continuationHistory =
+          &worker->continuationHistory[0][0][NO_PIECE][0];
+        stack[i].continuationCorrectionHistory =
+          &worker->continuationCorrectionHistory[NO_PIECE][0];
+        stack[i].staticEval = VALUE_NONE;
+        stack[i].reduction  = 0;
+    }
+    for (int i = 0; i <= MAX_PLY + 2; ++i)
+    {
+        stack[i].ply       = i;
+        stack[i].reduction = 0;
+    }
+
+    std::memset(nodesBuffer, 0, sizeof(nodesBuffer));
+
+    root = nodes[ply] = get_node(this, pos);
+
+    LOCK(this, root);
+
+    if (root->node_visits == 0)
+        generate_moves(root);
+}
+
+bool MonteCarlo::computational_budget(ThreadPool& threads, Search::LimitsType limits) {
+
+    if (limits.depth && maximumPly > limits.depth * 2)
+        return false;
+
+    return !threads.stop.load(std::memory_order_relaxed);
+}
+
+mctsNodeInfo* MonteCarlo::tree_policy(ThreadPool& threads, Search::LimitsType limits) {
+
+    assert(ply == 1);
+
+    if (root->number_of_sons == 0)
+    {
+        return root;
+    }
+
+    mctsNodeInfo* node = nullptr;
+    while ((node = nodes[ply]))
+    {
+        LOCK(this, node);
+
+        if (node->node_visits == 0)
+            break;
+
+        if (!computational_budget(threads, limits) || is_terminal(node))
+            return nullptr;
+
+        edges[ply] = best_child(node, STAT_UCB);
+
+        const Move m = edges[ply]->move;
+
+        Edge* edge = edges[ply];
+
+        node->node_visits++;
+
+        edge->visits          = edge->visits + 1.0;
+        edge->meanActionValue = edge->actionValue / edge->visits;
+
+        assert(m.is_ok());
+        assert(pos.legal(m));
+
+        do_move(m);
+
+        nodes[ply] = get_node(this, pos);
+        if (nodes[ply] == nullptr)
+        {
+            break;
+        }
+    }
+
+    if (node)
+    {
+        LOCK(this, node);
+
+        const size_t greedy = TRand<size_t>(0, 100);
+        if (!is_root(node) && node->ttValue < VALUE_KNOWN_WIN && node->ttValue > -VALUE_KNOWN_WIN
+            && (node->number_of_sons > 5 && greedy >= mctsMultiStrategy))
+        {
+            AB_Rollout = true;
+        }
+    }
+
+    return node;
+}
+
+Reward MonteCarlo::playout_policy(mctsNodeInfo* node) {
+
+    LOCK(this, node);
+
+    if (is_terminal(node))
+        return evaluate_terminal(node);
+
+    if (node->node_visits == 0)
+    {
+        generate_moves(node);
+        assert(node->node_visits == 1);
+    }
+
+    if (node->number_of_sons == 0)
+        return evaluate_terminal(node);
+
+    return node->children[0]->prior;
+}
+
+Value MonteCarlo::backup(Reward r, bool AB_Mode) {
+
+    assert(ply >= 1);
+    double weight = 1.0;
+
+    while (ply != 1)
+    {
+        undo_move();
+
+        r = 1.0 - r;
+
+        Edge* edge = edges[ply];
+
+        if (AB_Mode)
+        {
+            edge->prior = r;
+            AB_Mode     = false;
+        }
+
+        edge->visits = edge->visits - 1.0;
+
+        edge->visits          = edge->visits + weight;
+        edge->actionValue     = edge->actionValue + weight * r;
+        edge->meanActionValue = edge->actionValue / edge->visits;
+
+        assert(edge->meanActionValue >= 0.0);
+        assert(edge->meanActionValue <= 1.0);
+
+        const double minimax = best_child(nodes[ply], STAT_MEAN)->meanActionValue;
+
+        r = r * (1.0 - BACKUP_MINIMAX) + minimax * BACKUP_MINIMAX;
+
+        assert(stack[ply].currentMove == edge->move);
+    }
+
+    assert(ply == 1);
+
+    return reward_to_value(r);
+}
+
+Edge* MonteCarlo::best_child(mctsNodeInfo* node, EdgeStatistic statistic) const {
+
+    LOCK(this, node);
+
+    if (node->number_of_sons <= 0)
+        return &EDGE_NONE;
+
+    int    best      = -1;
+    double bestValue = -1000000000000.0;
+    for (int k = 0; k < node->number_of_sons; k++)
+    {
+        const double r =
+          statistic == STAT_VISITS ? node->children[k]->visits.load(std::memory_order_relaxed)
+          : statistic == STAT_MEAN
+            ? node->children[k]->meanActionValue.load(std::memory_order_relaxed)
+          : statistic == STAT_UCB
+            ? ucb(node->children[k], node->node_visits.load(std::memory_order_relaxed), false)
+          : statistic == STAT_PRIOR
+            ? ucb(node->children[k], node->node_visits.load(std::memory_order_relaxed), true)
+            : 0.0;
+
+        if (r > bestValue)
+        {
+            bestValue = r;
+            best      = k;
+        }
+    }
+
+    return node->children[best];
+}
+
+bool MonteCarlo::should_emit_pv(bool isMainThread) const {
+
+    if (!isMainThread)
+        return false;
+
+    if (ply != 1)
+        return false;
+
+    const TimePoint elapsed     = now() - startTime + 1;
+    const TimePoint outputDelay = now() - lastOutputTime;
+
+    if (elapsed < 1100)
+        return outputDelay >= 100;
+    else if (elapsed < static_cast<int64_t>(11 * 1000))
+        return outputDelay >= 1000;
+    else if (elapsed < static_cast<int64_t>(61 * 1000))
+        return outputDelay >= 10000;
+    else if (elapsed < static_cast<int64_t>(6 * 60 * 1000))
+        return outputDelay >= 30000;
+    else if (elapsed < static_cast<int64_t>(61 * 60 * 1000))
+        return outputDelay >= 60000;
+
+    return outputDelay >= 60000;
+}
+
+void MonteCarlo::emit_pv(Search::Worker* worker, ThreadPool& threads) {
+
+    assert(ply == 1);
+
+    LOCK(this, root);
+
+    int n = root->number_of_sons;
+
+    EdgeArray list(root->children);
+
+    if (mctsThreads > 1)
+        std::sort(list.begin(), list.begin() + n, ComparePrior);
+    else
+        std::sort(list.begin(), list.begin() + n, CompareRobustChoice);
+
+    Search::RootMoves& rootMoves = thisThread->root_moves();
+    rootMoves.clear();
+
+    if (n > 0)
+    {
+        for (int k = 0; k < n; k++)
+        {
+            rootMoves.push_back(Search::RootMove(list[k]->move));
+            const size_t index             = rootMoves.size() - 1;
+            rootMoves[index].previousScore = reward_to_value(list[k]->meanActionValue);
+            rootMoves[index].score         = rootMoves[index].previousScore;
+            rootMoves[index].selDepth      = maximumPly;
+            if (k > 0)
+            {
+                rootMoves[index].score = rootMoves[index].previousScore - k * 10;
+            }
+        }
+
+        Move move = rootMoves[0].pv[0];
+        int  cnt  = 0;
+        while (pos.legal(move))
+        {
+            cnt++;
+            do_move(move);
+            mctsNodeInfo* node = nodes[ply] = get_node(this, pos);
+            if (node == nullptr)
+            {
+                break;
+            }
+            LOCK(this, node);
+
+            if (ply > maximumPly)
+                maximumPly = ply;
+
+            if (is_terminal(node) || node->number_of_sons <= 0 || node->node_visits <= 0)
+                break;
+
+            move = best_child(node, STAT_VISITS)->move;
+
+            if (pos.legal(move))
+                rootMoves[0].pv.push_back(move);
+        }
+
+        for (int k = 0; k < cnt; k++)
+            undo_move();
+
+        assert(int(rootMoves.size()) == root->number_of_sons);
+        assert(ply == 1);
+
+        threads.main_manager()->pv(*worker, threads, tt, worker->completed_depth());
+    }
+    else
+    {
+        rootMoves.emplace_back(Move::none());
+        threads.main_manager()->updates.onUpdateNoMoves(
+          {0, {pos.checkers() ? -VALUE_MATE : VALUE_DRAW, pos}});
+    }
+
+    lastOutputTime = now();
+}
+
+inline bool MonteCarlo::is_root(const mctsNodeInfo* node) const {
+    if (node != root)
+    {
+        assert(ply != 1);
+        assert(nodes[ply] != root);
+
+        return false;
+    }
+    else
+    {
+        assert(ply == 1);
+        assert(nodes[ply] == root);
+
+        return true;
+    }
+}
+
+inline bool MonteCarlo::is_terminal(mctsNodeInfo* node) const {
+
+    {
+        LOCK(this, node);
+
+        if (node->node_visits > 0 && node->number_of_sons == 0)
+            return true;
+    }
+
+    if (ply >= MAX_PLY - 2)
+        return true;
+
+    if (pos.is_draw(ply - 1))
+        return true;
+
+    return false;
+}
+
+void MonteCarlo::do_move(const Move m) {
+
+    assert(ply < MAX_PLY);
+    stack[ply].ply         = ply;
+    stack[ply].currentMove = m;
+    stack[ply].inCheck     = pos.checkers();
+    const bool capture     = pos.capture(m);
+
+    stack[ply].continuationHistory =
+      &thisThread->continuationHistory[stack[ply].inCheck][capture][pos.moved_piece(m)][m.to_sq()];
+    stack[ply].continuationCorrectionHistory =
+      &thisThread->continuationCorrectionHistory[pos.moved_piece(m)][m.to_sq()];
+
+    pos.do_move(m, states[ply], &tt);
+
+    ply++;
+    if (ply > maximumPly)
+        maximumPly = ply;
+}
+
+void MonteCarlo::undo_move() {
+
+    assert(ply > 1);
+
+    ply--;
+    pos.undo_move(stack[ply].currentMove);
+}
+
+void MonteCarlo::generate_moves(mctsNodeInfo* node) {
+
+    LOCK(this, node);
+
+    if (node->node_visits != 0)
+        return;
+
+    auto [ttHit, ttData, ttWriter] = tt.probe(pos.key());
+    Depth depth                    = 30;
+
+    const PieceToHistory* contHist[] = {
+      stack[ply - 1].continuationHistory, stack[ply - 2].continuationHistory,
+      stack[ply - 3].continuationHistory, stack[ply - 4].continuationHistory,
+      stack[ply - 5].continuationHistory, stack[ply - 6].continuationHistory};
+    Move ttMove = Move::none();
+    if (ttHit && ttData.move && pos.pseudo_legal(ttData.move) && pos.legal(ttData.move))
+    {
+        ttMove = ttData.move;
+    }
+    MovePicker mp(pos, ttMove, depth, &thisThread->mainHistory, &thisThread->lowPlyHistory,
+                  &thisThread->captureHistory, contHist, &thisThread->pawnHistory,
+                  stack[ply].ply);
+    Move move;
+    int  moveCount = 0;
+
+    Reward bestPrior = REWARD_MATED;
+    while (((move = mp.next_move()) != Move::none()))
+        if (pos.legal(move))
+        {
+            stack[ply].moveCount = ++moveCount;
+            Reward prior         = calculate_prior(move);
+            if (prior > bestPrior)
+            {
+                node->ttValue = reward_to_value(prior);
+                bestPrior     = prior;
+            }
+
+            add_prior_to_node(node, move, prior);
+        }
+
+    int n = node->number_of_sons;
+    if (n > 0)
+    {
+        EdgeArray& children = node->children;
+        std::stable_sort(children.begin(), children.begin() + n, ComparePrior);
+    }
+
+    node->node_visits++;
+}
+
+Reward MonteCarlo::evaluate_terminal(mctsNodeInfo* node) const {
+
+    assert(is_terminal(node));
+
+    LOCK(this, node);
+
+    if (node->number_of_sons == 0)
+        return pos.checkers() ? REWARD_MATED : REWARD_DRAW;
+
+    if (ply >= MAX_PLY - 2)
+        return REWARD_DRAW;
+
+    return REWARD_DRAW;
+}
+
+Value MonteCarlo::evaluate_with_minimax(const Depth d) const {
+    stack[ply].ply          = ply;
+    stack[ply].currentMove  = Move::none();
+    stack[ply].excludedMove = Move::none();
+
+    return thisThread->minimax_value(pos, &stack[ply], d);
+}
+
+Value MonteCarlo::evaluate_with_minimax(mctsNodeInfo* node, Depth d) const {
+
+    stack[ply].ply          = ply;
+    stack[ply].currentMove  = Move::none();
+    stack[ply].excludedMove = Move::none();
+
+    constexpr auto delta = static_cast<Value>(18);
+
+    Value alpha;
+    Value beta;
+
+    {
+        LOCK(this, node);
+
+        alpha = std::max(node->ttValue - delta, -VALUE_INFINITE);
+        beta  = std::min(node->ttValue + delta, VALUE_INFINITE);
+    }
+
+    return thisThread->minimax_value(pos, &stack[ply], d, alpha, beta);
+}
+
+Reward MonteCarlo::calculate_prior(const Move m) {
+
+    const Depth depth = ply <= 2 || pos.capture(m) || pos.gives_check(m) ? PRIOR_SLOW_EVAL_DEPTH
+                                                                         : PRIOR_FAST_EVAL_DEPTH;
+
+    do_move(m);
+    const Reward prior = value_to_reward(-evaluate_with_minimax(depth));
+    undo_move();
+
+    return prior;
+}
+
+Reward MonteCarlo::value_to_reward(Value v) const {
+    constexpr double k = -0.00490739829861;
+    const double     r = 1.0 / (1 + std::exp(k * static_cast<int>(v)));
+
+    assert(REWARD_MATED <= r && r <= REWARD_MATE);
+    return r;
+}
+
+Value MonteCarlo::reward_to_value(Reward r) const {
+    if (r > 0.99)
+        return VALUE_KNOWN_WIN;
+    if (r < 0.01)
+        return -VALUE_KNOWN_WIN;
+
+    constexpr double g = 203.77396313709564;
+    const double     v = g * std::log(r / (1.0 - r));
+    return static_cast<Value>(static_cast<int>(v));
+}
+
+void MonteCarlo::set_exploration_constant(double c) { UCB_EXPLORATION_CONSTANT = c; }
+
+double MonteCarlo::exploration_constant() const { return UCB_EXPLORATION_CONSTANT; }
+
+double MonteCarlo::ucb(const Edge* edge, long fatherVisits, bool priorMode) const {
+
+    if (priorMode)
+        return edge->prior;
+
+    assert(fatherVisits > 0);
+
+    double result = 0.0;
+    if (((mctsThreads > 1) && (edge->visits > mctsMultiMinVisits))
+        || ((mctsThreads == 1) && edge->visits))
+    {
+        result += edge->meanActionValue;
+    }
+    else
+    {
+        result += UCB_UNEXPANDED_NODE;
+    }
+
+    const double C =
+      UCB_USE_FATHER_VISITS ? exploration_constant() * std::sqrt(fatherVisits) : exploration_constant();
+    const double losses = edge->visits - edge->actionValue;
+    const double visits = edge->visits;
+
+    const double divisor = losses * UCB_LOSSES_AVOIDANCE + visits * (1.0 - UCB_LOSSES_AVOIDANCE);
+    result += C * edge->prior / (1 + divisor);
+
+    result += UCB_LOG_TERM_FACTOR * std::sqrt(std::log(fatherVisits) / (1 + visits));
+
+    return result;
+}
+
+void MonteCarlo::default_parameters() {
+
+    BACKUP_MINIMAX           = 1.0;
+    PRIOR_FAST_EVAL_DEPTH    = 2;
+    PRIOR_SLOW_EVAL_DEPTH    = 3;
+    UCB_UNEXPANDED_NODE      = 1.0;
+    UCB_EXPLORATION_CONSTANT = 1.0;
+    UCB_LOSSES_AVOIDANCE     = 1.0;
+    UCB_LOG_TERM_FACTOR      = 0.0;
+    UCB_USE_FATHER_VISITS    = true;
+}
+
+void MonteCarlo::print_children() {
+
+    LOCK(this, root);
+    EdgeArray& children = root->children;
+
+    if (const int n = root->number_of_sons; n > 0)
+        std::sort(children.begin(), children.begin() + n, CompareRobustChoice);
+
+    for (int k = root->number_of_sons - 1; k >= 0; k--)
+    {
+        std::cout << "info string move " << k + 1 << " "
+                  << UCIEngine::move(children[k]->move, pos.is_chess960())
+                  << std::setprecision(2) << " win% " << children[k]->prior * 100
+                  << std::fixed << std::setprecision(0) << " visits " << children[k]->visits
+                  << std::endl;
+    }
+
+    lastOutputTime = now();
+}
+
+void clear() { MCTS.clear(); }
+
+}  // namespace Stockfish::BrainLearnMCTS

--- a/src/brainlearn_mcts.h
+++ b/src/brainlearn_mcts.h
@@ -1,0 +1,254 @@
+/*
+  Brainlearn, a UCI chess playing engine derived from Brainlearn
+  Copyright (C) 2004-2025 A.Manzo, F.Ferraguti, K.Kiniama and Brainlearn developers (see AUTHORS file)
+
+  Brainlearn is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Brainlearn is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef BRAINLEARN_MCTS_H_INCLUDED
+#define BRAINLEARN_MCTS_H_INCLUDED
+
+#include <array>
+#include <atomic>
+#include <cassert>
+#include <thread>
+#include <unordered_map>
+
+#include "misc.h"
+#include "movepick.h"
+#include "position.h"
+#include "search.h"
+#include "thread.h"
+#include "tt.h"
+
+namespace Stockfish::BrainLearnMCTS {
+
+using Reward = double;
+
+constexpr Reward REWARD_NONE  = 0.0;
+constexpr Reward REWARD_MATED = 0.0;
+constexpr Reward REWARD_DRAW  = 0.5;
+constexpr Reward REWARD_MATE  = 1.0;
+
+constexpr Value VALUE_KNOWN_WIN = 10000;
+
+enum EdgeStatistic {
+    STAT_UCB,
+    STAT_VISITS,
+    STAT_MEAN,
+    STAT_PRIOR
+};
+
+struct Edge {
+    Edge() :
+        move(Move::none()),
+        visits(0),
+        prior(REWARD_NONE),
+        actionValue(REWARD_NONE),
+        meanActionValue(REWARD_NONE) {}
+
+    Edge(const Edge&)            = delete;
+    Edge& operator=(const Edge&) = delete;
+
+    std::atomic<Move>   move;
+    std::atomic<double> visits;
+    std::atomic<Reward> prior;
+    std::atomic<Reward> actionValue;
+    std::atomic<Reward> meanActionValue;
+};
+
+extern size_t mctsThreads;
+extern size_t mctsMultiStrategy;
+extern double mctsMultiMinVisits;
+
+constexpr int MAX_CHILDREN = MAX_MOVES;
+using EdgeArray            = std::array<Edge*, MAX_CHILDREN>;
+
+class Spinlock {
+    static const size_t NO_THREAD = 0;
+
+    std::atomic<size_t> owner;
+    int                 lockCount;
+
+   public:
+    Spinlock() :
+        owner(0),
+        lockCount(0) {}
+
+    Spinlock(const Spinlock&)            = delete;
+    Spinlock& operator=(const Spinlock&) = delete;
+
+    void acquire(size_t threadId) {
+        if (mctsThreads > 1)
+        {
+            size_t currentOwner = NO_THREAD;
+
+            while (!owner.compare_exchange_weak(currentOwner, threadId, std::memory_order_acquire,
+                                                std::memory_order_relaxed)
+                   && currentOwner != threadId)
+            {
+                currentOwner = NO_THREAD;
+                std::this_thread::yield();
+            }
+
+            lockCount++;
+        }
+    }
+
+    void release([[maybe_unused]] size_t threadId) {
+        if (mctsThreads > 1)
+        {
+            assert(owner.load(std::memory_order_relaxed) == threadId);
+
+            if (--lockCount == 0)
+                owner.store(0);
+        }
+    }
+};
+
+struct mctsNodeInfo {
+    mctsNodeInfo() {
+        for (size_t i = 0; i < children.size(); ++i)
+            children[i] = new Edge();
+    }
+
+    ~mctsNodeInfo() {
+        for (size_t i = 0; i < children.size(); ++i)
+            delete children[i];
+    }
+
+    mctsNodeInfo(const mctsNodeInfo&)            = delete;
+    mctsNodeInfo& operator=(const mctsNodeInfo&) = delete;
+
+    Spinlock lock;
+
+    Key                key1           = 0;
+    Key                key2           = 0;
+    std::atomic<long>  node_visits    = 0;
+    std::atomic<int>   number_of_sons = 0;
+    std::atomic<Move>  lastMove       = Move::none();
+    std::atomic<Value> ttValue        = VALUE_NONE;
+    std::atomic<bool>  AB             = false;
+    EdgeArray          children;
+};
+
+class MonteCarlo;
+
+mctsNodeInfo* get_node(const MonteCarlo* mcts, const Position& pos);
+
+using MCTS_MAP_BASE = std::unordered_multimap<Key, mctsNodeInfo*>;
+
+extern std::atomic<size_t> MCTSNodeCount;
+
+class MCTSHashTable: public MCTS_MAP_BASE {
+   public:
+    ~MCTSHashTable() { clear(); }
+
+    void clear() {
+        for (unsigned i = 0; i < bucket_count(); ++i)
+        {
+            for (auto it = begin(i); it != end(i); ++it)
+                delete it->second;
+        }
+
+        MCTS_MAP_BASE::clear();
+        MCTSNodeCount = 0;
+    }
+};
+
+extern MCTSHashTable MCTS;
+
+const size_t MCTSMaxNodes = 100000;
+
+class MonteCarlo {
+    friend class AutoSpinLock;
+
+   public:
+    MonteCarlo(Position& p, Search::Worker* worker, TranspositionTable& transpositionTable);
+
+    MonteCarlo(const MonteCarlo&)            = delete;
+    MonteCarlo& operator=(const MonteCarlo&) = delete;
+
+    void search(ThreadPool& threads, Search::LimitsType limits, bool isMainThread,
+                Search::Worker* worker);
+
+    void          create_root(Search::Worker* worker);
+    bool          computational_budget(ThreadPool& threads, Search::LimitsType limits);
+    mctsNodeInfo* tree_policy(ThreadPool& threads, Search::LimitsType limits);
+    Reward        playout_policy(mctsNodeInfo* node);
+    Value         backup(Reward r, bool AB_Mode);
+    Edge*         best_child(mctsNodeInfo* node, EdgeStatistic statistic) const;
+
+    double ucb(const Edge* edge, long fatherVisits, bool priorMode) const;
+
+    bool is_root(const mctsNodeInfo* node) const;
+    bool is_terminal(mctsNodeInfo* node) const;
+    void do_move(Move m);
+    void undo_move();
+    void generate_moves(mctsNodeInfo* node);
+
+    [[nodiscard]] Reward value_to_reward(Value v) const;
+    [[nodiscard]] Value  reward_to_value(Reward r) const;
+    [[nodiscard]] Value  evaluate_with_minimax(Depth d) const;
+    Value                evaluate_with_minimax(mctsNodeInfo* node, Depth d) const;
+    [[nodiscard]] Reward evaluate_terminal(mctsNodeInfo* node) const;
+    Reward               calculate_prior(Move m);
+    void                 add_prior_to_node(mctsNodeInfo* node, Move m, Reward prior) const;
+
+    void                 default_parameters();
+    void                 set_exploration_constant(double c);
+    [[nodiscard]] double exploration_constant() const;
+
+    [[nodiscard]] bool should_emit_pv(bool isMainThread) const;
+    void               emit_pv(Search::Worker* worker, ThreadPool& threads);
+    void               print_children();
+
+    int max_ply() const { return maximumPly; }
+
+   private:
+    Position&       pos;
+    Search::Worker* thisThread;
+    TranspositionTable& tt;
+    mctsNodeInfo* root{};
+
+    int       ply{};
+    int       maximumPly{};
+    TimePoint startTime{};
+    TimePoint lastOutputTime{};
+
+    [[maybe_unused]] double max_epsilon = 0.99;
+    [[maybe_unused]] double min_epsilon = 0.00;
+    [[maybe_unused]] double decay_rate  = 0.8;
+    bool                    AB_Rollout{};
+
+    double BACKUP_MINIMAX{};
+    double UCB_UNEXPANDED_NODE{};
+    double UCB_EXPLORATION_CONSTANT{};
+    double UCB_LOSSES_AVOIDANCE{};
+    double UCB_LOG_TERM_FACTOR{};
+    bool   UCB_USE_FATHER_VISITS{};
+    int    PRIOR_FAST_EVAL_DEPTH{};
+    int    PRIOR_SLOW_EVAL_DEPTH{};
+
+    mctsNodeInfo *nodesBuffer[MAX_PLY + 10]{}, **nodes  = nodesBuffer + 7;
+    Edge *        edgesBuffer[MAX_PLY + 10]{}, **edges  = edgesBuffer + 7;
+    Search::Stack stackBuffer[MAX_PLY + 17]{}, *stack   = stackBuffer + 7;
+    StateInfo     statesBuffer[MAX_PLY + 10]{}, *states = statesBuffer + 7;
+};
+
+void clear();
+
+}  // namespace Stockfish::BrainLearnMCTS
+
+#endif  // BRAINLEARN_MCTS_H_INCLUDED

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -29,6 +29,7 @@
 #include <utility>
 #include <vector>
 
+#include "brainlearn_mcts.h"
 #include "evaluate.h"
 #include "experience.h"
 #include "misc.h"
@@ -107,12 +108,18 @@ Engine::Engine(std::optional<std::string> path) :
     options.add(  //
       "MultiPV", Option(1, 1, MAX_MOVES));
 
-    options.add("Search Strategy", Option("AlphaBeta MCTS Montecarlo", "AlphaBeta"));
+    options.add("Search Strategy",
+                Option("AlphaBeta MCTS Montecarlo BrainLearnMCTS BL-MCTS", "AlphaBeta"));
     options.add("MCTS Enabled", Option(false));
 
     options.add("MCTS Rollout Depth", Option(12, 4, 128));
     options.add("MCTS Simulations", Option(5000, 0, 1000000));
     options.add("MCTS Explore", Option(35, 1, 200));
+
+    options.add("BrainLearnMCTS", Option(false));
+    options.add("BrainLearnMCTSThreads", Option(0, 0, 512));
+    options.add("BrainLearnMultiStrategy", Option(20, 0, 100));
+    options.add("BrainLearnMultiMinVisits", Option(5, 0, 1000));
 
     options.add("Skill Level", Option(20, 0, 20));
 
@@ -246,6 +253,7 @@ void Engine::search_clear() {
 
     tt.clear(threads);
     threads.clear();
+    BrainLearnMCTS::clear();
 
     // @TODO wont work with multiple instances
     Tablebases::init(options["SyzygyPath"]);  // Free mapped files

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -35,6 +35,7 @@
 #include <utility>
 
 #include "bitboard.h"
+#include "brainlearn_mcts.h"
 #include "evaluate.h"
 #include "experience.h"
 #include "history.h"
@@ -214,9 +215,29 @@ void Search::Worker::start_searching() {
 
     accumulatorStack.reset();
 
+    const bool brainLearnEnabled =
+      options.count("BrainLearnMCTS") ? int(options["BrainLearnMCTS"]) : false;
+    const bool strategyRequestsBrainLearn =
+      options.count("Search Strategy")
+      && (options["Search Strategy"] == "BrainLearnMCTS" || options["Search Strategy"] == "BL-MCTS");
+    const bool useBrainLearn = brainLearnEnabled && strategyRequestsBrainLearn;
+
+    const int maxBrainLearnHelpers = std::max(0, int(options["Threads"]) - 1);
+    const int brainLearnHelpers =
+      options.count("BrainLearnMCTSThreads")
+        ? std::clamp<int>(options["BrainLearnMCTSThreads"], 0, maxBrainLearnHelpers)
+        : 0;
+
     // Non-main threads go directly to iterative_deepening()
     if (!is_mainthread())
     {
+        if (useBrainLearn)
+        {
+            if (threadIdx > 0 && threadIdx <= static_cast<size_t>(brainLearnHelpers))
+                run_brainlearn_mcts();
+            return;
+        }
+
         iterative_deepening();
         return;
     }
@@ -241,7 +262,33 @@ void Search::Worker::start_searching() {
         return !rootMoves.empty();
     };
 
-    if (useMcts)
+    if (useBrainLearn)
+    {
+        if (!ensure_root_moves())
+        {
+            rootMoves.emplace_back(Move::none());
+            main_manager()->updates.onUpdateNoMoves(
+              {0, {rootPos.checkers() ? -VALUE_MATE : VALUE_DRAW, rootPos}});
+        }
+        else
+        {
+            BrainLearnMCTS::mctsThreads = 1 + static_cast<size_t>(brainLearnHelpers);
+            BrainLearnMCTS::mctsMultiStrategy =
+              options.count("BrainLearnMultiStrategy")
+                ? size_t(int(options["BrainLearnMultiStrategy"]))
+                : 20;
+            BrainLearnMCTS::mctsMultiMinVisits =
+              options.count("BrainLearnMultiMinVisits")
+                ? double(int(options["BrainLearnMultiMinVisits"]))
+                : 5.0;
+
+            if (brainLearnHelpers > 0)
+                threads.start_searching();
+
+            run_brainlearn_mcts();
+        }
+    }
+    else if (useMcts)
     {
         if (!ensure_root_moves())
         {
@@ -289,8 +336,8 @@ void Search::Worker::start_searching() {
     Skill   skill =
       Skill(options["Skill Level"], options["UCI_LimitStrength"] ? int(options["UCI_Elo"]) : 0);
 
-    if (int(options["MultiPV"]) == 1 && !limits.depth && !limits.mate && !skill.enabled()
-        && rootMoves[0].pv[0] != Move::none())
+    if (!useBrainLearn && int(options["MultiPV"]) == 1 && !limits.depth && !limits.mate
+        && !skill.enabled() && rootMoves[0].pv[0] != Move::none())
         bestThread = threads.get_best_thread()->worker.get();
 
     main_manager()->bestPreviousScore        = bestThread->rootMoves[0].score;
@@ -454,6 +501,31 @@ void Search::Worker::run_monte_carlo() {
 
         main_manager()->updates.onUpdateFull(info);
     }
+}
+
+void Search::Worker::run_brainlearn_mcts() {
+
+    if (is_mainthread())
+        sync_cout << "info string BrainLearnMCTS enabled" << sync_endl;
+
+    completedDepth = rootDepth = Depth(1);
+    selDepth                   = 1;
+
+    BrainLearnMCTS::MonteCarlo monteCarlo(rootPos, this, tt);
+
+    monteCarlo.search(threads, limits, is_mainthread(), this);
+
+    if (is_mainthread())
+    {
+        const int maxPly = std::clamp(monteCarlo.max_ply(), 1, MAX_PLY - 1);
+        completedDepth   = rootDepth = Depth(maxPly);
+        selDepth                     = maxPly;
+        monteCarlo.emit_pv(this, threads);
+    }
+
+    nodes.store(BrainLearnMCTS::MCTSNodeCount.load(std::memory_order_relaxed),
+               std::memory_order_relaxed);
+    tbHits.store(0, std::memory_order_relaxed);
 }
 
 void Search::Worker::iterative_deepening() {
@@ -1971,6 +2043,54 @@ Value Search::Worker::evaluate(const Position& pos) {
         v += (pos.side_to_move() == WHITE ? contemptValue : -contemptValue);
 
     return std::clamp(v, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);
+}
+
+Value Search::Worker::minimax_value(Position& pos, Search::Stack* ss, Depth depth) {
+
+    Value alpha = -VALUE_INFINITE;
+    Value beta  = VALUE_INFINITE;
+    Move  pv[MAX_PLY + 1];
+    ss->pv = pv;
+
+    Value value = search<PV>(pos, ss, alpha, beta, depth, false);
+
+    if (limits.mate && value >= VALUE_MATE_IN_MAX_PLY && VALUE_MATE - value <= 2 * limits.mate)
+        threads.stop = true;
+
+    return value;
+}
+
+Value Search::Worker::minimax_value(
+  Position& pos, Search::Stack* ss, Depth depth, Value alpha, Value beta) {
+
+    Move pv[MAX_PLY + 1];
+    ss->pv = pv;
+
+    Value value = VALUE_ZERO;
+    Value delta = Value(18);
+
+    while (!threads.stop.load(std::memory_order_relaxed))
+    {
+        value = search<PV>(pos, ss, alpha, beta, depth, false);
+        if (value <= alpha)
+        {
+            beta  = (alpha + beta) / 2;
+            alpha = std::max(value - delta, -VALUE_INFINITE);
+        }
+        else if (value >= beta)
+        {
+            beta = std::min(value + delta, VALUE_INFINITE);
+        }
+        else
+        {
+            break;
+        }
+    }
+
+    if (limits.mate && value >= VALUE_MATE_IN_MAX_PLY && VALUE_MATE - value <= 2 * limits.mate)
+        threads.stop = true;
+
+    return value;
 }
 
 namespace {

--- a/src/search.h
+++ b/src/search.h
@@ -275,6 +275,9 @@ class Worker {
    void start_searching();
 
     bool is_mainthread() const { return threadIdx == 0; }
+    size_t thread_index() const { return threadIdx; }
+    RootMoves& root_moves() { return rootMoves; }
+    Depth completed_depth() const { return completedDepth; }
 
     void ensure_network_replicated();
 
@@ -293,9 +296,13 @@ class Worker {
 
     TTMoveHistory ttMoveHistory;
 
+    Value minimax_value(Position& pos, Search::Stack* ss, Depth depth);
+    Value minimax_value(Position& pos, Search::Stack* ss, Depth depth, Value alpha, Value beta);
+
    private:
    void iterative_deepening();
     void run_monte_carlo();
+    void run_brainlearn_mcts();
 
     void do_move(Position& pos, const Move move, StateInfo& st, Stack* const ss);
     void


### PR DESCRIPTION
### Motivation
- Provide BrainLearn’s Monte-Carlo Tree Search implementation as an additional, optional search strategy alongside the existing Wordfish MCTS and AlphaBeta drivers.
- Keep BrainLearn MCTS OFF by default and avoid changing or regressing existing MCTS/AlphaBeta behaviour or hot paths when it is not enabled.
- Allow BrainLearn MCTS to be selected via `Search Strategy` and to run safely with Threads / stop / ponder / ucinewgame / quit hooks.
- Expose the BrainLearn tuning parameters required by the module while minimizing symbol collisions by putting the ported code in a dedicated namespace.

### Description
- Added the BrainLearn MCTS implementation: new files `src/brainlearn_mcts.h` and `src/brainlearn_mcts.cpp` containing the ported algorithm inside `namespace Stockfish::BrainLearnMCTS` and a `clear()` function.
- Build integration: added `brainlearn_mcts.cpp` and header to `src/Makefile` so the new code is compiled when building the engine.
- UCI options: added the exact new options `BrainLearnMCTS`, `BrainLearnMCTSThreads`, `BrainLearnMultiStrategy`, and `BrainLearnMultiMinVisits`, and extended `Search Strategy` to accept `BrainLearnMCTS` and alias `BL-MCTS` in `src/engine.cpp`.
- Runtime wiring: integrated BrainLearn as a selectable driver in `Search::Worker::start_searching()` and added `run_brainlearn_mcts()` which constructs and runs `BrainLearnMCTS::MonteCarlo`; added `BrainLearnMCTS::clear()` call to `Engine::search_clear()` for lifecycle reset; added small adapters (`Search::Worker::minimax_value`, `thread_index()`, `root_moves()`, `completed_depth()`) used by the ported code to hook into Wordfish search infrastructure.
- Minimal logging: when BrainLearn strategy is active the engine prints a single `info string BrainLearnMCTS enabled` line at the start of the search (no spam).
- Documentation: updated `README.md` with a short “BrainLearn MCTS (experimental)” section describing how to enable and the new options.

### Testing
- No automated tests were executed as part of this rollout (no CI/build/test run was invoked).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69657500c97883278bc7ab3a308b7f65)