### PR TITLE
Clean up BL-MCTS termination logging

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -212,6 +212,7 @@ void Search::Worker::start_searching() {
 
     contemptValue     = Value(contemptSetting * PawnValue / 100);
     kingSafetySetting = int(options["King Safety"]);
+    brainlearnSummary = BrainLearnSummary{};
 
     accumulatorStack.reset();
 
@@ -403,6 +404,13 @@ void Search::Worker::start_searching() {
         }
     }
     auto bestmove = UCIEngine::move(fallbackMove, rootPos.is_chess960());
+    if (useBrainLearn && brainlearnSummary.ready)
+    {
+        sync_cout << "info string BL-MCTS playouts=" << brainlearnSummary.playouts
+                  << " elapsed=" << brainlearnSummary.elapsed
+                  << " reason=" << brainlearnSummary.reason << sync_endl;
+        brainlearnSummary.ready = false;
+    }
     main_manager()->updates.onBestmove(bestmove, ponder);
 }
 
@@ -568,12 +576,7 @@ bool Search::Worker::run_brainlearn_mcts() {
     }
 
     if (is_mainthread())
-    {
         threads.stop = false;
-        static std::atomic_bool stageEmitted{false};
-        if (!stageEmitted.exchange(true))
-            sync_cout << "info string BL-MCTS stage=enter" << sync_endl;
-    }
 
     Move initialFallback = Move::none();
     if (is_mainthread() && !rootMoves.empty() && !rootMoves[0].pv.empty())
@@ -649,22 +652,15 @@ bool Search::Worker::run_brainlearn_mcts() {
         const bool      timeExpired =
           monteCarlo.time_expired()
           || (useTimeBudget && threads.stop.load(std::memory_order_relaxed));
-        const bool guardTriggered = monteCarlo.guard_triggered();
-        std::string_view reason =
-          guardTriggered ? "guard"
-          : noLegalMoves ? "nomoves"
-          : fallbackUsed ? "fallback"
-          : timeExpired  ? "time"
-                         : "stop";
+        std::string_view reason = noLegalMoves ? "nomoves"
+                                 : fallbackUsed ? "fallback"
+                                 : timeExpired  ? "time"
+                                                : "stop";
 
-        sync_cout << "info string BL-MCTS playouts=" << playouts << " elapsed=" << elapsed
-                  << " reason=" << reason << sync_endl;
-        sync_cout << "info string BL-MCTS debug budget=" << allocatedTime
-                  << " useTB=" << (useTimeBudget ? 1 : 0)
-                  << " expired=" << (timeExpired ? 1 : 0)
-                  << " nomoves=" << (noLegalMoves ? 1 : 0)
-                  << " stop=" << (threads.stop.load(std::memory_order_relaxed) ? 1 : 0)
-                  << " rootN=" << monteCarlo.root_legal_moves() << sync_endl;
+        brainlearnSummary.playouts = playouts;
+        brainlearnSummary.elapsed  = elapsed;
+        brainlearnSummary.reason   = std::string(reason);
+        brainlearnSummary.ready    = hasMove;
     }
 
     nodes.store(BrainLearnMCTS::MCTSNodeCount.load(std::memory_order_relaxed),

--- a/src/search.h
+++ b/src/search.h
@@ -300,6 +300,13 @@ class Worker {
     Value minimax_value(Position& pos, Search::Stack* ss, Depth depth, Value alpha, Value beta);
 
    private:
+    struct BrainLearnSummary {
+        uint64_t   playouts = 0;
+        TimePoint  elapsed  = TimePoint(0);
+        std::string reason;
+        bool       ready = false;
+    };
+
    void iterative_deepening();
     bool run_monte_carlo();
     bool run_brainlearn_mcts();
@@ -347,6 +354,8 @@ class Worker {
     RootMoves rootMoves;
     Depth     rootDepth, completedDepth;
     Value     rootDelta;
+
+    BrainLearnSummary brainlearnSummary;
 
     size_t                    threadIdx;
     NumaReplicatedAccessToken numaAccessToken;


### PR DESCRIPTION
### Motivation
- Reduce noisy UCI `info` output from BrainLearn MCTS and produce a single, well-formed termination summary per search.
- Ensure the BL-MCTS summary is printed exactly once and immediately before the `bestmove` in BrainLearnMCTS mode.
- Avoid changing any search logic while gating debug output removal and normalizing reported termination reasons.

### Description
- Added a `BrainLearnSummary` struct and per-worker `brainlearnSummary` member in `Search::Worker` to capture termination details (`playouts`, `elapsed`, `reason`, `ready`) in `src/search.h`.
- Replaced the immediate BL-MCTS termination `sync_cout` calls in `run_brainlearn_mcts()` with code that fills `brainlearnSummary` and marks it ready in `src/search.cpp`.
- Removed the `info string BL-MCTS stage=enter` emission and the verbose debug `info string BL-MCTS debug ...` output, and emit a single `info string BL-MCTS playouts=<N> elapsed=<ms> reason=<...>` just before `bestmove` when appropriate.
- Normalized the termination `reason` to the allowed values (`nomoves`, `fallback`, `time`, `stop`) and avoided introducing other reasons into the UCI summary.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696597ac728c8327ad1cc8bd949810a2)