### PR TITLE
Fix MCTS helper setup and stop handling

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -242,6 +242,8 @@ void Engine::stop() {
     threads.stop = true;
     Brainlearn::request_stop();
     wait_for_search_finished();
+    if (threads.main_thread() && threads.main_thread()->worker)
+        threads.main_thread()->worker->join_mcts_helpers();
 }
 
 void Engine::search_clear() {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -217,6 +217,18 @@ void Search::Worker::log_mcts_debug(std::string_view line) const {
     sync_cout << line << sync_endl;
 }
 
+void Search::Worker::join_mcts_helpers() {
+    std::vector<std::thread> threadsToJoin;
+    {
+        std::lock_guard<std::mutex> lock(mctsHelperMutex);
+        threadsToJoin.swap(mctsHelperThreads);
+    }
+
+    for (auto& helperThread : threadsToJoin)
+        if (helperThread.joinable())
+            helperThread.join();
+}
+
 void Search::Worker::start_searching() {
 
     limits.startTime = now();
@@ -228,6 +240,7 @@ void Search::Worker::start_searching() {
     contemptValue     = Value(contemptSetting * PawnValue / 100);
     kingSafetySetting = int(options["King Safety"]);
     mctsSummary = MctsSummary{};
+    const bool debugLog = mcts_debug_enabled();
 
     accumulatorStack.reset();
 
@@ -270,8 +283,13 @@ void Search::Worker::start_searching() {
         sync_cout << "info string MCTS helpers=" << clampedMctsHelpers
                   << " engineThreads=" << engineThreads << sync_endl;
 
-    std::vector<std::unique_ptr<Search::Worker>> mctsHelperWorkers;
-    std::vector<std::thread>                     mctsHelperThreads;
+    if (is_mainthread())
+        join_mcts_helpers();
+    {
+        std::lock_guard<std::mutex> lock(mctsHelperMutex);
+        mctsHelperWorkers.clear();
+        mctsHelperThreads.clear();
+    }
     const bool                                   hasRootMoves = ensure_root_moves();
     if (!hasRootMoves)
     {
@@ -302,8 +320,11 @@ void Search::Worker::start_searching() {
                 const std::string fen = rootPos.fen();
                 const bool        chess960 = rootPos.is_chess960();
 
-                mctsHelperWorkers.reserve(clampedMctsHelpers);
-                mctsHelperThreads.reserve(clampedMctsHelpers);
+                {
+                    std::lock_guard<std::mutex> lock(mctsHelperMutex);
+                    mctsHelperWorkers.reserve(clampedMctsHelpers);
+                    mctsHelperThreads.reserve(clampedMctsHelpers);
+                }
 
                 for (int idx = 0; idx < clampedMctsHelpers; ++idx)
                 {
@@ -317,30 +338,57 @@ void Search::Worker::start_searching() {
                     helperWorker->tbConfig = tbConfig;
                     helperWorker->rootState = StateInfo();
                     helperWorker->rootPos.set(fen, chess960, &helperWorker->rootState);
+                    helperWorker->rootState = rootState;
                     helperWorker->rootMoves.clear();
                     helperWorker->contemptValue = contemptValue;
                     helperWorker->kingSafetySetting = kingSafetySetting;
                     helperWorker->accumulatorStack.reset();
                     helperWorker->mctsSummary = MctsSummary{};
 
-                    if (MoveList<LEGAL>(helperWorker->rootPos).size() == 0)
+                    MoveList<LEGAL> legalMoves(helperWorker->rootPos);
+                    const size_t    legalCount = legalMoves.size();
+                    if (debugLog)
                     {
-                        sync_cout << "info string MCTS helper init failed: no legal moves from FEN="
-                                  << fen << sync_endl;
+                        std::string sampleMoves;
+                        int         samples = 0;
+                        for (const Move m : legalMoves)
+                        {
+                            if (samples >= 4)
+                                break;
+                            if (!sampleMoves.empty())
+                                sampleMoves += " ";
+                            sampleMoves += UCIEngine::move(m, chess960);
+                            ++samples;
+                        }
+
+                        log_mcts_debug("info string MCTS helper=" + std::to_string(idx + 1)
+                                       + " fen=" + fen + " legal_moves="
+                                       + std::to_string(legalCount) + " sample=[" + sampleMoves
+                                       + "]");
+                    }
+
+                    if (legalCount == 0)
+                    {
+                        log_mcts_debug("info string MCTS helper init failed: no legal moves from FEN="
+                                       + fen);
                         helperWorker->mctsSummary.playouts = 0;
                         helperWorker->mctsSummary.elapsed  = TimePoint(0);
                         helperWorker->mctsSummary.reason   = "nomoves";
                         helperWorker->mctsSummary.ready    = true;
+                        std::lock_guard<std::mutex> lock(mctsHelperMutex);
                         mctsHelperWorkers.emplace_back(std::move(helperWorker));
                         continue;
                     }
 
                     const bool emitOutput = idx == 0;
-                    mctsHelperThreads.emplace_back(
-                      [helper = helperWorker.get(), emitOutput]() {
-                          helper->run_mcts_search(emitOutput);
-                      });
-                    mctsHelperWorkers.emplace_back(std::move(helperWorker));
+                    {
+                        std::lock_guard<std::mutex> lock(mctsHelperMutex);
+                        mctsHelperThreads.emplace_back(
+                          [helper = helperWorker.get(), emitOutput]() {
+                              helper->run_mcts_search(emitOutput);
+                          });
+                        mctsHelperWorkers.emplace_back(std::move(helperWorker));
+                    }
                 }
             }
         }
@@ -368,11 +416,7 @@ void Search::Worker::start_searching() {
     threads.wait_for_search_finished();
 
     if (useMcts)
-    {
-        for (auto& helperThread : mctsHelperThreads)
-            if (helperThread.joinable())
-                helperThread.join();
-    }
+        join_mcts_helpers();
 
     // When playing in 'nodes as time' mode, subtract the searched nodes from
     // the available ones before exiting.
@@ -444,6 +488,7 @@ void Search::Worker::start_searching() {
         bool     anyTime       = false;
         bool     anyFallback   = false;
 
+        std::lock_guard<std::mutex> lock(mctsHelperMutex);
         for (const auto& helper : mctsHelperWorkers)
         {
             if (!helper || !helper->mctsSummary.ready)

--- a/src/search.h
+++ b/src/search.h
@@ -27,8 +27,10 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <vector>
 
 #include "history.h"
@@ -282,6 +284,7 @@ class Worker {
     void ensure_network_replicated();
     bool mcts_debug_enabled() const;
     void log_mcts_debug(std::string_view line) const;
+    void join_mcts_helpers();
 
     // Public because they need to be updatable by the stats
     ButterflyHistory mainHistory;
@@ -357,6 +360,9 @@ class Worker {
     Value     rootDelta;
 
     MctsSummary mctsSummary;
+    std::vector<std::unique_ptr<Search::Worker>> mctsHelperWorkers;
+    std::vector<std::thread>                     mctsHelperThreads;
+    std::mutex                                   mctsHelperMutex;
 
     size_t                    threadIdx;
     NumaReplicatedAccessToken numaAccessToken;


### PR DESCRIPTION
### Motivation

- Prevent MCTS helper threads from starting with an invalid root ("playouts=0 reason=nomoves") by ensuring helpers rebuild the root `Position`/`StateInfo` correctly from FEN and generate legal moves. 
- Keep the main thread running standard AlphaBeta UCI info while MCTS helpers run in the background, and avoid helpers spamming UCI output. 
- Make `stop()` and new-search paths deterministic by signaling and joining helper threads to avoid hangs in CMD/GUI environments.

### Description

- Added helper lifecycle fields (`mctsHelperWorkers`, `mctsHelperThreads`, `mctsHelperMutex`) to `Search::Worker` in `src/search.h` to track helpers per main worker. 
- Implemented `Search::Worker::join_mcts_helpers()` and call it at search start and when stopping to deterministically join helper threads, and wired a call from `Engine::stop()` in `src/engine.cpp`. 
- Reworked helper initialization in `Search::Worker::start_searching()` to rebuild the helper root with `rootPos.fen()` plus `Position::set(...)`, set the thread-local `rootState`, and verify legal moves using `MoveList<LEGAL>` before spawning helpers. 
- Added debug-only logging via `log_mcts_debug()` to emit helper id, FEN, legal move count and sample moves to aid diagnosing `nomoves` failures, and protected helper vectors with a mutex when creating/inspecting/joining threads.

### Testing

- Ran the conflict-marker scan `rg -n "<<<<<<<|=======|>>>>>>>" .` which returned zero matches indicating no unresolved merge markers. 
- Windows CMD smoke tests (`movetime` and `infinite + stop`) were not executed in this environment (non-Windows), so their outputs are not included.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696969caa3f88327ba2fe82351178ddb)