### PR TITLE
Switch default big NNUE to nn-c288c895ea92.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -33,7 +33,7 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultNameBig "nn-2962dca31855.nnue"
+#define EvalFileDefaultNameBig "nn-c288c895ea92.nnue"
 #define EvalFileDefaultNameSmall "nn-37f18f62d772.nnue"
 
 namespace NNUE {


### PR DESCRIPTION
### Motivation
- Use the updated default big NNUE network filename so the build and download logic reference `nn-c288c895ea92.nnue` instead of the previous network.

### Description
- Replace the `EvalFileDefaultNameBig` macro value in `src/evaluate.h` to `"nn-c288c895ea92.nnue"`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69710ea4648083278bad01cdffb1ddeb)