### PR TITLE
Perf: cache NNUE verify + deterministic Brainlearnjrc build naming

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -39,7 +39,8 @@ else ifeq ($(COMP),mingw)
 endif
 
 ### Executable name
-RELEASE_TAG ?= 4.30-030326
+ENGINE_BASE := Brainlearnjrc
+ENGINE_VERSION := 1.70-030326
 
 ### Installation dir definitions
 PREFIX = /usr/local
@@ -146,23 +147,25 @@ else
 endif
 
 ifeq ($(ARCH),x86-64-sse41-popcnt)
-        BUILD_ARCH_SUFFIX := -sse41popcnt
+	ARCH_SUFFIX := sse41popcnt
 else ifeq ($(ARCH),x86-64-avx2)
-        BUILD_ARCH_SUFFIX := -avx2
+	ARCH_SUFFIX := avx2
 else ifeq ($(ARCH),x86-64-bmi2)
-        BUILD_ARCH_SUFFIX := -bmi2
+	ARCH_SUFFIX := bmi2
 else ifeq ($(ARCH),x86-64-fma3)
-        BUILD_ARCH_SUFFIX := -FMA3
+	ARCH_SUFFIX := FMA3
 else ifeq ($(ARCH),x86-64-avx512)
-        BUILD_ARCH_SUFFIX := -avx512
+	ARCH_SUFFIX := avx512
 else
-        BUILD_ARCH_SUFFIX := -$(ARCH)
+	$(error Unsupported ARCH '$(ARCH)'. Supported: x86-64-sse41-popcnt x86-64-avx2 x86-64-bmi2 x86-64-fma3 x86-64-avx512)
 endif
 
+ENGINE_ID := $(ENGINE_BASE)-$(ENGINE_VERSION)-$(ARCH_SUFFIX)
+
 ifeq ($(target_windows),yes)
-	EXE = Wordfish-$(RELEASE_TAG)$(BUILD_ARCH_SUFFIX).exe
+	EXE = $(ENGINE_ID).exe
 else
-	EXE = Wordfish-$(RELEASE_TAG)$(BUILD_ARCH_SUFFIX)
+	EXE = $(ENGINE_ID)
 endif
 
 optimize = yes
@@ -467,6 +470,7 @@ ifeq ($(MAKELEVEL),0)
 endif
 
 CXXFLAGS = $(ENV_CXXFLAGS) -Wall -Wcast-qual -fno-exceptions -std=c++17 $(EXTRACXXFLAGS)
+CXXFLAGS += -DENGINE_ID_STRING=\"$(ENGINE_ID)\"
 DEPENDFLAGS = $(ENV_DEPENDFLAGS) -std=c++17
 LDFLAGS = $(ENV_LDFLAGS) $(EXTRALDFLAGS)
 

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -212,6 +212,7 @@ std::uint64_t Engine::perft(const std::string& fen, Depth depth, bool isChess960
 void Engine::go(Search::LimitsType& limits) {
     assert(limits.perft == 0);
     verify_networks();
+    threads.ensure_network_replicated();
 
     const bool searchRequested = limits.depth || limits.nodes || limits.mate || limits.infinite
                                  || limits.ponderMode || !limits.searchmoves.empty();
@@ -268,6 +269,7 @@ void Engine::set_on_bestmove(std::function<void(std::string_view, std::string_vi
 
 void Engine::set_on_verify_networks(std::function<void(std::string_view)>&& f) {
     onVerifyNetworks = std::move(f);
+    networksNeedVerification = true;
 }
 
 void Engine::wait_for_search_finished() { threads.main_thread()->wait_for_search_finished(); }
@@ -334,6 +336,9 @@ void Engine::set_ponderhit(bool b) { threads.main_manager()->ponder = b; }
 // network related
 
 void Engine::verify_networks() const {
+    if (!networksNeedVerification)
+        return;
+
     networks->big.verify(options["EvalFile"], onVerifyNetworks);
     networks->small.verify(options["EvalFileSmall"], onVerifyNetworks);
 
@@ -366,6 +371,8 @@ void Engine::verify_networks() const {
 
         onVerifyNetworks(message);
     }
+
+    networksNeedVerification = false;
 }
 
 void Engine::load_networks() {
@@ -375,6 +382,7 @@ void Engine::load_networks() {
     });
     threads.clear();
     threads.ensure_network_replicated();
+    networksNeedVerification = true;
 }
 
 void Engine::load_big_network(const std::string& file) {
@@ -382,6 +390,7 @@ void Engine::load_big_network(const std::string& file) {
       [this, &file](NN::Networks& networks_) { networks_.big.load(binaryDirectory, file); });
     threads.clear();
     threads.ensure_network_replicated();
+    networksNeedVerification = true;
 }
 
 void Engine::load_small_network(const std::string& file) {
@@ -389,6 +398,7 @@ void Engine::load_small_network(const std::string& file) {
       [this, &file](NN::Networks& networks_) { networks_.small.load(binaryDirectory, file); });
     threads.clear();
     threads.ensure_network_replicated();
+    networksNeedVerification = true;
 }
 
 void Engine::save_network(const std::pair<std::optional<std::string>, std::string> files[2]) {

--- a/src/engine.h
+++ b/src/engine.h
@@ -123,6 +123,7 @@ class Engine {
 
     Search::SearchManager::UpdateContext  updateContext;
     std::function<void(std::string_view)> onVerifyNetworks;
+    mutable bool                           networksNeedVerification = true;
 };
 
 }  // namespace Stockfish

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -131,6 +131,9 @@ class Logger {
 
 
 std::string engine_version_info() {
+#ifdef ENGINE_ID_STRING
+    return ENGINE_ID_STRING;
+#endif
     return std::string(base) + "-" + std::string(arch_tag());
 }
 


### PR DESCRIPTION
### Motivation
- Reduce repeated NNUE verification work and ensure pre-search network warmup to avoid runtime stalls.  
- Provide deterministic, architecture-tagged executable names and UCI engine id strings so every supported ARCH build produces an exact `Brainlearnjrc-1.70-030326-<suffix>` identifier and unsupported ARCHs fail early.  

### Description
- Add a verification cache flag `mutable bool networksNeedVerification` to `Engine` and use it to short-circuit `Engine::verify_networks()` when verification is not required.  
- Invalidate the cache when networks or the verify callback are replaced (`set_on_verify_networks`, `load_networks`, `load_big_network`, `load_small_network`).  
- Trigger a pre-search warmup by calling `threads.ensure_network_replicated()` immediately after `verify_networks()` in `Engine::go()`.  
- Centralize deterministic naming in the Makefile by introducing `ENGINE_BASE := Brainlearnjrc` and `ENGINE_VERSION := 1.70-030326`, mapping `ARCH` to an exact `ARCH_SUFFIX` for: `x86-64-sse41-popcnt`, `x86-64-avx2`, `x86-64-bmi2`, `x86-64-fma3`, and `x86-64-avx512`, and making unsupported `ARCH` values fail with `$(error ...)`.  
- Generate `ENGINE_ID := $(ENGINE_BASE)-$(ENGINE_VERSION)-$(ARCH_SUFFIX)`, set the final `EXE = $(ENGINE_ID)$(.exe if windows)`, and export the id into the compiler flags via `-DENGINE_ID_STRING="$(ENGINE_ID)"`.  
- Make `engine_version_info()` return the compile-time `ENGINE_ID_STRING` when defined so the UCI `id name` prints the exact deterministic engine id.  

### Testing
- Ran the build and verification sequence: `make -C src clean` and `make -C src -j build ARCH=<arch>` for each of `x86-64-sse41-popcnt`, `x86-64-avx2`, `x86-64-bmi2`, `x86-64-fma3`, and `x86-64-avx512`, and each build completed successfully.  
- Confirmed each produced binary prints the exact UCI id with `printf "uci\nquit\n" | ./src/Brainlearnjrc-1.70-030326-<suffix>` and observed `id name Brainlearnjrc-1.70-030326-<suffix>` for all five suffixes.  
- Verified that builds include the `-DENGINE_ID_STRING` define in `CXXFLAGS` and that no runtime fallback to `unknown` is used for the UCI id.  
- All automated build steps and UCI id checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6c17dfbf08327818267467e36e6bf)