### PR TITLE
Branding: use ENGINE_NAME for engine_version_info; restore 2-line startup banner

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,7 +28,8 @@
 using namespace Stockfish;
 
 int main(int argc, char* argv[]) {
-    std::cout << engine_info() << std::endl;
+    std::cout << engine_version_info() << std::endl;
+    std::cout << "Developed by " << engine_author_info() << std::endl;
 
     Bitboards::init();
     Position::init();

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -125,6 +125,10 @@ class Logger {
 // For releases (non-dev builds) we only include the version number:
 //      Stockfish version
 std::string engine_version_info() {
+#ifdef ENGINE_NAME
+    return ENGINE_NAME;
+#endif
+
     std::stringstream ss;
     ss << "Stockfish " << version << std::setfill('0');
 
@@ -157,7 +161,7 @@ std::string engine_version_info() {
 }
 
 std::string engine_info(bool to_uci) {
-    return engine_version_info() + (to_uci ? "" : " by " + engine_author_info());
+    return engine_version_info() + (to_uci ? "\nid author " : " by ") + engine_author_info();
 }
 
 std::string engine_author_info() {

--- a/src/misc.h
+++ b/src/misc.h
@@ -46,9 +46,9 @@
 
 namespace Stockfish {
 
+std::string engine_author_info();
 std::string engine_version_info();
 std::string engine_info(bool to_uci = false);
-std::string engine_author_info();
 std::string compiler_info();
 
 // Prefetch hint enums for explicit call-site control.


### PR DESCRIPTION
### Motivation
- Restore Wordfish branding that was lost after the SFNNv13 sync so the compiled `ENGINE_NAME` is reported instead of the upstream-hardcoded "Stockfish ..." string. 
- Ensure UCI `id name`/`id author` and the startup banner show the engine name and the proper author line.

### Description
- Updated `src/misc.h` to ensure the `Stockfish` namespace declares `engine_author_info()`, `engine_version_info()`, and `engine_info(bool to_uci = false)`.
- Modified `src/misc.cpp` so `engine_version_info()` returns `ENGINE_NAME` when the macro is defined, preserving the original fallback logic otherwise.
- Changed `src/misc.cpp` so `engine_info(bool to_uci)` builds the UCI multi-line author form using `engine_author_info()` (returns the Jorge Ruiz + Stockfish developers string).
- Replaced the single-line startup print in `src/main.cpp` with two lines that print `engine_version_info()` and `Developed by ` + `engine_author_info()`.

### Testing
- Ran `make -C src -j2 build`, which completed successfully. 
- Ran `printf 'uci\nquit\n' | ./src/Wordfish-4.20-230226-sse41popcnt | head -n 8` to validate UCI output, which produced the expected two-line startup banner and `id` lines and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c5fbc4d3c83278b3ca933269b47d5)