### PR TITLE
Fix BrainLearnMCTS root moves, time/stop polling and diagnostics

### DIFF
--- a/src/brainlearn_mcts.cpp
+++ b/src/brainlearn_mcts.cpp
@@ -174,9 +174,20 @@ void MonteCarlo::search(ThreadPool&        threads,
     Reward reward      = value_to_reward(VALUE_DRAW);
     playoutsCount      = 0;
     timeExpired        = false;
+    guardTriggered     = false;
 
-    while (computational_budget(threads, limits) && (node = tree_policy(threads, limits)))
+    while (!threads.stop.load(std::memory_order_relaxed) && !timeExpired && !noLegalMoves)
     {
+        if (useTimeBudget && now() >= endTime)
+        {
+            timeExpired = true;
+            break;
+        }
+
+        node = tree_policy(threads, limits);
+        if (!node)
+            break;
+
         LOCK(this, node);
 
         if (AB_Rollout)
@@ -212,6 +223,21 @@ void MonteCarlo::search(ThreadPool&        threads,
 
         if (should_emit_pv(isMainThread))
             emit_pv(worker, threads);
+
+        if (threads.stop.load(std::memory_order_relaxed))
+            break;
+
+        if (useTimeBudget && now() >= endTime)
+        {
+            timeExpired = true;
+            break;
+        }
+
+        if (elapsed_ms() > TimePoint(60000) || playoutsCount > 100000000ULL)
+        {
+            guardTriggered = true;
+            break;
+        }
     }
 
     if (ply >= 1)
@@ -269,8 +295,9 @@ void MonteCarlo::create_root(Search::Worker* worker) {
 
     LOCK(this, root);
 
-    if (root->node_visits == 0)
-        generate_moves(root);
+    root->node_visits    = 0;
+    root->number_of_sons = 0;
+    generate_root_moves(root);
 
     noLegalMoves = root->number_of_sons == 0;
 }
@@ -654,6 +681,35 @@ void MonteCarlo::generate_moves(mctsNodeInfo* node) {
         }
 
     int n = node->number_of_sons;
+    if (n > 0)
+    {
+        EdgeArray& children = node->children;
+        std::stable_sort(children.begin(), children.begin() + n, ComparePrior);
+    }
+
+    node->node_visits++;
+}
+
+void MonteCarlo::generate_root_moves(mctsNodeInfo* node) {
+
+    LOCK(this, node);
+
+    if (node->node_visits != 0 || node->number_of_sons != 0)
+        return;
+
+    int    moveCount = 0;
+    Reward bestPrior = REWARD_DRAW;
+    for (Move move : MoveList<LEGAL>(pos))
+    {
+        stack[ply].moveCount = ++moveCount;
+        const Reward prior = REWARD_DRAW;
+        add_prior_to_node(node, move, prior);
+    }
+
+    if (moveCount > 0)
+        node->ttValue = reward_to_value(bestPrior);
+
+    const int n = node->number_of_sons;
     if (n > 0)
     {
         EdgeArray& children = node->children;

--- a/src/brainlearn_mcts.h
+++ b/src/brainlearn_mcts.h
@@ -186,6 +186,8 @@ class MonteCarlo {
     [[nodiscard]] uint64_t playouts() const { return playoutsCount; }
     [[nodiscard]] bool time_expired() const { return timeExpired; }
     [[nodiscard]] bool no_legal_moves() const { return noLegalMoves; }
+    [[nodiscard]] bool guard_triggered() const { return guardTriggered; }
+    [[nodiscard]] int root_legal_moves() const { return root ? root->number_of_sons.load() : 0; }
     [[nodiscard]] TimePoint elapsed_ms() const { return now() - startTime; }
 
     void          create_root(Search::Worker* worker);
@@ -202,6 +204,7 @@ class MonteCarlo {
     void do_move(Move m);
     void undo_move();
     void generate_moves(mctsNodeInfo* node);
+    void generate_root_moves(mctsNodeInfo* node);
 
     [[nodiscard]] Reward value_to_reward(Value v) const;
     [[nodiscard]] Value  reward_to_value(Reward r) const;
@@ -236,6 +239,7 @@ class MonteCarlo {
     bool      useTimeBudget{};
     bool      timeExpired{};
     bool      noLegalMoves{};
+    bool      guardTriggered{};
 
     [[maybe_unused]] double max_epsilon = 0.99;
     [[maybe_unused]] double min_epsilon = 0.00;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -563,12 +563,13 @@ bool Search::Worker::run_brainlearn_mcts() {
     if (brainLimits.depth && !brainLimits.movetime && !brainLimits.use_time_management()
         && !brainLimits.infinite)
     {
-        brainLimits.movetime = TimePoint(brainLimits.depth) * 200;
+        brainLimits.movetime = std::max(TimePoint(200), TimePoint(brainLimits.depth) * 200);
         brainLimits.depth    = 0;
     }
 
     if (is_mainthread())
     {
+        threads.stop = false;
         static std::atomic_bool stageEmitted{false};
         if (!stageEmitted.exchange(true))
             sync_cout << "info string BL-MCTS stage=enter" << sync_endl;
@@ -586,7 +587,7 @@ bool Search::Worker::run_brainlearn_mcts() {
     {
         if (brainLimits.movetime)
         {
-            allocatedTime = brainLimits.movetime;
+            allocatedTime = std::max(TimePoint(1), brainLimits.movetime);
             useTimeBudget = true;
         }
         else if (brainLimits.use_time_management() && is_mainthread())
@@ -645,15 +646,25 @@ bool Search::Worker::run_brainlearn_mcts() {
         }
 
         const TimePoint elapsed = monteCarlo.elapsed_ms();
-        const bool      timeExpired = monteCarlo.time_expired();
+        const bool      timeExpired =
+          monteCarlo.time_expired()
+          || (useTimeBudget && threads.stop.load(std::memory_order_relaxed));
+        const bool guardTriggered = monteCarlo.guard_triggered();
         std::string_view reason =
-          noLegalMoves ? "nomoves"
+          guardTriggered ? "guard"
+          : noLegalMoves ? "nomoves"
           : fallbackUsed ? "fallback"
           : timeExpired  ? "time"
                          : "stop";
 
         sync_cout << "info string BL-MCTS playouts=" << playouts << " elapsed=" << elapsed
                   << " reason=" << reason << sync_endl;
+        sync_cout << "info string BL-MCTS debug budget=" << allocatedTime
+                  << " useTB=" << (useTimeBudget ? 1 : 0)
+                  << " expired=" << (timeExpired ? 1 : 0)
+                  << " nomoves=" << (noLegalMoves ? 1 : 0)
+                  << " stop=" << (threads.stop.load(std::memory_order_relaxed) ? 1 : 0)
+                  << " rootN=" << monteCarlo.root_legal_moves() << sync_endl;
     }
 
     nodes.store(BrainLearnMCTS::MCTSNodeCount.load(std::memory_order_relaxed),
@@ -2144,8 +2155,9 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
 }
 
 Depth Search::Worker::reduction(bool i, Depth d, int mn, int delta) const {
-    int reductionScale = reductions[d] * reductions[mn];
-    return reductionScale - delta * 757 / rootDelta + !i * reductionScale * 218 / 512 + 1200;
+    int reductionScale      = reductions[d] * reductions[mn];
+    Value safeRootDelta     = rootDelta != 0 ? rootDelta : 1;
+    return reductionScale - delta * 757 / safeRootDelta + !i * reductionScale * 218 / 512 + 1200;
 }
 
 // elapsed() returns the time elapsed since the search started. If the


### PR DESCRIPTION
### Motivation
- Ensure `BrainLearnMCTS` actually runs playouts and respects `go movetime`/`stop` by fixing root move enumeration and time/stop polling. 
- Provide a short debug diagnostic to verify allocated budget and termination causes while debugging the Windows hang. 
- Prevent accidental infinite loops or divide-by-zero conditions when MCTS calls minimax or runs long. 
- Keep changes minimal and targeted (no refactors) so the behaviour is easy to validate.

### Description
- Added a temporary debug line in the BL-MCTS driver that prints `allocated_time_ms`, `useTimeBudget`, `timeExpired`, `noLegalMoves`, `stop` and `root_legal_moves` as: `info string BL-MCTS debug budget=... useTB=... expired=... nomoves=... stop=... rootN=...` in `run_brainlearn_mcts` (search.cpp). 
- Fixed root move generation by adding `generate_root_moves` and calling it from `create_root` to enumerate all legal moves using the engine's `MoveList<LEGAL>` generator, and exposed `root_legal_moves()` and `guard_triggered()` accessors (brainlearn_mcts.cpp / brainlearn_mcts.h). 
- Tightened time/budget and stop polling by moving checks into the inner MCTS loop in `MonteCarlo::search`, resetting `threads.stop` for main-thread BL-MCTS runs, and adding a HARD debug guard to break on excessive elapsed time or playout count (brainlearn_mcts.cpp / search.cpp). 
- Improved movetime handling and safety: enforce sane minimum movetime translation from depth (`brainLimits.movetime = max(200ms, D*200ms)`), avoid zero allocated times (`max(TimePoint(1), ...)`), and avoid a divide-by-zero in `reduction()` by using a safe `rootDelta` fallback (search.cpp). 

### Testing
- Built the engine with `make -C src build -j2` and the build completed successfully. 
- Ran an automated UCI movetime test with `printf "... go movetime 2000 ..." | ./src/Wordfish-...` and observed `info string BL-MCTS playouts>0`, `elapsed` ≈ 2000 and `reason=time` plus the debug budget line, indicating success. 
- Ran an automated `go infinite` then `stop` sequence and observed a prompt return with `reason=stop` and BL-MCTS summary emitted, indicating the stop polling/unwind works. 
- All automated tests above completed successfully (build + exercised UCI `movetime` and `stop`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69658d74b3c48327a452c4b3edc32de8)