### PR TITLE
UCI: restore id author for Wordfish

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -157,8 +157,11 @@ std::string engine_version_info() {
 }
 
 std::string engine_info(bool to_uci) {
-    return engine_version_info() + (to_uci ? "\nid author " : " by ")
-         + "the Stockfish developers (see AUTHORS file)";
+    return engine_version_info() + (to_uci ? "" : " by " + engine_author_info());
+}
+
+std::string engine_author_info() {
+    return "Jorge Ruiz and the Stockfish developers (see AUTHORS file)";
 }
 
 

--- a/src/misc.h
+++ b/src/misc.h
@@ -48,6 +48,7 @@ namespace Stockfish {
 
 std::string engine_version_info();
 std::string engine_info(bool to_uci = false);
+std::string engine_author_info();
 std::string compiler_info();
 
 // Prefetch hint enums for explicit call-site control.

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -117,6 +117,7 @@ void UCIEngine::loop() {
         else if (token == "uci")
         {
             sync_cout << "id name " << engine_info(true) << "\n"
+                      << "id author " << engine_author_info() << "\n"
                       << engine.get_options() << sync_endl;
 
             print_info_string(Experience::status_summary());


### PR DESCRIPTION
### Motivation
- The SFNNv13 sync removed the explicit UCI `id author` output, breaking Wordfish branding expectations.
- Restore the author line so `uci` produces both `id name` and `id author` with the expected author string.

### Description
- Added a new declaration `std::string engine_author_info();` in `src/misc.h` next to other engine metadata helpers.
- Implemented `engine_author_info()` in `src/misc.cpp` to return the constant string `"Jorge Ruiz and the Stockfish developers (see AUTHORS file)"` and adjusted `engine_info(bool to_uci)` so UCI mode does not duplicate the author.
- Updated the `uci` handler in `src/uci.cpp` to emit `id author` between `id name` and the engine options output.

### Testing
- Ran `make -C src -j2 build` which completed successfully.
- Executed `printf 'uci\nquit\n' | src/Wordfish-4.10-120226-sse41popcnt | sed -n '1,12p'` and observed the `id author` line present as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c56a8a07083279e13d9255e0458e3)