### PR TITLE
Update NNUE defaults, robust net downloader, and Makefile NNUE gating

### DIFF
--- a/scripts/net.sh
+++ b/scripts/net.sh
@@ -1,76 +1,128 @@
 #!/bin/sh
+set -eu
 
-wget_or_curl=$( (command -v wget > /dev/null 2>&1 && echo "wget -qO-") || \
-                (command -v curl > /dev/null 2>&1 && echo "curl -skL"))
+script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+repo_root="$(CDPATH= cd -- "$script_dir/.." && pwd)"
 
+src_dir="$repo_root/src"
+nnue_dir="$src_dir/nnue"
 
-sha256sum=$( (command -v shasum > /dev/null 2>&1 && echo "shasum -a 256") || \
-             (command -v sha256sum > /dev/null 2>&1 && echo "sha256sum"))
-
-if [ -z "$sha256sum" ]; then
-  >&2 echo "sha256sum not found, NNUE files will be assumed valid."
+# Auto-detect evaluate.h location
+if [ -f "$nnue_dir/evaluate.h" ]; then
+  evaluate_file="$nnue_dir/evaluate.h"
+elif [ -f "$src_dir/evaluate.h" ]; then
+  evaluate_file="$src_dir/evaluate.h"
+else
+  >&2 echo "Error: cannot find evaluate.h in $nnue_dir/evaluate.h or $src_dir/evaluate.h"
+  exit 1
 fi
 
+mkdir -p "$nnue_dir"
+
+# Downloader
+if command -v wget >/dev/null 2>&1; then
+  download_cmd="wget -qO-"
+elif command -v curl >/dev/null 2>&1; then
+  download_cmd="curl -skL"
+else
+  >&2 printf "%s\n" "Neither wget nor curl is installed." \
+    "Install one of these tools to download NNUE files automatically."
+  exit 1
+fi
+
+sha256_first12() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}' | cut -c 1-12
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}' | cut -c 1-12
+  else
+    >&2 echo "Error: sha256sum or shasum -a 256 is required to validate NNUE files."
+    exit 1
+  fi
+}
+
+file_size_bytes() {
+  wc -c < "$1" | tr -d ' '
+}
+
 get_nnue_filename() {
-  grep "$1" evaluate.h | grep "#define" | sed "s/.*\(nn-[a-z0-9]\{12\}.nnue\).*/\1/"
+  # Extract nn-<12hex>.nnue from the macro line in evaluate.h
+  grep "$1" "$evaluate_file" | grep "#define" | sed -n 's/.*\(nn-[a-z0-9]\{12\}\.nnue\).*/\1/p'
 }
 
 validate_network() {
-  # If no sha256sum command is available, assume the file is always valid.
-  if [ -n "$sha256sum" ] && [ -f "$1" ]; then
-    if [ "$1" != "nn-$($sha256sum "$1" | cut -c 1-12).nnue" ]; then
-      rm -f "$1"
-      return 1
-    fi
-  fi
-}
+  # $1 full path, $2 min size
+  fpath="$1"
+  minsz="$2"
 
-fetch_network() {
-  _filename="$(get_nnue_filename "$1")"
+  [ -f "$fpath" ] || return 1
 
-  if [ -z "$_filename" ]; then
-    >&2 echo "NNUE file name not found for: $1"
+  fname="$(basename "$fpath")"
+  sz="$(file_size_bytes "$fpath")"
+  if [ "$sz" -lt "$minsz" ]; then
+    rm -f "$fpath"
     return 1
   fi
 
-  if [ -f "$_filename" ]; then
-    if validate_network "$_filename"; then
-      echo "Existing $_filename validated, skipping download"
-      return
-    else
-      echo "Removing invalid NNUE file: $_filename"
-    fi
+  h12="$(sha256_first12 "$fpath")"
+  if [ "$fname" != "nn-$h12.nnue" ]; then
+    rm -f "$fpath"
+    return 1
   fi
 
-  if [ -z "$wget_or_curl" ]; then
-    >&2 printf "%s\n" "Neither wget or curl is installed." \
-          "Install one of these tools to download NNUE files automatically."
+  return 0
+}
+
+fetch_network() {
+  # $1 macro name, $2 min size
+  macro="$1"
+  minsz="$2"
+
+  fname="$(get_nnue_filename "$macro")"
+  if [ -z "$fname" ]; then
+    >&2 echo "NNUE file name not found for: $macro (in $evaluate_file)"
     exit 1
   fi
 
+  target="$nnue_dir/$fname"
+  link="$src_dir/$fname"
+
+  if [ -f "$target" ]; then
+    if validate_network "$target" "$minsz"; then
+      ln -sf "$target" "$link"
+      echo "Existing $fname validated, skipping download"
+      return 0
+    else
+      echo "Removing invalid NNUE file: $fname"
+      rm -f "$target"
+    fi
+  fi
+
   for url in \
-    "https://tests.stockfishchess.org/api/nn/$_filename" \
-    "https://github.com/official-stockfish/networks/raw/master/$_filename"; do
+    "https://tests.stockfishchess.org/api/nn/$fname" \
+    "https://github.com/official-stockfish/networks/raw/master/$fname"; do
+
     echo "Downloading from $url ..."
-    if $wget_or_curl "$url" > "$_filename"; then
-      if validate_network "$_filename"; then
-        echo "Successfully validated $_filename"
+    if $download_cmd "$url" > "$target"; then
+      if validate_network "$target" "$minsz"; then
+        ln -sf "$target" "$link"
+        echo "Successfully validated $fname"
+        return 0
       else
-        echo "Downloaded $_filename is invalid"
+        echo "Downloaded $fname is invalid"
+        rm -f "$target"
         continue
       fi
     else
       echo "Failed to download from $url"
-    fi
-    if [ -f "$_filename" ]; then
-      return
+      rm -f "$target"
     fi
   done
 
-  # Download was not successful in the loop, return false.
-  >&2 echo "Failed to download $_filename"
-  return 1
+  >&2 echo "Failed to download $fname"
+  exit 1
 }
 
-fetch_network EvalFileDefaultNameBig && \
-fetch_network EvalFileDefaultNameSmall
+# BIG and SMALL (bytes)
+fetch_network EvalFileDefaultNameBig   50000000
+fetch_network EvalFileDefaultNameSmall 1000000

--- a/src/Makefile
+++ b/src/Makefile
@@ -872,6 +872,16 @@ ifeq ($(pext),yes)
 	endif
 endif
 
+### NNUE embedding options (Revolution-compatible)
+NNUE_EMBEDDING_OFF ?= no
+ifneq ($(filter 1 yes true on,$(NNUE_EMBEDDING_OFF)),)
+	NNUE_EMBEDDING_OFF := yes
+	NNUE_TARGET :=
+	CXXFLAGS += -DNNUE_EMBEDDING_OFF
+else
+	NNUE_TARGET := net
+endif
+
 ### 3.8.1 Try to include git commit sha for versioning
 GIT_SHA := $(shell git rev-parse HEAD 2>/dev/null | cut -c 1-8)
 ifneq ($(GIT_SHA), )
@@ -1020,13 +1030,13 @@ endif
 	clang-profile-use clang-profile-make FORCE \
 	format analyze
 
-analyze: net config-sanity objclean
+analyze: $(NNUE_TARGET) config-sanity objclean
 	$(MAKE) -k ARCH=$(ARCH) COMP=$(COMP) $(OBJS)
 
-build: net config-sanity
+build: $(NNUE_TARGET) config-sanity
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) all
 
-profile-build: net config-sanity objclean profileclean
+profile-build: $(NNUE_TARGET) config-sanity objclean profileclean
 	@echo ""
 	@echo "Step 1/4. Building instrumented executable ..."
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) $(profile_make)
@@ -1081,7 +1091,7 @@ format:
 
 all: $(EXE) .depend
 
-config-sanity: net
+config-sanity: $(NNUE_TARGET)
 	@echo ""
 	@echo "Config:" && \
 	echo "debug: '$(debug)'" && \

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -62,11 +62,8 @@ Engine::Engine(std::optional<std::string> path) :
     networks(
       numaContext,
       // Heap-allocate because sizeof(NN::Networks) is large
-      std::make_unique<NN::Networks>(
-        std::make_unique<NN::NetworkBig>(NN::EvalFile{EvalFileDefaultNameBig, "None", ""},
-                                         NN::EmbeddedNNUEType::BIG),
-        std::make_unique<NN::NetworkSmall>(NN::EvalFile{EvalFileDefaultNameSmall, "None", ""},
-                                           NN::EmbeddedNNUEType::SMALL))) {
+      std::make_unique<NN::Networks>(NN::EvalFile{EvalFileDefaultNameBig, "None", ""},
+                                     NN::EvalFile{EvalFileDefaultNameSmall, "None", ""})) {
 
     pos.set(StartFEN, false, &states->back());
 

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -33,7 +33,7 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultNameBig "nn-2962dca31855.nnue"
+#define EvalFileDefaultNameBig "nn-c288c895ea92.nnue"
 #define EvalFileDefaultNameSmall "nn-37f18f62d772.nnue"
 
 namespace NNUE {

--- a/src/misc.h
+++ b/src/misc.h
@@ -23,6 +23,7 @@
 #include <array>
 #include <cassert>
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <cstdio>
 #include <exception>  // IWYU pragma: keep
@@ -135,6 +136,7 @@ class ValueList {
 
    public:
     std::size_t size() const { return size_; }
+    std::ptrdiff_t ssize() const { return static_cast<std::ptrdiff_t>(size_); }
     void        push_back(const T& value) {
         assert(size_ < MaxSize);
         values_[size_++] = value;

--- a/src/nnue/features/full_threats.cpp
+++ b/src/nnue/features/full_threats.cpp
@@ -33,6 +33,8 @@
 
 namespace Stockfish::Eval::NNUE::Features {
 
+namespace {
+
 struct HelperOffsets {
     int cumulativePieceOffset, cumulativeOffset;
 };
@@ -42,8 +44,15 @@ constexpr std::array<Piece, 12> AllPieces = {
   B_PAWN, B_KNIGHT, B_BISHOP, B_ROOK, B_QUEEN, B_KING,
 };
 
+std::array<HelperOffsets, PIECE_NB>                    helper_offsets{};
+std::array<std::array<IndexType, SQUARE_NB>, PIECE_NB> offsets{};
+std::array<std::array<std::array<uint32_t, 2>, PIECE_NB>, PIECE_NB> index_lut1{};
+std::array<std::array<std::array<uint8_t, SQUARE_NB>, SQUARE_NB>, PIECE_NB> index_lut2{};
+
+bool threats_initialized = false;
+
 template<PieceType PT>
-constexpr auto make_piece_indices_type() {
+auto make_piece_indices_type() {
     static_assert(PT != PieceType::PAWN);
 
     std::array<std::array<uint8_t, SQUARE_NB>, SQUARE_NB> out{};
@@ -54,7 +63,7 @@ constexpr auto make_piece_indices_type() {
 
         for (Square to = SQ_A1; to <= SQ_H8; ++to)
         {
-            out[from][to] = constexpr_popcount(((1ULL << to) - 1) & attacks);
+            out[from][to] = popcount(((1ULL << to) - 1) & attacks);
         }
     }
 
@@ -62,7 +71,7 @@ constexpr auto make_piece_indices_type() {
 }
 
 template<Piece P>
-constexpr auto make_piece_indices_piece() {
+auto make_piece_indices_piece() {
     static_assert(type_of(P) == PieceType::PAWN);
 
     std::array<std::array<uint8_t, SQUARE_NB>, SQUARE_NB> out{};
@@ -75,19 +84,19 @@ constexpr auto make_piece_indices_piece() {
 
         for (Square to = SQ_A1; to <= SQ_H8; ++to)
         {
-            out[from][to] = constexpr_popcount(((1ULL << to) - 1) & attacks);
+            out[from][to] = popcount(((1ULL << to) - 1) & attacks);
         }
     }
 
     return out;
 }
 
-constexpr auto index_lut2_array() {
-    constexpr auto KNIGHT_ATTACKS = make_piece_indices_type<PieceType::KNIGHT>();
-    constexpr auto BISHOP_ATTACKS = make_piece_indices_type<PieceType::BISHOP>();
-    constexpr auto ROOK_ATTACKS   = make_piece_indices_type<PieceType::ROOK>();
-    constexpr auto QUEEN_ATTACKS  = make_piece_indices_type<PieceType::QUEEN>();
-    constexpr auto KING_ATTACKS   = make_piece_indices_type<PieceType::KING>();
+auto index_lut2_array() {
+    auto KNIGHT_ATTACKS = make_piece_indices_type<PieceType::KNIGHT>();
+    auto BISHOP_ATTACKS = make_piece_indices_type<PieceType::BISHOP>();
+    auto ROOK_ATTACKS   = make_piece_indices_type<PieceType::ROOK>();
+    auto QUEEN_ATTACKS  = make_piece_indices_type<PieceType::QUEEN>();
+    auto KING_ATTACKS   = make_piece_indices_type<PieceType::KING>();
 
     std::array<std::array<std::array<uint8_t, SQUARE_NB>, SQUARE_NB>, PIECE_NB> indices{};
 
@@ -112,9 +121,9 @@ constexpr auto index_lut2_array() {
     return indices;
 }
 
-constexpr auto init_threat_offsets() {
+auto init_threat_offset_data() {
     std::array<HelperOffsets, PIECE_NB>                    indices{};
-    std::array<std::array<IndexType, SQUARE_NB>, PIECE_NB> offsets{};
+    std::array<std::array<IndexType, SQUARE_NB>, PIECE_NB> offsets_local{};
 
     int cumulativeOffset = 0;
     for (Piece piece : AllPieces)
@@ -124,19 +133,19 @@ constexpr auto init_threat_offsets() {
 
         for (Square from = SQ_A1; from <= SQ_H8; ++from)
         {
-            offsets[pieceIdx][from] = cumulativePieceOffset;
+            offsets_local[pieceIdx][from] = cumulativePieceOffset;
 
             if (type_of(piece) != PAWN)
             {
                 Bitboard attacks = PseudoAttacks[type_of(piece)][from];
-                cumulativePieceOffset += constexpr_popcount(attacks);
+                cumulativePieceOffset += popcount(attacks);
             }
 
             else if (from >= SQ_A2 && from <= SQ_H7)
             {
                 Bitboard attacks = (pieceIdx < 8) ? pawn_attacks_bb<WHITE>(square_bb(from))
                                                   : pawn_attacks_bb<BLACK>(square_bb(from));
-                cumulativePieceOffset += constexpr_popcount(attacks);
+                cumulativePieceOffset += popcount(attacks);
             }
         }
 
@@ -145,14 +154,10 @@ constexpr auto init_threat_offsets() {
         cumulativeOffset += numValidTargets[pieceIdx] * cumulativePieceOffset;
     }
 
-    return std::pair{indices, offsets};
+    return std::pair{indices, offsets_local};
 }
 
-constexpr auto helper_offsets = init_threat_offsets().first;
-// Lookup array for indexing threats
-constexpr auto offsets = init_threat_offsets().second;
-
-constexpr auto init_index_luts() {
+auto init_index_luts() {
     std::array<std::array<std::array<uint32_t, 2>, PIECE_NB>, PIECE_NB> indices{};
 
     for (Piece attacker : AllPieces)
@@ -179,16 +184,30 @@ constexpr auto init_index_luts() {
     return indices;
 }
 
+}  // namespace
+
+void init_threat_offsets() {
+    if (threats_initialized)
+        return;
+
+    auto [indices, offsets_local] = init_threat_offset_data();
+    helper_offsets                = indices;
+    offsets                       = offsets_local;
+
+    index_lut1 = init_index_luts();
+    index_lut2 = index_lut2_array();
+
+    threats_initialized = true;
+}
+
 // The final index is calculated from summing data found in these two LUTs, as well
 // as offsets[attacker][from]
 
 // [attacker][attacked][from < to]
-constexpr auto index_lut1 = init_index_luts();
 // [attacker][from][to]
-constexpr auto index_lut2 = index_lut2_array();
 
 // Index of a feature for a given king position and another piece on some square
-inline sf_always_inline IndexType FullThreats::make_index(
+inline IndexType FullThreats::make_index(
   Color perspective, Piece attacker, Square from, Square to, Piece attacked, Square ksq) {
     const std::int8_t orientation   = OrientTBL[ksq] ^ (56 * perspective);
     unsigned          from_oriented = uint8_t(from) ^ orientation;

--- a/src/nnue/features/full_threats.h
+++ b/src/nnue/features/full_threats.h
@@ -33,6 +33,8 @@ namespace Stockfish::Eval::NNUE::Features {
 static constexpr int numValidTargets[PIECE_NB] = {0, 6, 12, 10, 10, 12, 8, 0,
                                                   0, 6, 12, 10, 10, 12, 8, 0};
 
+void init_threat_offsets();
+
 class FullThreats {
    public:
     // Feature name


### PR DESCRIPTION
### Motivation

- Ensure the repository uses the exact requested Stockfish NNUE filenames and downloads/validates them robustly. 
- Make the NNUE download/install independent of CWD and fail hard when required tools or validations are missing. 
- Add Revolution-compatible Makefile gating so embedding can be disabled and build prerequisites honor that setting.

### Description

- Update default BIG NNUE macro in `src/evaluate.h` to `nn-c288c895ea92.nnue` while keeping the small net macro unchanged. 
- Replace `scripts/net.sh` with a CWD-independent, fail-fast downloader that auto-detects `evaluate.h`, requires `wget` or `curl`, requires `sha256sum`/`shasum` for validation, enforces minimum size thresholds, and creates a symlink into `src/` so the build embedding step can find the files.  The script validates filename by sha256 prefix and removes invalid downloads.
- Add Revolution-compatible NNUE gating block to `src/Makefile` (`NNUE_EMBEDDING_OFF ?= no`) and set `NNUE_TARGET := net` or empty when embedding is disabled, and replace `net` prerequisites with `$(NNUE_TARGET)` for `analyze`, `build`, `profile-build`, and `config-sanity`, keeping the `net` target as the wrapper that calls `../scripts/net.sh`.
- Adjust engine/network construction in `src/engine.cpp` to call `Networks` with `EvalFile` arguments (matching the `Networks` constructor signature) instead of trying to construct `Network` objects inline.
- Convert compile-time FullThreats LUT initialization into a runtime initializer: declare `init_threat_offsets()` in `src/nnue/features/full_threats.h`, implement a lazy `init_threat_offsets()` in `src/nnue/features/full_threats.cpp`, and move previously-constexpr LUTs into runtime-initialized arrays to avoid constexpr/ABI issues.
- Add `ValueList::ssize()` and include `<cstddef>` in `src/misc.h` for signed sizes used by NNUE accumulator code.

Files changed: `src/evaluate.h`, `scripts/net.sh`, `src/Makefile`, `src/engine.cpp`, `src/misc.h`, `src/nnue/features/full_threats.h`, `src/nnue/features/full_threats.cpp`.

### Testing

- `make -C src net` — succeeded; both `nn-c288c895ea92.nnue` and `nn-37f18f62d772.nnue` were validated and placed under `src/nnue/` (the script also created src/ symlinks). (PASS)
- `make -C src build` — succeeded; build completed and produced `src/Wordfish-4.0-230126-sse41popcnt`. (PASS)
- UCI smoke test `./src/Wordfish-4.0-230126-sse41popcnt <<'EOF' ... EOF` — succeeded; engine printed id/options and logged that it is using `nn-c288c895ea92.nnue` and `nn-37f18f62d772.nnue`, then returned a best move. (PASS)
- `make -C src -n build` — dry-run shows the build calls `../scripts/net.sh` and the config output; (PASS)
- `make -C src -n build NNUE_EMBEDDING_OFF=yes` — dry-run shows `-DNNUE_EMBEDDING_OFF` present in `CXXFLAGS` and `$(NNUE_TARGET)` is empty so net is omitted; (PASS)

All automated steps above completed successfully in the test environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697712420378832786a7703dc26b8a7b)