### PR TITLE
Fix BrainLearnMCTS time control handling

### DIFF
--- a/src/brainlearn_mcts.cpp
+++ b/src/brainlearn_mcts.cpp
@@ -172,6 +172,8 @@ void MonteCarlo::search(ThreadPool&        threads,
     mctsNodeInfo* node = nullptr;
     AB_Rollout         = false;
     Reward reward      = value_to_reward(VALUE_DRAW);
+    playoutsCount      = 0;
+    timeExpired        = false;
 
     while (computational_budget(threads, limits) && (node = tree_policy(threads, limits)))
     {
@@ -206,6 +208,8 @@ void MonteCarlo::search(ThreadPool&        threads,
         if (ply >= 1)
             node->ttValue = backup(reward, AB_Rollout);
 
+        ++playoutsCount;
+
         if (should_emit_pv(isMainThread))
             emit_pv(worker, threads);
     }
@@ -215,6 +219,9 @@ void MonteCarlo::search(ThreadPool&        threads,
 
     if (should_emit_pv(isMainThread))
         emit_pv(worker, threads);
+
+    if (isMainThread && timeExpired)
+        threads.stop = true;
 }
 
 MonteCarlo::MonteCarlo(Position& p, Search::Worker* worker, TranspositionTable& transpositionTable) :
@@ -264,14 +271,32 @@ void MonteCarlo::create_root(Search::Worker* worker) {
 
     if (root->node_visits == 0)
         generate_moves(root);
+
+    noLegalMoves = root->number_of_sons == 0;
+}
+
+void MonteCarlo::set_time_budget(TimePoint allocatedTime, bool useTime) {
+    useTimeBudget = useTime;
+    endTime       = useTimeBudget ? startTime + allocatedTime : TimePoint(0);
 }
 
 bool MonteCarlo::computational_budget(ThreadPool& threads, Search::LimitsType limits) {
 
-    if (limits.depth && maximumPly > limits.depth * 2)
+    (void) limits;
+
+    if (noLegalMoves)
         return false;
 
-    return !threads.stop.load(std::memory_order_relaxed);
+    if (threads.stop.load(std::memory_order_relaxed))
+        return false;
+
+    if (useTimeBudget && now() >= endTime)
+    {
+        timeExpired = true;
+        return false;
+    }
+
+    return true;
 }
 
 mctsNodeInfo* MonteCarlo::tree_policy(ThreadPool& threads, Search::LimitsType limits) {

--- a/src/brainlearn_mcts.h
+++ b/src/brainlearn_mcts.h
@@ -182,6 +182,11 @@ class MonteCarlo {
 
     void search(ThreadPool& threads, Search::LimitsType limits, bool isMainThread,
                 Search::Worker* worker);
+    void set_time_budget(TimePoint allocatedTime, bool useTimeBudget);
+    [[nodiscard]] uint64_t playouts() const { return playoutsCount; }
+    [[nodiscard]] bool time_expired() const { return timeExpired; }
+    [[nodiscard]] bool no_legal_moves() const { return noLegalMoves; }
+    [[nodiscard]] TimePoint elapsed_ms() const { return now() - startTime; }
 
     void          create_root(Search::Worker* worker);
     bool          computational_budget(ThreadPool& threads, Search::LimitsType limits);
@@ -226,6 +231,11 @@ class MonteCarlo {
     int       maximumPly{};
     TimePoint startTime{};
     TimePoint lastOutputTime{};
+    TimePoint endTime{};
+    uint64_t  playoutsCount{};
+    bool      useTimeBudget{};
+    bool      timeExpired{};
+    bool      noLegalMoves{};
 
     [[maybe_unused]] double max_epsilon = 0.99;
     [[maybe_unused]] double min_epsilon = 0.00;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -559,6 +559,14 @@ bool Search::Worker::run_brainlearn_mcts() {
     completedDepth = rootDepth = Depth(1);
     selDepth                   = 1;
 
+    Search::LimitsType brainLimits = limits;
+    if (brainLimits.depth && !brainLimits.movetime && !brainLimits.use_time_management()
+        && !brainLimits.infinite)
+    {
+        brainLimits.movetime = TimePoint(brainLimits.depth) * 200;
+        brainLimits.depth    = 0;
+    }
+
     if (is_mainthread())
     {
         static std::atomic_bool stageEmitted{false};
@@ -572,7 +580,27 @@ bool Search::Worker::run_brainlearn_mcts() {
 
     BrainLearnMCTS::MonteCarlo monteCarlo(rootPos, this, tt);
 
-    monteCarlo.search(threads, limits, is_mainthread(), this);
+    TimePoint allocatedTime = TimePoint(0);
+    bool      useTimeBudget = false;
+    if (!brainLimits.infinite)
+    {
+        if (brainLimits.movetime)
+        {
+            allocatedTime = brainLimits.movetime;
+            useTimeBudget = true;
+        }
+        else if (brainLimits.use_time_management() && is_mainthread())
+        {
+            allocatedTime = main_manager()->tm.maximum();
+            useTimeBudget = allocatedTime > 0;
+        }
+    }
+    if (is_mainthread())
+        monteCarlo.set_time_budget(allocatedTime, useTimeBudget);
+    else
+        monteCarlo.set_time_budget(TimePoint(0), false);
+
+    monteCarlo.search(threads, brainLimits, is_mainthread(), this);
 
     bool hasMove = true;
     if (is_mainthread())
@@ -580,14 +608,19 @@ bool Search::Worker::run_brainlearn_mcts() {
         const int maxPly = std::clamp(monteCarlo.max_ply(), 1, MAX_PLY - 1);
         completedDepth   = rootDepth = Depth(maxPly);
         selDepth                     = maxPly;
-        monteCarlo.emit_pv(this, threads);
+        const uint64_t playouts = monteCarlo.playouts();
+        if (playouts > 0)
+            monteCarlo.emit_pv(this, threads);
 
         auto has_valid_move = [&]() {
             return !rootMoves.empty() && !rootMoves[0].pv.empty()
                 && rootMoves[0].pv[0] != Move::none() && rootPos.legal(rootMoves[0].pv[0]);
         };
 
-        if (!has_valid_move())
+        const bool noLegalMoves = monteCarlo.no_legal_moves();
+        bool       fallbackUsed = playouts == 0;
+
+        if ((playouts == 0 || noLegalMoves) && !has_valid_move())
         {
             Move fallbackMove =
               initialFallback != Move::none() && rootPos.legal(initialFallback) ? initialFallback
@@ -608,7 +641,19 @@ bool Search::Worker::run_brainlearn_mcts() {
             }
 
             hasMove = fallbackMove != Move::none();
+            fallbackUsed = true;
         }
+
+        const TimePoint elapsed = monteCarlo.elapsed_ms();
+        const bool      timeExpired = monteCarlo.time_expired();
+        std::string_view reason =
+          noLegalMoves ? "nomoves"
+          : fallbackUsed ? "fallback"
+          : timeExpired  ? "time"
+                         : "stop";
+
+        sync_cout << "info string BL-MCTS playouts=" << playouts << " elapsed=" << elapsed
+                  << " reason=" << reason << sync_endl;
     }
 
     nodes.store(BrainLearnMCTS::MCTSNodeCount.load(std::memory_order_relaxed),


### PR DESCRIPTION
### Motivation

- BrainLearnMCTS returned immediately and ignored UCI time controls because its internal loop did not consult the engine `Limits`/`TimeManagement` and used alpha-beta style termination conditions.
- The driver needed to map depth-only `go` commands to a sensible time budget for a time-based MCTS algorithm and ensure movetime is honored exactly.
- A one-time end-of-search summary and playouts counter were required to diagnose and verify that the search actually ran.

### Description

- Add time-budget and stop state to the MCTS implementation by introducing `MonteCarlo::set_time_budget`, `playoutsCount`, `useTimeBudget`, `timeExpired`, and `noLegalMoves`, and make `computational_budget` honor `threads.stop`, `noLegalMoves`, and the time budget.
- Increment a playout counter inside `MonteCarlo::search` on each simulation and expose it via `MonteCarlo::playouts()` and `elapsed_ms()`.
- Detect lack of legal moves in `create_root` and stop immediately when no moves exist, and if the time budget expires set `timeExpired` and propagate `threads.stop` for the main thread.
- In the driver `Search::Worker::run_brainlearn_mcts` map depth-only limits to a small movetime (`D * 200ms`), use `main_manager()->tm.maximum()` when time management is active, call `monteCarlo.set_time_budget(...)`, only call `monteCarlo.emit_pv(...)` when `playouts > 0`, choose fallback only when `playouts == 0` or there are no legal moves, and emit a single summary `info string BL-MCTS playouts=<N> elapsed=<ms> reason=<time|stop|nomoves|fallback>` at search end.

### Testing

- Built the project successfully with `make -C src -j4 build` after the changes and the compilation completed without errors.
- Verified object files and link step completed and produced the engine binary in `src` during the automated build.
- No additional automated unit tests were added as the fix is an integration/behavior change inside the search driver and MCTS loop.
- Windows/MSYS2 `clang64` build and runtime `go ... / stop` interaction were not executed in this environment and should be verified on target platforms.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696588fd87648327b02991fd9d7ee22e)