### PR TITLE
Port SFNNv11 threat-feature architecture and validate NNUE default/PGO

### DIFF
--- a/src/nnue/features/full_threats.h
+++ b/src/nnue/features/full_threats.h
@@ -30,8 +30,8 @@ class Position;
 
 namespace Stockfish::Eval::NNUE::Features {
 
-static constexpr int numValidTargets[PIECE_NB] = {0, 6, 12, 10, 10, 12, 8, 0,
-                                                  0, 6, 12, 10, 10, 12, 8, 0};
+static constexpr int numValidTargets[PIECE_NB] = {0, 6, 10, 8, 8, 10, 8, 0,
+                                                  0, 6, 10, 8, 8, 10, 8, 0};
 
 void init_threat_offsets();
 
@@ -44,7 +44,7 @@ class FullThreats {
     static constexpr std::uint32_t HashValue = 0x8f234cb8u;
 
     // Number of feature dimensions
-    static constexpr IndexType Dimensions = 79856;
+    static constexpr IndexType Dimensions = 66864;
 
     // clang-format off
     // Orient a square according to perspective (rotates by 180 for black)
@@ -61,10 +61,10 @@ class FullThreats {
 
     static constexpr int map[PIECE_TYPE_NB-2][PIECE_TYPE_NB-2] = {
       {0,  1, -1,  2, -1, -1},
-      {0,  1,  2,  3,  4,  5},
-      {0,  1,  2,  3, -1,  4},
-      {0,  1,  2,  3, -1,  4},
-      {0,  1,  2,  3,  4,  5},
+      {0,  1,  2,  3,  4, -1},
+      {0,  1,  2,  3, -1, -1},
+      {0,  1,  2,  3, -1, -1},
+      {0,  1,  2,  3,  4, -1},
       {0,  1,  2,  3, -1, -1}
     };
     // clang-format on


### PR DESCRIPTION
### Motivation
- Update the NNUE threat-feature layout to the SFNNv11 architecture to match Stockfish changes and reduce the big-net size and per-update cost while keeping the engine's default big net usable for benching and PGO.

### Description
- Apply the SFNNv11 threat-feature changes in `src/nnue/features/full_threats.h` by adjusting `numValidTargets` for relevant piece types, reducing `FullThreats::Dimensions` from `79856` to `66864`, and updating the `map` matrix to remove king-target threat slots.
- Leave the final default big network filename set to `nn-3dd094f3dfcf.nnue` so the engine loads the intended net at runtime.
- Only `src/nnue/features/full_threats.h` was modified as part of this PR.

### Testing
- Ran a baseline build with `make -C src -j4 build ARCH=x86-64-sse41-popcnt COMP=gcc` which completed successfully.
- Ran `./src/Wordfish-4.10-120226-sse41popcnt bench` initially which failed with `EXIT_CODE=1` due to the big-net not present (expected during isolation), then after isolation/revert the bench passed with `EXIT_CODE=0`.
- After porting the SFNNv11 changes and restoring the default big net to `nn-3dd094f3dfcf.nnue`, `./src/Wordfish-4.10-120226-sse41popcnt bench` completed with no NNUE errors and `EXIT_CODE=0`.
- Performed `make -C src profile-build ARCH=x86-64-sse41-popcnt COMP=gcc` which completed all PGO steps (Step 1/4 through Step 4/4) successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dcf1630e48327bb0fec6eb485e393)