### PR TITLE
Simplify attackers_to_exist function

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -500,13 +500,10 @@ Bitboard Position::attackers_to(Square s, Bitboard occupied) const {
 
 bool Position::attackers_to_exist(Square s, Bitboard occupied, Color c) const {
 
-    return ((attacks_bb<ROOK>(s) & pieces(c, ROOK, QUEEN))
-            && (attacks_bb<ROOK>(s, occupied) & pieces(c, ROOK, QUEEN)))
-        || ((attacks_bb<BISHOP>(s) & pieces(c, BISHOP, QUEEN))
-            && (attacks_bb<BISHOP>(s, occupied) & pieces(c, BISHOP, QUEEN)))
-        || (((attacks_bb<PAWN>(s, ~c) & pieces(PAWN)) | (attacks_bb<KNIGHT>(s) & pieces(KNIGHT))
-             | (attacks_bb<KING>(s) & pieces(KING)))
-            & pieces(c));
+    return (attacks_bb<ROOK>(s, occupied) & pieces(c, ROOK, QUEEN))
+        || (attacks_bb<BISHOP>(s, occupied) & pieces(c, BISHOP, QUEEN))
+        || (attacks_bb<PAWN>(s, ~c) & pieces(c, PAWN))
+        || (attacks_bb<KNIGHT>(s) & pieces(c, KNIGHT)) || (attacks_bb<KING>(s) & pieces(c, KING));
 }
 
 // Tests whether a pseudo-legal move is legal


### PR DESCRIPTION
### Motivation
- Bring the local implementation of `Position::attackers_to_exist()` in line with the upstream simplification to make slider checks use the provided `occupied` bitboard and to simplify the combined attacker test.

### Description
- Replaced the return expression of `Position::attackers_to_exist(Square s, Bitboard occupied, Color c)` with the simplified form from upstream, using `attacks_bb<ROOK/BISHOP>(s, occupied)` for sliders and combining pawn/knight/king checks directly.
- Edited only `src/position.cpp` and made no other changes to formatting, includes, or other files.

### Testing
- Ran `git diff -- src/position.cpp` and confirmed only `src/position.cpp` changed with a net of `+4/-7` lines.
- Built the project with `make -C src -j build` and the build completed successfully.
- Inspected the new HEAD and the change appears as a single-file update implementing the simplified return expression.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6b96265b48327954e6fd359bb2aee)