### PR TITLE
Integrate MCTS root stats into AlphaBeta ordering

### DIFF
--- a/src/mcts/montecarlo.cpp
+++ b/src/mcts/montecarlo.cpp
@@ -126,6 +126,68 @@ bool stop_requested() { return mctsStopRequested.load(std::memory_order_relaxed)
 
 void clear() { MCTS.clear(); }
 
+Value reward_to_value(Reward r) {
+    if (r > 0.99)
+        return VALUE_MATE;
+    if (r < 0.01)
+        return -VALUE_MATE;
+
+    constexpr double g = 203.77396313709564;  //  this is 1 / k
+    const double     v = g * log(r / (1.0 - r));
+    return static_cast<Value>(static_cast<int>(v));
+}
+
+bool collect_root_stats(const Position& pos, size_t threadId, std::vector<MctsMoveStat>& out) {
+    out.clear();
+
+    const Key key1 = pos.key();
+    const Key key2 = pos.pawn_key();
+
+    mctsNodeInfo* node = nullptr;
+    createLock.acquire(threadId);
+    if (!MCTS.empty())
+    {
+        const auto [fst, snd] = MCTS.equal_range(key1);
+        for (auto it = fst; it != snd; ++it)
+        {
+            mctsNodeInfo* candidate = it->second;
+            if (candidate->key1 == key1 && candidate->key2 == key2)
+            {
+                node = candidate;
+                break;
+            }
+        }
+    }
+    createLock.release(threadId);
+
+    if (!node)
+        return false;
+
+    if (mctsThreads > 1)
+        node->lock.acquire(threadId);
+
+    const int n = node->number_of_sons.load(std::memory_order_relaxed);
+    out.reserve(n);
+    for (int k = 0; k < n; ++k)
+    {
+        Edge* edge = node->children[k];
+        const Move move = edge->move.load(std::memory_order_relaxed);
+        if (!move.is_ok())
+            continue;
+        MctsMoveStat stat;
+        stat.move = move;
+        stat.visits = edge->visits.load(std::memory_order_relaxed);
+        stat.meanActionValue = edge->meanActionValue.load(std::memory_order_relaxed);
+        stat.prior = edge->prior.load(std::memory_order_relaxed);
+        out.push_back(stat);
+    }
+
+    if (mctsThreads > 1)
+        node->lock.release(threadId);
+
+    return !out.empty();
+}
+
 template<typename T>
 T TRand(const T min, const T max) {
     static std::random_device        rd;

--- a/src/mcts/montecarlo.h
+++ b/src/mcts/montecarlo.h
@@ -24,6 +24,7 @@
 #include <cmath>
 #include <thread>
 #include <unordered_map>
+#include <vector>
 
 #include "../movepick.h"
 #include "../position.h"
@@ -69,6 +70,13 @@ struct Edge {
     std::atomic<Reward> meanActionValue;
 };
 
+struct MctsMoveStat {
+    Move   move = Move::none();
+    double visits = 0.0;
+    Reward meanActionValue = REWARD_NONE;
+    Reward prior = REWARD_NONE;
+};
+
 extern size_t                           mctsThreads;
 extern size_t                           mctsMultiStrategy;
 extern double                           mctsMultiMinVisits;
@@ -77,6 +85,8 @@ void                                    request_stop();
 void                                    clear_stop();
 bool                                    stop_requested();
 void                                    clear();
+Value                                   reward_to_value(Reward r);
+bool collect_root_stats(const Position& pos, size_t threadId, std::vector<MctsMoveStat>& out);
 constexpr int                           MAX_CHILDREN = MAX_MOVES;
 typedef std::array<Edge*, MAX_CHILDREN> EdgeArray;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -636,6 +636,67 @@ bool Search::Worker::run_mcts_search(bool emitOutput) {
     return hasMove;
 }
 
+void Search::Worker::apply_mcts_root_ordering() {
+    // Use MCTS helper statistics to bias AlphaBeta root move ordering.
+    if (!is_mainthread())
+        return;
+
+    if (!options.count("MCTS") || !bool(int(options["MCTS"])))
+        return;
+
+    if (rootMoves.empty())
+        return;
+
+    std::vector<Brainlearn::MctsMoveStat> stats;
+    const size_t lockId =
+      threadIdx == 0 ? Brainlearn::mctsThreads + 1 : threadIdx;
+    if (!Brainlearn::collect_root_stats(rootPos, lockId, stats))
+        return;
+
+    auto find_stat = [&](Move move) -> const Brainlearn::MctsMoveStat* {
+        for (const auto& stat : stats)
+            if (stat.move == move)
+                return &stat;
+        return nullptr;
+    };
+
+    bool hasStats = false;
+    for (RootMove& rm : rootMoves)
+    {
+        if (const auto* stat = find_stat(rm.pv[0]))
+        {
+            hasStats = true;
+            if (rm.score == -VALUE_INFINITE)
+                rm.previousScore = Brainlearn::reward_to_value(stat->meanActionValue);
+        }
+    }
+
+    if (!hasStats)
+        return;
+
+    std::stable_sort(rootMoves.begin(), rootMoves.end(),
+                     [&](const RootMove& a, const RootMove& b) {
+                         const auto* statA = find_stat(a.pv[0]);
+                         const auto* statB = find_stat(b.pv[0]);
+
+                         if (statA && statB)
+                         {
+                             const double scoreA = 10.0 * statA->visits + statA->prior;
+                             const double scoreB = 10.0 * statB->visits + statB->prior;
+                             if (scoreA != scoreB)
+                                 return scoreA > scoreB;
+                             if (statA->meanActionValue != statB->meanActionValue)
+                                 return statA->meanActionValue > statB->meanActionValue;
+                             return false;
+                         }
+                         if (statA && !statB)
+                             return true;
+                         if (!statA && statB)
+                             return false;
+                         return false;
+                     });
+}
+
 void Search::Worker::iterative_deepening() {
 
     SearchManager* mainThread = (is_mainthread() ? main_manager() : nullptr);
@@ -705,6 +766,8 @@ void Search::Worker::iterative_deepening() {
         // all the move scores except the (new) PV are set to -VALUE_INFINITE.
         for (RootMove& rm : rootMoves)
             rm.previousScore = rm.score;
+
+        apply_mcts_root_ordering();
 
         size_t pvFirst = 0;
         pvLast         = 0;

--- a/src/search.h
+++ b/src/search.h
@@ -314,6 +314,7 @@ class Worker {
 
    void iterative_deepening();
     bool run_mcts_search(bool emitOutput);
+    void apply_mcts_root_ordering();
 
     void do_move(Position& pos, const Move move, StateInfo& st, Stack* const ss);
     void


### PR DESCRIPTION
### Motivation
- Expose MCTS root statistics so AlphaBeta can be biased by helper results without changing the threading model or treating MCTS as a replacement search.
- Preserve AlphaBeta-on-main-thread and avoid copying `Position` objects while allowing helpers to influence root move ordering.
- Provide a minimal integration so MCTS affects best-move selection (not just logging) and keeps UCI output stable.

### Description
- Added a lightweight snapshot API: `MctsMoveStat` and `collect_root_stats(...)` in `src/mcts/montecarlo.{h,cpp}` to extract root children `move`, `visits`, `meanActionValue`, and `prior` with minimal locking and compatibility with `mctsThreads`.
- Exposed MCTS reward conversion as `reward_to_value(Reward)` in `src/mcts/montecarlo.*` so MCTS mean/prior values can be translated to engine `Value` scores.
- Implemented `Search::Worker::apply_mcts_root_ordering()` in `src/search.cpp` and wired it into `iterative_deepening()` to bias `RootMoves` ordering using MCTS `visits`, `prior`, and `meanActionValue` without changing AlphaBeta logic or thread model.
- Kept integration minimal and commented where MCTS statistics are consumed, and used stable sort so AlphaBeta move ordering changes are deterministic and limited to root ordering only.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69696f3bc66083279694cfb4c63ab5a3)