### PR TITLE
UCI: remove duplicate id author line

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -117,7 +117,6 @@ void UCIEngine::loop() {
         else if (token == "uci")
         {
             sync_cout << "id name " << engine_info(true) << "\n"
-                      << "id author " << engine_author_info() << "\n"
                       << engine.get_options() << sync_endl;
 
             print_info_string(Experience::status_summary());


### PR DESCRIPTION
### Motivation
- The UCI identification printed two identical `id author` lines because `engine_info(true)` already includes author information, so the duplicate should be removed.

### Description
- Removed the explicit `<< "id author " << engine_author_info() << "\n"` from the `uci` command handler in `src/uci.cpp` so output now relies on `engine_info(true)` plus `engine.get_options()`.

### Testing
- Built the project with `make -C src -j2 build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c633b55048327b611e1ad314cc83a)