### PR TITLE
Fix Monte Carlo root state access

### DIFF
--- a/src/mcts/montecarlo.cpp
+++ b/src/mcts/montecarlo.cpp
@@ -363,8 +363,8 @@ void MonteCarlo::create_root(Search::Worker* worker) {
 
     const std::string fen = pos.fen();
     const bool        isChess960 = pos.is_chess960();
-    worker->rootState           = StateInfo();
-    pos.set(fen, isChess960, &worker->rootState);
+    worker->root_state()           = StateInfo();
+    pos.set(fen, isChess960, &worker->root_state());
 
     // Initialize variables
     ply            = 1;

--- a/src/search.h
+++ b/src/search.h
@@ -280,6 +280,7 @@ class Worker {
     size_t thread_index() const { return threadIdx; }
     RootMoves& root_moves() { return rootMoves; }
     Depth completed_depth() const { return completedDepth; }
+    StateInfo& root_state() { return rootState; }
 
     void ensure_network_replicated();
     bool mcts_debug_enabled() const;


### PR DESCRIPTION
### Motivation
- Fix compilation errors where `MonteCarlo::create_root` attempted to write to the private `Worker::rootState` by providing a public accessor so the MCTS initialization can set the root state safely.

### Description
- Added a public accessor `StateInfo& root_state()` to `Search::Worker` in `src/search.h`.
- Updated `MonteCarlo::create_root` in `src/mcts/montecarlo.cpp` to call `worker->root_state()` and pass that to `pos.set` instead of accessing `rootState` directly.
- No other logic or behavior was changed.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69711855ea8083279f9ece271ffd7ef8)