### PR TITLE
Activate BrainLearnMCTS from checkbox and stream periodic UCI info during BL‑MCTS

### DIFF
--- a/src/brainlearn_mcts.cpp
+++ b/src/brainlearn_mcts.cpp
@@ -232,6 +232,9 @@ void MonteCarlo::search(ThreadPool&        threads,
         if (should_emit_pv(isMainThread))
             emit_pv(worker, threads);
 
+        if (should_emit_info(isMainThread))
+            emit_info(threads);
+
         if (threads.stop.load(std::memory_order_relaxed) || stop_requested())
             break;
 
@@ -253,6 +256,9 @@ void MonteCarlo::search(ThreadPool&        threads,
 
     if (should_emit_pv(isMainThread))
         emit_pv(worker, threads);
+
+    if (should_emit_info(isMainThread))
+        emit_info(threads);
 
     if (isMainThread && timeExpired)
         threads.stop = true;
@@ -276,6 +282,7 @@ void MonteCarlo::create_root(Search::Worker* worker) {
     maximumPly     = 1;
     startTime      = now();
     lastOutputTime = startTime;
+    lastInfoTime   = startTime;
 
     for (auto& currentStack : stackBuffer)
     {
@@ -507,6 +514,19 @@ bool MonteCarlo::should_emit_pv(bool isMainThread) const {
     return outputDelay >= 60000;
 }
 
+bool MonteCarlo::should_emit_info(bool isMainThread) const {
+
+    if (!isMainThread)
+        return false;
+
+    if (ply != 1)
+        return false;
+
+    const TimePoint outputDelay = now() - lastInfoTime;
+
+    return outputDelay >= 200;
+}
+
 void MonteCarlo::emit_pv(Search::Worker* worker, ThreadPool& threads) {
 
     assert(ply == 1);
@@ -583,6 +603,63 @@ void MonteCarlo::emit_pv(Search::Worker* worker, ThreadPool& threads) {
     }
 
     lastOutputTime = now();
+}
+
+void MonteCarlo::emit_info(ThreadPool& threads) {
+
+    assert(ply == 1);
+
+    LOCK(this, root);
+
+    if (root->number_of_sons <= 0)
+    {
+        lastInfoTime = now();
+        return;
+    }
+
+    const bool chess960 = pos.is_chess960();
+    std::ostringstream pvStream;
+    int movesMade = 0;
+
+    Move move = best_child(root, STAT_VISITS)->move;
+    while (move != Move::none() && pos.legal(move))
+    {
+        if (movesMade > 0)
+            pvStream << ' ';
+        pvStream << UCIEngine::move(move, chess960);
+
+        do_move(move);
+        ++movesMade;
+
+        mctsNodeInfo* node = nodes[ply] = get_node(this, pos);
+        if (node == nullptr)
+            break;
+
+        LOCK(this, node);
+
+        if (is_terminal(node) || node->number_of_sons <= 0 || node->node_visits <= 0)
+            break;
+
+        move = best_child(node, STAT_VISITS)->move;
+    }
+
+    for (int k = 0; k < movesMade; k++)
+        undo_move();
+
+    if (pvStream.str().empty() && move != Move::none() && pos.legal(move))
+        pvStream << UCIEngine::move(move, chess960);
+
+    const TimePoint elapsed      = std::max<TimePoint>(1, elapsed_ms());
+    const uint64_t  nodesVisited = playoutsCount;
+    const uint64_t  nps          = nodesVisited * 1000 / elapsed;
+    const int       depth        = std::max(1, maximumPly);
+    const int       selDepth     = std::max(1, maximumPly);
+
+    sync_cout << "info depth " << depth << " seldepth " << selDepth << " nodes " << nodesVisited
+              << " nps " << nps << " hashfull " << tt.hashfull() << " time " << elapsed
+              << " pv " << (pvStream.str().empty() ? "(none)" : pvStream.str()) << sync_endl;
+
+    lastInfoTime = now();
 }
 
 inline bool MonteCarlo::is_root(const mctsNodeInfo* node) const {

--- a/src/brainlearn_mcts.h
+++ b/src/brainlearn_mcts.h
@@ -223,7 +223,9 @@ class MonteCarlo {
     [[nodiscard]] double exploration_constant() const;
 
     [[nodiscard]] bool should_emit_pv(bool isMainThread) const;
+    [[nodiscard]] bool should_emit_info(bool isMainThread) const;
     void               emit_pv(Search::Worker* worker, ThreadPool& threads);
+    void               emit_info(ThreadPool& threads);
     void               print_children();
 
     int max_ply() const { return maximumPly; }
@@ -238,6 +240,7 @@ class MonteCarlo {
     int       maximumPly{};
     TimePoint startTime{};
     TimePoint lastOutputTime{};
+    TimePoint lastInfoTime{};
     TimePoint endTime{};
     uint64_t  playoutsCount{};
     bool      useTimeBudget{};

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -218,7 +218,12 @@ void Search::Worker::start_searching() {
     const bool strategyRequestsBrainLearn =
       options.count("Search Strategy")
       && (options["Search Strategy"] == "BrainLearnMCTS" || options["Search Strategy"] == "BL-MCTS");
-    const bool useBrainLearn = strategyRequestsBrainLearn;
+    const bool strategyIsAlphaBeta =
+      options.count("Search Strategy") && options["Search Strategy"] == "AlphaBeta";
+    const bool brainLearnCheckboxEnabled =
+      options.count("BrainLearnMCTS") && bool(int(options["BrainLearnMCTS"]));
+    const bool useBrainLearn =
+      strategyRequestsBrainLearn || (brainLearnCheckboxEnabled && strategyIsAlphaBeta);
 
     const int maxBrainLearnHelpers = std::max(0, int(options["Threads"]) - 1);
     const int brainLearnHelpers =


### PR DESCRIPTION
### Motivation
- GUIs may never change the `Search Strategy` combo so the `BrainLearnMCTS` checkbox must be able to force the BL‑MCTS driver when the combo remains at the `AlphaBeta` default. 
- While BL‑MCTS is running, emit periodic standard UCI `info` lines so GUIs (Fritz/Cutechess) display live analysis instead of only the final BL‑MCTS summary, but cap output rate to avoid spamming.

### Description
- Treat the checkbox as a fallback selector in driver selection: added `strategyIsAlphaBeta`, `brainLearnCheckboxEnabled` and changed `useBrainLearn` to run BL‑MCTS when the checkbox is true and `Search Strategy` is `AlphaBeta` in `Search::Worker::start_searching` (`src/search.cpp`).
- Added `should_emit_info` and `emit_info` declarations and a `lastInfoTime` timestamp to `MonteCarlo` in `src/brainlearn_mcts.h` to support periodic info emission.
- Call `emit_info()` from the main Monte Carlo loop and at search end, initialize `lastInfoTime` in `create_root`, and implement `should_emit_info()` to cap output to ~200ms (`src/brainlearn_mcts.cpp`).
- Implemented `emit_info()` to build a PV from the current best path, compute `nodes`/`nps`/`time`/`depth`/`seldepth`, and print a standard UCI `info depth ... seldepth ... nodes ... nps ... hashfull ... time ... pv ...` line; the final BL‑MCTS summary printing remains unchanged.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968fb338d148327a3520727e92c2625)