### PR TITLE
Normalize BL-MCTS Search Strategy alias

### DIFF
--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -41,6 +41,10 @@ bool CaseInsensitiveLess::operator()(const std::string& s1, const std::string& s
       });
 }
 
+static bool equals_case_insensitive(const std::string& s1, const std::string& s2) {
+    return !CaseInsensitiveLess()(s1, s2) && !CaseInsensitiveLess()(s2, s1);
+}
+
 void OptionsMap::add_info_listener(InfoListener&& message_func) { info = std::move(message_func); }
 
 void OptionsMap::setoption(std::istringstream& is) {
@@ -57,7 +61,12 @@ void OptionsMap::setoption(std::istringstream& is) {
         value += (value.empty() ? "" : " ") + token;
 
     if (options_map.count(name))
+    {
+        if (equals_case_insensitive(name, "Search Strategy")
+            && equals_case_insensitive(value, "BL-MCTS"))
+            value = "BrainLearnMCTS";
         options_map[name] = value;
+    }
     else
         sync_cout << "No such option: " << name << sync_endl;
 }


### PR DESCRIPTION
### Motivation
- Ensure the UCI `Search Strategy` option accepts the historical alias `BL-MCTS` and is handled as the canonical `BrainLearnMCTS` value to make option parsing and logging consistent.
- Avoid duplicates and surprises in downstream code that checks `options["Search Strategy"]` by normalizing the alias early during `setoption` parsing.
- Keep the change minimal and local to option parsing so AlphaBeta/MCTS/other paths are unaffected when `BrainLearnMCTS` is not selected.

### Description
- Add a case-insensitive equality helper and update `OptionsMap::setoption` in `src/ucioption.cpp` to translate `BL-MCTS` into `BrainLearnMCTS` when the `Search Strategy` option is set.
- The code only rewrites the `value` string before storing it in `options_map`, preserving all existing `Option` behaviors and callbacks.
- No other files or search logic were changed; the change ensures the engine sees the canonical name for logging and runtime checks.

### Testing
- `make -j build` was run in `src` and completed successfully producing the engine binary (pass).
- UCI/bench smoke tests `printf "uci\nisready\nquit\n" | ./Wordfish-...` and `printf "bench\nquit\n" | ./Wordfish-...` were executed and produced normal UCI option lists and benchmark output (pass).
- BrainLearnMCTS runtime sequences including `printf "uci\nisready\nsetoption name BrainLearnMCTS value true\nsetoption name Search Strategy value BrainLearnMCTS\nsetoption name Threads value 4\nsetoption name BrainLearnMCTSThreads value 2\nposition startpos\ngo depth 8\nquit\n" | ./Wordfish-...`, a `go infinite` then `stop` cycle, and a `ucinewgame` + small search were executed and returned `bestmove` and `info string BrainLearnMCTS enabled` without hanging or crashing (pass).
- MSYS2 `clang64` build was not executed because the environment was unavailable (not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696579abffd88327bd234834e44754c4)