### PR TITLE
Platform-select SHM backend and add Windows stub (shm_win.h)

### DIFF
--- a/src/shm.h
+++ b/src/shm.h
@@ -36,7 +36,9 @@
 #include <utility>
 #include <variant>
 
-#if !defined(_WIN32) && !defined(__ANDROID__)
+#if defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__)
+    #include "shm_win.h"
+#elif !defined(__ANDROID__)
     #include "shm_linux.h"
 #endif
 

--- a/src/shm_win.h
+++ b/src/shm_win.h
@@ -1,0 +1,52 @@
+/*
+  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+  Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
+
+  Stockfish is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Stockfish is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef SHM_WIN_H_INCLUDED
+#define SHM_WIN_H_INCLUDED
+
+#include <string>
+
+namespace Stockfish::shm {
+
+template<typename T>
+class SharedMemory {
+   public:
+    explicit SharedMemory(const std::string&) noexcept {}
+
+    [[nodiscard]] bool open(const T&) noexcept { return false; }
+    void               close() noexcept {}
+
+    [[nodiscard]] bool is_open() const noexcept { return false; }
+    [[nodiscard]] bool is_initialized() const noexcept { return false; }
+
+    [[nodiscard]] const T& get() const noexcept {
+        static const T dummy{};
+        return dummy;
+    }
+};
+
+template<typename T>
+SharedMemory<T> create_shared(const std::string& name, const T& initial_value) {
+    SharedMemory<T> shm(name);
+    shm.open(initial_value);
+    return shm;
+}
+
+}  // namespace Stockfish::shm
+
+#endif


### PR DESCRIPTION
### Motivation
- Fix Windows (MSYS2/MinGW) `profile-build` failures by preventing the Linux SHM backend from being compiled on Windows toolchains. 
- The issue is an include/backend selection for SHM, not NNUE or network evaluation code. 

### Description
- Update `src/shm.h` to select the backend header per-platform: include `shm_win.h` for `defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__)`, otherwise include `shm_linux.h` (Android excluded). 
- Add `src/shm_win.h` as a minimal, safe Windows stub that implements `Stockfish::shm::SharedMemory<T>` and `shm::create_shared()` as no-op / disabled implementations so the engine and `benchmark.cpp` can compile on Windows without real SHM support. 
- Only `src/shm.h` and `src/shm_win.h` were modified/added and no NNUE/evaluation/net code was changed. 

### Testing
- Ran `make -C src clean` and it completed successfully. 
- Ran `make -C src -j4 build ARCH=x86-64-sse41-popcnt COMP=gcc` and the build succeeded producing the normal binary. 
- Ran `make -C src profile-build ARCH=x86-64-sse41-popcnt COMP=gcc`; the build progressed to the PGO benchmark stage but the run failed at benchmark time due to the NNUE network not being loaded at runtime (`ERROR: The network file ... was not loaded successfully`), which is unrelated to the SHM header selection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dcbf81750832781b712d7e5cee4a2)