### PR TITLE
Fix BrainLearnMCTS hang, enforce movetime start and clamp threads

### DIFF
--- a/src/brainlearn_mcts.cpp
+++ b/src/brainlearn_mcts.cpp
@@ -183,25 +183,28 @@ void MonteCarlo::search(ThreadPool&        threads,
     timeExpired        = false;
     guardTriggered     = false;
 
-    while (!threads.stop.load(std::memory_order_relaxed) && !stop_requested() && !timeExpired
-           && !noLegalMoves)
+    constexpr TimePoint zeroPlayoutTimeoutMs = TimePoint(1000);
+
+    while (!should_abort(threads) && !noLegalMoves)
     {
-        if (useTimeBudget && now() >= endTime)
+        if (playoutsCount == 0 && elapsed_ms() >= zeroPlayoutTimeoutMs)
         {
-            timeExpired = true;
+            guardTriggered = true;
             break;
         }
 
         node = tree_policy(threads, limits);
-        if (!node)
+        if (!node || should_abort(threads))
             break;
 
         LOCK(this, node);
 
         if (AB_Rollout)
         {
+            if (should_abort(threads))
+                break;
             Value value = evaluate_with_minimax(node, std::min(ply, MAX_PLY - ply - 2));
-            if (threads.stop || stop_requested())
+            if (should_abort(threads))
                 break;
 
             if (value == VALUE_ZERO)
@@ -221,7 +224,7 @@ void MonteCarlo::search(ThreadPool&        threads,
         }
         else
         {
-            reward = playout_policy(node);
+            reward = playout_policy(node, threads);
         }
 
         if (ply >= 1)
@@ -235,14 +238,8 @@ void MonteCarlo::search(ThreadPool&        threads,
         if (should_emit_info(isMainThread))
             emit_info(threads);
 
-        if (threads.stop.load(std::memory_order_relaxed) || stop_requested())
+        if (should_abort(threads))
             break;
-
-        if (useTimeBudget && now() >= endTime)
-        {
-            timeExpired = true;
-            break;
-        }
 
         if (elapsed_ms() > TimePoint(60000) || playoutsCount > 100000000ULL)
         {
@@ -342,9 +339,25 @@ bool MonteCarlo::computational_budget(ThreadPool& threads, Search::LimitsType li
     return true;
 }
 
+bool MonteCarlo::should_abort(ThreadPool& threads) {
+    if (threads.stop.load(std::memory_order_relaxed) || stop_requested())
+        return true;
+
+    if (useTimeBudget && now() >= endTime)
+    {
+        timeExpired = true;
+        return true;
+    }
+
+    return false;
+}
+
 mctsNodeInfo* MonteCarlo::tree_policy(ThreadPool& threads, Search::LimitsType limits) {
 
     assert(ply == 1);
+
+    if (should_abort(threads))
+        return nullptr;
 
     if (root->number_of_sons == 0)
     {
@@ -354,6 +367,9 @@ mctsNodeInfo* MonteCarlo::tree_policy(ThreadPool& threads, Search::LimitsType li
     mctsNodeInfo* node = nullptr;
     while ((node = nodes[ply]))
     {
+        if (should_abort(threads))
+            return nullptr;
+
         LOCK(this, node);
 
         if (node->node_visits == 0)
@@ -378,6 +394,9 @@ mctsNodeInfo* MonteCarlo::tree_policy(ThreadPool& threads, Search::LimitsType li
 
         do_move(m);
 
+        if (should_abort(threads))
+            return nullptr;
+
         nodes[ply] = get_node(this, pos);
         if (nodes[ply] == nullptr)
         {
@@ -400,7 +419,10 @@ mctsNodeInfo* MonteCarlo::tree_policy(ThreadPool& threads, Search::LimitsType li
     return node;
 }
 
-Reward MonteCarlo::playout_policy(mctsNodeInfo* node) {
+Reward MonteCarlo::playout_policy(mctsNodeInfo* node, ThreadPool& threads) {
+
+    if (should_abort(threads))
+        return REWARD_DRAW;
 
     LOCK(this, node);
 
@@ -412,6 +434,9 @@ Reward MonteCarlo::playout_policy(mctsNodeInfo* node) {
         generate_moves(node);
         assert(node->node_visits == 1);
     }
+
+    if (should_abort(threads))
+        return REWARD_DRAW;
 
     if (node->number_of_sons == 0)
         return evaluate_terminal(node);

--- a/src/brainlearn_mcts.h
+++ b/src/brainlearn_mcts.h
@@ -197,7 +197,7 @@ class MonteCarlo {
     void          create_root(Search::Worker* worker);
     bool          computational_budget(ThreadPool& threads, Search::LimitsType limits);
     mctsNodeInfo* tree_policy(ThreadPool& threads, Search::LimitsType limits);
-    Reward        playout_policy(mctsNodeInfo* node);
+    Reward        playout_policy(mctsNodeInfo* node, ThreadPool& threads);
     Value         backup(Reward r, bool AB_Mode);
     Edge*         best_child(mctsNodeInfo* node, EdgeStatistic statistic) const;
 
@@ -248,6 +248,7 @@ class MonteCarlo {
     bool      noLegalMoves{};
     bool      guardTriggered{};
     bool      emittedSearchMarker{};
+    bool      should_abort(ThreadPool& threads);
 
     [[maybe_unused]] double max_epsilon = 0.99;
     [[maybe_unused]] double min_epsilon = 0.00;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -226,11 +226,12 @@ void Search::Worker::start_searching() {
       strategyRequestsBrainLearn || (brainLearnCheckboxEnabled && strategyIsAlphaBeta);
     bool       ranAlphaBeta = !useBrainLearn;
 
-    const int maxBrainLearnHelpers = std::max(0, int(options["Threads"]) - 1);
-    const int brainLearnHelpers =
-      options.count("BrainLearnMCTSThreads")
-        ? std::clamp<int>(options["BrainLearnMCTSThreads"], 0, maxBrainLearnHelpers)
-        : 0;
+    const int maxBrainLearnThreads = std::max(1, int(options["Threads"]));
+    const int requestedBrainLearnThreads =
+      options.count("BrainLearnMCTSThreads") ? int(options["BrainLearnMCTSThreads"]) : 0;
+    const int clampedBrainLearnThreads = std::clamp(
+      requestedBrainLearnThreads == 0 ? 1 : requestedBrainLearnThreads, 1, maxBrainLearnThreads);
+    const int brainLearnHelpers = clampedBrainLearnThreads - 1;
 
     // Non-main threads go directly to iterative_deepening()
     if (!is_mainthread())
@@ -275,7 +276,7 @@ void Search::Worker::start_searching() {
         }
         else
         {
-            BrainLearnMCTS::mctsThreads = 1 + static_cast<size_t>(brainLearnHelpers);
+            BrainLearnMCTS::mctsThreads = static_cast<size_t>(clampedBrainLearnThreads);
             BrainLearnMCTS::mctsMultiStrategy =
               options.count("BrainLearnMultiStrategy")
                 ? size_t(int(options["BrainLearnMultiStrategy"]))

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -249,6 +249,8 @@ void ThreadPool::start_thinking(const OptionsMap&  options,
     main_manager()->stopOnPonderhit = stop = abortedSearch = false;
     main_manager()->ponder                                 = limits.ponderMode;
 
+    limits.startTime = now();
+
     increaseDepth = true;
 
     Search::RootMoves rootMoves;


### PR DESCRIPTION
### Motivation
- Prevent immediate `movetime` expiry and bogus single-line AlphaBeta info by ensuring the search start time is set when a new search begins. 
- Prevent BrainLearn MCTS from hanging by making the inner Monte Carlo loop respect `stop`/time signals and add safety guards for zero-playouts or runaway playouts. 
- Ensure `BrainLearnMCTSThreads` is clamped to a valid range and that MCTS worker allocation uses the intended total thread count.

### Description
- Set `limits.startTime = now()` at the beginning of `ThreadPool::start_thinking` so `movetime` is measured from the actual search start (`src/thread.cpp`).
- Clamp the requested `BrainLearnMCTSThreads` to `[1, Threads]`, compute helper thread count, and propagate the clamped total into `BrainLearnMCTS::mctsThreads` (`src/search.cpp`).
- Add a `MonteCarlo::should_abort(ThreadPool&)` helper and wire periodic stop/time checks into the MCTS main loop and tree policy to always poll both `stop` and time budget inside the inner simulation loop (`src/brainlearn_mcts.cpp`, `src/brainlearn_mcts.h`).
- Introduce a zero-playout guard (1s) that triggers a safe break if no playouts complete within the timeout, plus other hard-guard checks to avoid runaway playout counts; adjust `playout_policy` to accept `ThreadPool&` and early-return when abort is requested (`src/brainlearn_mcts.cpp`, `src/brainlearn_mcts.h`).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969112bc4848327b10af92126315799)