### PR TITLE
Add BrainLearnMCTS info marker for Fritz UI and silence unused parameter warning

### DIFF
--- a/src/brainlearn_mcts.cpp
+++ b/src/brainlearn_mcts.cpp
@@ -283,6 +283,7 @@ void MonteCarlo::create_root(Search::Worker* worker) {
     startTime      = now();
     lastOutputTime = startTime;
     lastInfoTime   = startTime;
+    emittedSearchMarker = false;
 
     for (auto& currentStack : stackBuffer)
     {
@@ -607,6 +608,8 @@ void MonteCarlo::emit_pv(Search::Worker* worker, ThreadPool& threads) {
 
 void MonteCarlo::emit_info(ThreadPool& threads) {
 
+    (void) threads;
+
     assert(ply == 1);
 
     LOCK(this, root);
@@ -655,9 +658,20 @@ void MonteCarlo::emit_info(ThreadPool& threads) {
     const int       depth        = std::max(1, maximumPly);
     const int       selDepth     = std::max(1, maximumPly);
 
+    std::string pvLine = pvStream.str();
+
+    if (!emittedSearchMarker)
+    {
+        emittedSearchMarker = true;
+        if (pvLine.empty())
+            pvLine = "BrainLearnMCTS";
+        else
+            pvLine = "BrainLearnMCTS " + pvLine;
+    }
+
     sync_cout << "info depth " << depth << " seldepth " << selDepth << " nodes " << nodesVisited
               << " nps " << nps << " hashfull " << tt.hashfull() << " time " << elapsed
-              << " pv " << (pvStream.str().empty() ? "(none)" : pvStream.str()) << sync_endl;
+              << " pv " << (pvLine.empty() ? "(none)" : pvLine) << sync_endl;
 
     lastInfoTime = now();
 }

--- a/src/brainlearn_mcts.h
+++ b/src/brainlearn_mcts.h
@@ -247,6 +247,7 @@ class MonteCarlo {
     bool      timeExpired{};
     bool      noLegalMoves{};
     bool      guardTriggered{};
+    bool      emittedSearchMarker{};
 
     [[maybe_unused]] double max_epsilon = 0.99;
     [[maybe_unused]] double min_epsilon = 0.00;


### PR DESCRIPTION
### Motivation
- Make BrainLearnMCTS visibly active in Fritz by emitting a harmless, standard `info` PV marker once per MCTS search and remove a `-Wunused-parameter` clang warning from `emit_info`.

### Description
- Add a `bool emittedSearchMarker` member to the `MonteCarlo` state, reset it at the start of each search in `create_root`, silence the unused `ThreadPool& threads` parameter with `(void) threads;` in `MonteCarlo::emit_info`, and prepend the single-shot `"BrainLearnMCTS"` tag to the emitted PV line so the engine prints `info ... pv ...` containing the marker.

### Testing
- No automated tests or builds were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696901877ec483278748975d76893a7a)