### PR TITLE
Restore default signal handler after shared-memory cleanup

### DIFF
--- a/src/shm_linux.h
+++ b/src/shm_linux.h
@@ -104,6 +104,12 @@ class CleanupHooks {
 
     static void handle_signal(int sig) noexcept {
         SharedMemoryRegistry::cleanup_all();
+        struct sigaction sa;
+        sa.sa_handler = SIG_DFL;
+        sigemptyset(&sa.sa_mask);
+        sa.sa_flags = 0;
+        sigaction(sig, &sa, nullptr);
+        raise(sig);
         _Exit(128 + sig);
     }
 


### PR DESCRIPTION
### Motivation
- Ensure processes get standard crash feedback on Linux when signals occur after Stockfish installs handlers by restoring the default handler before terminating.

### Description
- In `src/shm_linux.h` inside `CleanupHooks::handle_signal`, call `sigaction` to reset the handler to `SIG_DFL` and invoke `raise(sig)` after `SharedMemoryRegistry::cleanup_all()` so the signal is re-delivered with default handling.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697110451d788327bbb780406095c7d8)