### PR TITLE
Check for Wine when running mingw PGO benchmark (profile-build)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1033,6 +1033,15 @@ profile-build: net config-sanity objclean profileclean
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) $(profile_make)
 	@echo ""
 	@echo "Step 2/4. Running benchmark for pgo-build ..."
+ifeq ($(target_windows),yes)
+ifneq ($(filter $(KERNEL),Linux Darwin FreeBSD OpenBSD NetBSD),)
+ifeq ($(WINE_PATH),)
+	@echo "Wine is required to run Windows binaries for profile-guided builds." && \
+	echo "Install wine or set WINE_PATH to its location before running profile-build." && \
+	exit 1
+endif
+endif
+endif
 	$(PGOBENCH) > PGOBENCH.out 2>&1
 	tail -n 4 PGOBENCH.out
 	@echo ""


### PR DESCRIPTION
### Motivation
- Prevent confusing failures when running `make profile-build` for Windows (`mingw`) builds on non-Windows hosts by ensuring Wine is available or `WINE_PATH` is set.

### Description
- Add a guard in `src/Makefile` under the `profile-build` target that checks `target_windows` and the host kernel and prints a clear message and `exit 1` if `WINE_PATH` is not set.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69711a1bad8c8327af09c39aac0983c6)