### PR TITLE
Fix MCTS best-move fallback check

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -396,10 +396,14 @@ bool Search::Worker::run_monte_carlo() {
     const auto result =
       MCTS::analyze(rootPos, rootPos.side_to_move(), options, limits, stopRequested, depthHint);
 
+    Move bestMove = result.bestMove;
+    if ((bestMove == Move::none() || !bestMove.is_ok()) && !rootMoves.empty())
+        bestMove = rootMoves[0].pv.empty() ? Move::none() : rootMoves[0].pv[0];
+
     const bool hasBestMove =
-      result.bestMove != Move::none() && result.bestMove.is_ok()
+      bestMove != Move::none() && bestMove.is_ok()
       && std::any_of(rootMoves.begin(), rootMoves.end(), [&](const RootMove& rm) {
-             return !rm.pv.empty() && rm.pv[0] == result.bestMove;
+             return !rm.pv.empty() && rm.pv[0] == bestMove;
          });
 
     if (!hasBestMove)


### PR DESCRIPTION
### Motivation
- Ensure the MCTS search path does not abort and fall back to AlphaBeta when the MCTS analysis returns no explicit `bestMove`.
- Keep MCTS behavior consistent with root moves so a valid best move is produced and MCTS info lines are emitted when requested.

### Description
- In `Search::Worker::run_monte_carlo()` capture `result.bestMove` into a local `bestMove` and, if invalid, fall back to `rootMoves[0].pv[0]` when available.
- Use the new `bestMove` variable in the `hasBestMove` check and comparisons against `rootMoves` instead of using `result.bestMove` directly.
- Change is localized to `src/search.cpp` (minimal diff).

### Testing
- Build: `cd src && make -j build COMP=clang EXTRALDFLAGS="-fuse-ld=lld"` → build succeeded and produced `Wordfish-3.80-120126-sse41popcnt`.
- Default / MCTS / BrainLearn checks: `cd src && printf "uci\nisready\nposition startpos\ngo depth 6\nquit\n" | ./Wordfish-3.80-120126-sse41popcnt` → printed `Driver=AlphaBeta` only and `bestmove a2a3`; `cd src && printf "uci\nsetoption name Search Strategy value MCTS\nisready\nposition startpos\ngo depth 6\nquit\n" | ./Wordfish-3.80-120126-sse41popcnt` → printed `Driver=WordfishMCTS` and `info string WordfishMCTS rollout=12 sims=5000 explore=35` and produced `bestmove c2c4`; `cd src && printf "uci\nsetoption name Search Strategy value BrainLearnMCTS\nisready\nposition startpos\ngo depth 6\nquit\n" | ./Wordfish-3.80-120126-sse41popcnt` → printed `Driver=BrainLearnMCTS` and produced `bestmove c2c4`.
- Stop / ucinewgame: `cd src && bash -c '(printf "uci\nisready\nposition startpos\ngo infinite\n"; sleep 1; printf "stop\nquit\n") | ./Wordfish-3.80-120126-sse41popcnt'` → `stop` returned promptly and `bestmove` was printed; `cd src && printf "uci\nisready\nucinewgame\nisready\nposition startpos\ngo depth 6\nquit\n" | ./Wordfish-3.80-120126-sse41popcnt` → search ran normally and returned `bestmove a2a3`.
- Automated command sessions above (build + UCI invocations) completed successfully in this environment; MSYS2/clang64 build was not run here due to toolchain unavailability.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696580fa6a2c8327a3291df48260d7e0)