### PR TITLE
Align MCTS options and fix helper root initialization to avoid 'nomoves'

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -110,8 +110,8 @@ Engine::Engine(std::optional<std::string> path) :
 
     options.add("MCTS", Option(false));
     options.add("MCTSThreads", Option(0, 0, 512));
-    options.add("MCTS Multi Strategy", Option(20, 0, 100));
-    options.add("MCTS Multi MinVisits", Option(5, 0, 1000));
+    options.add("Multi Strategy", Option(20, 0, 100));
+    options.add("Multi MinVisits", Option(5, 0, 1000));
 
     options.add("Skill Level", Option(20, 0, 20));
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -288,12 +288,12 @@ void Search::Worker::start_searching() {
             Brainlearn::mctsThreads =
               std::max<size_t>(1, static_cast<size_t>(clampedMctsHelpers));
             Brainlearn::mctsMultiStrategy =
-              options.count("MCTS Multi Strategy")
-                ? size_t(int(options["MCTS Multi Strategy"]))
+              options.count("Multi Strategy")
+                ? size_t(int(options["Multi Strategy"]))
                 : 20;
             Brainlearn::mctsMultiMinVisits =
-              options.count("MCTS Multi MinVisits")
-                ? double(int(options["MCTS Multi MinVisits"]))
+              options.count("Multi MinVisits")
+                ? double(int(options["Multi MinVisits"]))
                 : 5.0;
 
             if (clampedMctsHelpers > 0)
@@ -315,12 +315,25 @@ void Search::Worker::start_searching() {
 
                     helperWorker->limits = limits;
                     helperWorker->tbConfig = tbConfig;
+                    helperWorker->rootState = StateInfo();
                     helperWorker->rootPos.set(fen, chess960, &helperWorker->rootState);
                     helperWorker->rootMoves.clear();
                     helperWorker->contemptValue = contemptValue;
                     helperWorker->kingSafetySetting = kingSafetySetting;
                     helperWorker->accumulatorStack.reset();
                     helperWorker->mctsSummary = MctsSummary{};
+
+                    if (MoveList<LEGAL>(helperWorker->rootPos).size() == 0)
+                    {
+                        sync_cout << "info string MCTS helper init failed: no legal moves from FEN="
+                                  << fen << sync_endl;
+                        helperWorker->mctsSummary.playouts = 0;
+                        helperWorker->mctsSummary.elapsed  = TimePoint(0);
+                        helperWorker->mctsSummary.reason   = "nomoves";
+                        helperWorker->mctsSummary.ready    = true;
+                        mctsHelperWorkers.emplace_back(std::move(helperWorker));
+                        continue;
+                    }
 
                     const bool emitOutput = idx == 0;
                     mctsHelperThreads.emplace_back(


### PR DESCRIPTION
### Motivation
- Make the engine's MCTS settings and helper initialization match BrainLearn semantics and eliminate two observed failures: helpers reporting `reason=nomoves` and `go movetime` producing `nodes=0` with an instant `bestmove`.
- Ensure helper threads use a persistent `StateInfo` for their root position and validate the helper root so helpers never start with an invalid/empty move list.

### Description
- Renamed UCI option names to BrainLearn-style `Multi Strategy` and `Multi MinVisits` and updated code to read the new option keys in `src/engine.cpp` and `src/search.cpp`.
- In `src/search.cpp` helper initialization, added an explicit `helperWorker->rootState = StateInfo();` before calling `helperWorker->rootPos.set(...)` so each helper has a persistent `StateInfo` instance and `rootPos.set` uses that state.
- After setting the helper root position, validate legality with `MoveList<LEGAL>(helperWorker->rootPos)` and, if empty, emit `info string MCTS helper init failed: no legal moves from FEN=<fen>` and mark the helper's `mctsSummary` as ready with `reason = "nomoves"`, skipping spawning the helper search thread as a fail-safe.
- Kept existing MCTS module layout and Makefile references intact (the project already uses `mcts/montecarlo.cpp` and `mcts/montecarlo.h`).

### Testing
- Ran a merge-marker scan with `rg -n "<<<<<<<|=======|>>>>>>>" .` which returned no results, indicating no unresolved merge markers.
- Verified occurrences of the new options with `rg` (e.g. `rg -n "Multi Strategy" src`), confirming source updates; these searches succeeded.
- Did not run the Windows `go movetime` / `go infinite` interaction tests requested in the spec because those require executing the Windows binary; those tests remain to be run on Windows and should validate runtime behavior and UCI outputs as described in the task.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696960c4939c8327942022760b5851f4)