### PR TITLE
Align MCTS helper root initialization with BrainLearn

### DIFF
--- a/src/mcts/montecarlo.cpp
+++ b/src/mcts/montecarlo.cpp
@@ -352,7 +352,6 @@ MonteCarlo::MonteCarlo(Position&           p,
     thisThread(worker),
     tt(transpositionTable) {
     default_parameters();
-    create_root(worker);
 }
 
 /// MonteCarlo::create_root(Search::Worker* worker) initializes the Monte-Carlo tree with the given position
@@ -361,6 +360,11 @@ void MonteCarlo::create_root(Search::Worker* worker) {
     assert(ply == 0);
     assert(nodes[1] == nullptr);
     assert(root == nullptr);
+
+    const std::string fen = pos.fen();
+    const bool        isChess960 = pos.is_chess960();
+    worker->rootState           = StateInfo();
+    pos.set(fen, isChess960, &worker->rootState);
 
     // Initialize variables
     ply            = 1;
@@ -400,9 +404,8 @@ void MonteCarlo::create_root(Search::Worker* worker) {
 
     LOCK(this, root);
 
-    if (root->node_visits == 0)
-        generate_moves(root);
-    noLegalMoves = root->number_of_sons == 0;
+    generate_root_moves();
+    noLegalMoves = worker->root_moves().empty();
 }
 
 /// MonteCarlo::computational_budget() returns true the search is still
@@ -800,6 +803,25 @@ void MonteCarlo::undo_move() {
 /// generate moves if we want to have a decent order (captures first, then
 /// quiet moves, etc.). We have to pass various history tables to the MovePicker
 /// constructor, like in the alpha-beta implementation of move ordering.
+void MonteCarlo::generate_root_moves() {
+
+    assert(root != nullptr);
+
+    if (root->node_visits == 0)
+        generate_moves(root);
+
+    Search::RootMoves& rootMoves = thisThread->root_moves();
+    rootMoves.clear();
+
+    const int n = root->number_of_sons.load(std::memory_order_relaxed);
+    for (int k = 0; k < n; ++k)
+    {
+        const Move move = root->children[k]->move.load(std::memory_order_relaxed);
+        if (move.is_ok())
+            rootMoves.emplace_back(move);
+    }
+}
+
 void MonteCarlo::generate_moves(mctsNodeInfo* node) {
 
     LOCK(this, node);

--- a/src/mcts/montecarlo.h
+++ b/src/mcts/montecarlo.h
@@ -246,6 +246,7 @@ class MonteCarlo {
     [[nodiscard]] Reward evaluate_terminal(mctsNodeInfo* node) const;
     Reward               calculate_prior(Move m);
     void                 add_prior_to_node(mctsNodeInfo* node, Move m, Reward prior) const;
+    void                 generate_root_moves();
 
     // Tweaking the exploration algorithm
     void                 default_parameters();

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -241,7 +241,6 @@ void Search::Worker::start_searching() {
     kingSafetySetting = int(options["King Safety"]);
     mctsSummary = MctsSummary{};
     mctsInfoLogged = false;
-    const bool debugLog = mcts_debug_enabled();
 
     accumulatorStack.reset();
 
@@ -338,46 +337,6 @@ void Search::Worker::start_searching() {
                     helperWorker->kingSafetySetting = kingSafetySetting;
                     helperWorker->accumulatorStack.reset();
                     helperWorker->mctsSummary = MctsSummary{};
-
-                    MoveList<LEGAL> legalMoves(helperWorker->rootPos);
-                    const size_t    legalCount = legalMoves.size();
-                    if (debugLog)
-                    {
-                        std::string sampleMoves;
-                        int         samples = 0;
-                        for (const Move m : legalMoves)
-                        {
-                            if (samples >= 4)
-                                break;
-                            if (!sampleMoves.empty())
-                                sampleMoves += " ";
-                            sampleMoves += UCIEngine::move(m, chess960);
-                            ++samples;
-                        }
-
-                        log_mcts_debug("info string MCTS helper=" + std::to_string(idx + 1)
-                                       + " fen=" + fen + " legal_moves="
-                                       + std::to_string(legalCount) + " sample=[" + sampleMoves
-                                       + "]");
-                    }
-
-                    if (legalCount == 0)
-                    {
-                        const std::string stm = helperWorker->rootPos.side_to_move() == WHITE
-                                                  ? "white"
-                                                  : "black";
-                        sync_cout << "info string MCTS helper init failed: no legal moves fen=" << fen
-                                  << " side=" << stm << sync_endl;
-                        log_mcts_debug("info string MCTS helper init failed: no legal moves fen="
-                                       + fen + " side=" + stm);
-                        helperWorker->mctsSummary.playouts = 0;
-                        helperWorker->mctsSummary.elapsed  = TimePoint(0);
-                        helperWorker->mctsSummary.reason   = "nomoves";
-                        helperWorker->mctsSummary.ready    = true;
-                        std::lock_guard<std::mutex> lock(mctsHelperMutex);
-                        mctsHelperWorkers.emplace_back(std::move(helperWorker));
-                        continue;
-                    }
 
                     const bool emitOutput = idx == 0;
                     {
@@ -532,11 +491,31 @@ bool Search::Worker::run_mcts_search(bool emitOutput) {
         mctsLimits.depth    = 0;
     }
 
-    Move initialFallback = Move::none();
-    if (emitOutput && !rootMoves.empty() && !rootMoves[0].pv.empty())
-        initialFallback = rootMoves[0].pv[0];
+    const std::string fen = rootPos.fen();
+    const bool        isChess960 = rootPos.is_chess960();
+    rootState = StateInfo();
+    rootPos.set(fen, isChess960, &rootState);
 
     Brainlearn::MonteCarlo monteCarlo(rootPos, this, tt);
+    monteCarlo.create_root(this);
+    if (monteCarlo.no_legal_moves())
+    {
+        mctsSummary.playouts = 0;
+        mctsSummary.elapsed  = TimePoint(0);
+        mctsSummary.reason   = "nomoves";
+        mctsSummary.ready    = true;
+
+        if (debugLog)
+        {
+            log_mcts_debug("info string MCTS helper=" + std::to_string(threadIdx)
+                           + " exit playouts=0 elapsed=0 reason=nomoves");
+        }
+
+        nodes.store(Brainlearn::MCTSNodeCount.load(std::memory_order_relaxed),
+                    std::memory_order_relaxed);
+        tbHits.store(0, std::memory_order_relaxed);
+        return false;
+    }
 
     TimePoint allocatedTime = TimePoint(0);
     bool      useTimeBudget = false;
@@ -560,42 +539,12 @@ bool Search::Worker::run_mcts_search(bool emitOutput) {
 
     const uint64_t playouts = monteCarlo.playouts();
     const bool     noLegalMoves = monteCarlo.no_legal_moves();
-    bool           fallbackUsed = playouts == 0;
-    bool           hasMove = true;
+    bool           hasMove = !noLegalMoves;
     if (emitOutput)
     {
         const int maxPly = std::clamp(monteCarlo.max_ply(), 1, MAX_PLY - 1);
         completedDepth   = rootDepth = Depth(maxPly);
         selDepth                     = maxPly;
-
-        auto has_valid_move = [&]() {
-            return !rootMoves.empty() && !rootMoves[0].pv.empty()
-                && rootMoves[0].pv[0] != Move::none() && rootPos.legal(rootMoves[0].pv[0]);
-        };
-
-        if ((playouts == 0 || noLegalMoves) && !has_valid_move())
-        {
-            Move fallbackMove =
-              initialFallback != Move::none() && rootPos.legal(initialFallback) ? initialFallback
-                                                                                : Move::none();
-            if (fallbackMove == Move::none())
-            {
-                for (Move m : MoveList<LEGAL>(rootPos))
-                {
-                    fallbackMove = m;
-                    break;
-                }
-            }
-
-            if (fallbackMove != Move::none())
-            {
-                rootMoves.clear();
-                rootMoves.emplace_back(fallbackMove);
-            }
-
-            hasMove = fallbackMove != Move::none();
-            fallbackUsed = true;
-        }
     }
 
     const TimePoint elapsed = monteCarlo.elapsed_ms();
@@ -603,7 +552,6 @@ bool Search::Worker::run_mcts_search(bool emitOutput) {
       monteCarlo.time_expired()
       || (useTimeBudget && threads.stop.load(std::memory_order_relaxed));
     std::string_view reason = noLegalMoves ? "nomoves"
-                             : fallbackUsed ? "fallback"
                              : timeExpired  ? "time"
                                             : "stop";
 


### PR DESCRIPTION
### Motivation

- Make the Wordfish MCTS helper behavior match BrainLearn by fixing the "nomoves" lifecycle bug and aligning root initialization, move generation and helper startup sequencing. 
- Ensure helpers reconstruct their root `Position` via FEN, call the MCTS root initializer before doing playouts, and exit cleanly when no legal root moves exist. 

### Description

- Added `MonteCarlo::generate_root_moves()` and declared it in `src/mcts/montecarlo.h` to populate `Search::RootMoves` from the MCTS root children. 
- Changed `MonteCarlo::create_root()` in `src/mcts/montecarlo.cpp` to reconstruct the helper `rootState`/`rootPos` from FEN, always call `generate_root_moves()`, and set `noLegalMoves` from `worker->root_moves().empty()`. 
- Removed automatic `create_root()` call from the `MonteCarlo` constructor so helpers explicitly call `create_root()` at startup. 
- Updated `Search::Worker::run_mcts_search()` in `src/search.cpp` to rebuild `rootPos` via `rootPos.fen()`/`set(...)`, call `monteCarlo.create_root(this)` before entering the MCTS loop, and exit immediately with `reason = "nomoves"` if `monteCarlo.no_legal_moves()` is true. 
- Removed prior helper-side pre-check/fallback logic that attempted to run MCTS when no legal root moves were present, aligning with BrainLearn semantics (no fake playouts, helpers do not emit bestmove or AlphaBeta info). 

Files changed: `src/mcts/montecarlo.cpp`, `src/mcts/montecarlo.h`, `src/search.cpp`.

### Testing

- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69697f5fb6d0832785f117d7d7e569da)