### PR TITLE
Simplify away main history default (upstream 21b0974f8d1603e695aaa8148ba7fcd28bc47704)

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -785,7 +785,7 @@ void Search::Worker::undo_null_move(Position& pos) { pos.undo_null_move(); }
 
 // Reset histories, usually before a new game
 void Search::Worker::clear() {
-    mainHistory.fill(68);
+    mainHistory.fill(0);
     captureHistory.fill(-689);
     pawnHistory.fill(-1238);
     pawnCorrectionHistory.fill(5);


### PR DESCRIPTION
### Motivation
- Align the local code with the upstream intent to eliminate a non-zero main-history baseline and simplify main-history handling.

### Description
- Replace the reset of `mainHistory` in `Search::Worker::clear()` from `mainHistory.fill(68)` to `mainHistory.fill(0)` in `src/search.cpp`.

### Testing
- Ran repository checks to ensure only `src/search.cpp` was modified and that `mainHistoryDefault` no longer appears (commands executed: `git diff -- src/search.cpp`, `rg -n "mainHistoryDefault"`), and both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dc0d56838832791be80f96e103206)