### PR TITLE
Make shared-memory and NNUE hashing deterministic (avoid salted std::hash)

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -298,6 +298,20 @@ inline uint64_t mul_hi64(uint64_t a, uint64_t b) {
 #endif
 }
 
+inline std::uint64_t basic_hash_bytes(const unsigned char* data, std::size_t size) noexcept {
+    std::uint64_t hash = 14695981039346656037ULL;
+    for (std::size_t i = 0; i < size; ++i)
+    {
+        hash ^= data[i];
+        hash *= 1099511628211ULL;
+    }
+    return hash;
+}
+
+inline std::uint64_t basic_hash(std::string_view data) noexcept {
+    return basic_hash_bytes(reinterpret_cast<const unsigned char*>(data.data()), data.size());
+}
+
 
 template<typename T>
 inline void hash_combine(std::size_t& seed, const T& v) {
@@ -312,8 +326,8 @@ inline void hash_combine(std::size_t& seed, const std::size_t& v) {
 
 template<typename T>
 inline std::size_t get_raw_data_hash(const T& value) {
-    return std::hash<std::string_view>{}(
-      std::string_view(reinterpret_cast<const char*>(&value), sizeof(value)));
+    return static_cast<std::size_t>(
+      basic_hash_bytes(reinterpret_cast<const unsigned char*>(&value), sizeof(value)));
 }
 
 template<std::size_t Capacity>
@@ -434,7 +448,7 @@ void move_to_front(std::vector<T>& vec, Predicate pred) {
 template<std::size_t N>
 struct std::hash<Stockfish::FixedString<N>> {
     std::size_t operator()(const Stockfish::FixedString<N>& fstr) const noexcept {
-        return std::hash<std::string_view>{}((std::string_view) fstr);
+        return static_cast<std::size_t>(Stockfish::basic_hash(std::string_view(fstr)));
     }
 };
 

--- a/src/shm.h
+++ b/src/shm.h
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
 #include <cstring>
 #include <functional>
 #include <iomanip>
@@ -44,6 +45,7 @@
     #define SF_MAX_SEM_NAME_LEN NAME_MAX
 #endif
 
+#include "misc.h"
 #include "types.h"
 
 #include "memory.h"
@@ -511,7 +513,7 @@ template<typename T>
 struct SystemWideSharedConstant {
    private:
     static std::string createHashString(const std::string& input) {
-        size_t hash = std::hash<std::string>{}(input);
+        std::uint64_t hash = basic_hash(input);
 
         std::stringstream ss;
         ss << std::hex << std::setfill('0') << hash;
@@ -533,11 +535,12 @@ struct SystemWideSharedConstant {
     // that are not present in the content, for example NUMA node allocation.
     SystemWideSharedConstant(const T& value, std::size_t discriminator = 0) {
         std::size_t content_hash    = std::hash<T>{}(value);
-        std::size_t executable_hash = std::hash<std::string>{}(getExecutablePathHash());
+        std::size_t executable_hash = static_cast<std::size_t>(basic_hash(getExecutablePathHash()));
 
-        std::string shm_name = std::string("Local\\sf_") + std::to_string(content_hash) + "$"
-                             + std::to_string(executable_hash) + "$"
-                             + std::to_string(discriminator);
+        char shm_name_buf[128];
+        std::snprintf(shm_name_buf, sizeof(shm_name_buf), "Local\\sf_%zu$%zu$%zu", content_hash,
+                      executable_hash, discriminator);
+        std::string shm_name = shm_name_buf;
 
 #if !defined(_WIN32)
         // POSIX shared memory names must start with a slash

--- a/src/shm_linux.h
+++ b/src/shm_linux.h
@@ -42,6 +42,8 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include "misc.h"
+
 #if defined(__NetBSD__) || defined(__DragonFly__) || defined(__linux__)
     #include <limits.h>
     #define SF_MAX_SEM_NAME_LEN NAME_MAX
@@ -170,7 +172,7 @@ class SharedMemory: public detail::SharedMemoryBase {
     }
 
     static std::string make_sentinel_base(const std::string& name) {
-        uint64_t hash = std::hash<std::string>{}(name);
+        uint64_t hash = basic_hash(name);
         char     buf[32];
         std::snprintf(buf, sizeof(buf), "sfshm_%016" PRIx64, static_cast<uint64_t>(hash));
         return buf;
@@ -427,11 +429,10 @@ class SharedMemory: public detail::SharedMemoryBase {
     }
 
     std::string sentinel_full_path(pid_t pid) const {
-        std::string path = "/dev/shm/";
-        path += sentinel_base_;
-        path.push_back('.');
-        path += std::to_string(pid);
-        return path;
+        char buf[64];
+        std::snprintf(buf, sizeof(buf), "/dev/shm/%s.%ld", sentinel_base_.c_str(),
+                      static_cast<long>(pid));
+        return buf;
     }
 
     void decrement_refcount_relaxed() noexcept {


### PR DESCRIPTION
### Motivation
- `std::hash` and some runtime-dependent formatting were producing invocation-dependent salts which could lead to non-deterministic PGO binaries and unstable shared-memory/net names. 
- The intent is to make name/hash generation deterministic across runs while keeping no functional behavior change.

### Description
- Added a small deterministic FNV-1a style helper: `basic_hash_bytes` and `basic_hash` in `src/misc.h` and used it for raw-data hashing in `get_raw_data_hash` and `FixedString` hashing via the `std::hash<FixedString<N>>` specialization. 
- Replaced uses of `std::hash<std::string>` for shared-memory naming with `basic_hash` in `src/shm.h` and formatted shared-memory names with `std::snprintf` instead of concatenating `std::to_string`, producing stable `shm_name` strings on all platforms. 
- Switched sentinel path construction in `src/shm_linux.h` to use `basic_hash` for the base and `std::snprintf` to generate the sentinel filename (avoids `std::to_string(pid)` path differences) and added necessary includes (`<cstdio>` and `misc.h`).

### Testing
- No automated tests or build steps were executed as part of this change (no tests run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69733fb892448327b84b9ba88a22c022)