### PR TITLE
Use RELEASE_TAG/BUILD_ARCH_SUFFIX for binary naming, remove ENGINE_ID_STRING, and reorder network replication

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -39,8 +39,7 @@ else ifeq ($(COMP),mingw)
 endif
 
 ### Executable name
-ENGINE_BASE := Brainlearnjrc
-ENGINE_VERSION := 1.70-030326
+RELEASE_TAG ?= 4.30-030326
 
 ### Installation dir definitions
 PREFIX = /usr/local
@@ -147,25 +146,23 @@ else
 endif
 
 ifeq ($(ARCH),x86-64-sse41-popcnt)
-	ARCH_SUFFIX := sse41popcnt
+        BUILD_ARCH_SUFFIX := -sse41popcnt
 else ifeq ($(ARCH),x86-64-avx2)
-	ARCH_SUFFIX := avx2
+        BUILD_ARCH_SUFFIX := -avx2
 else ifeq ($(ARCH),x86-64-bmi2)
-	ARCH_SUFFIX := bmi2
+        BUILD_ARCH_SUFFIX := -bmi2
 else ifeq ($(ARCH),x86-64-fma3)
-	ARCH_SUFFIX := FMA3
+        BUILD_ARCH_SUFFIX := -FMA3
 else ifeq ($(ARCH),x86-64-avx512)
-	ARCH_SUFFIX := avx512
+        BUILD_ARCH_SUFFIX := -avx512
 else
-	$(error Unsupported ARCH '$(ARCH)'. Supported: x86-64-sse41-popcnt x86-64-avx2 x86-64-bmi2 x86-64-fma3 x86-64-avx512)
+        BUILD_ARCH_SUFFIX := -$(ARCH)
 endif
 
-ENGINE_ID := $(ENGINE_BASE)-$(ENGINE_VERSION)-$(ARCH_SUFFIX)
-
 ifeq ($(target_windows),yes)
-	EXE = $(ENGINE_ID).exe
+	EXE = Wordfish-$(RELEASE_TAG)$(BUILD_ARCH_SUFFIX).exe
 else
-	EXE = $(ENGINE_ID)
+	EXE = Wordfish-$(RELEASE_TAG)$(BUILD_ARCH_SUFFIX)
 endif
 
 optimize = yes
@@ -470,7 +467,6 @@ ifeq ($(MAKELEVEL),0)
 endif
 
 CXXFLAGS = $(ENV_CXXFLAGS) -Wall -Wcast-qual -fno-exceptions -std=c++17 $(EXTRACXXFLAGS)
-CXXFLAGS += -DENGINE_ID_STRING=\"$(ENGINE_ID)\"
 DEPENDFLAGS = $(ENV_DEPENDFLAGS) -std=c++17
 LDFLAGS = $(ENV_LDFLAGS) $(EXTRALDFLAGS)
 

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -381,24 +381,24 @@ void Engine::load_networks() {
         networks_.small.load(binaryDirectory, options["EvalFileSmall"]);
     });
     threads.clear();
-    threads.ensure_network_replicated();
     networksNeedVerification = true;
+    threads.ensure_network_replicated();
 }
 
 void Engine::load_big_network(const std::string& file) {
     networks.modify_and_replicate(
       [this, &file](NN::Networks& networks_) { networks_.big.load(binaryDirectory, file); });
     threads.clear();
-    threads.ensure_network_replicated();
     networksNeedVerification = true;
+    threads.ensure_network_replicated();
 }
 
 void Engine::load_small_network(const std::string& file) {
     networks.modify_and_replicate(
       [this, &file](NN::Networks& networks_) { networks_.small.load(binaryDirectory, file); });
     threads.clear();
-    threads.ensure_network_replicated();
     networksNeedVerification = true;
+    threads.ensure_network_replicated();
 }
 
 void Engine::save_network(const std::pair<std::optional<std::string>, std::string> files[2]) {

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -131,9 +131,6 @@ class Logger {
 
 
 std::string engine_version_info() {
-#ifdef ENGINE_ID_STRING
-    return ENGINE_ID_STRING;
-#endif
     return std::string(base) + "-" + std::string(arch_tag());
 }
 


### PR DESCRIPTION
### Motivation

- Standardize release tagging and binary names via a `RELEASE_TAG` and a normalized architecture suffix variable instead of embedding an engine id/version macro. 
- Avoid embedding an `ENGINE_ID_STRING` into build flags so the runtime version string is produced from runtime data. 
- Ensure networks replication is performed after the engine marks networks as needing verification to avoid potential ordering/race issues.

### Description

- Introduce `RELEASE_TAG` and `BUILD_ARCH_SUFFIX` in `src/Makefile` and change the produced executable name to `Wordfish-$(RELEASE_TAG)$(BUILD_ARCH_SUFFIX)(.exe)` instead of using `ENGINE_ID`/`ENGINE_VERSION`/`ENGINE_BASE`.
- Replace the previous `ARCH_SUFFIX` logic with `BUILD_ARCH_SUFFIX` mappings and a default fallback that uses `-$(ARCH)`.
- Remove the `-DENGINE_ID_STRING=...` injection from `CXXFLAGS` so the build no longer forces a compile-time engine id string.
- Update `src/misc.cpp` to stop returning `ENGINE_ID_STRING` in `engine_version_info()` and instead return `base + '-' + arch_tag()`.
- Reorder calls in `src/engine.cpp` so that `threads.ensure_network_replicated()` is called after `networksNeedVerification = true` in `load_networks()`, `load_big_network()` and `load_small_network()`.

### Testing

- Built the project via `make` on x86-64 (gcc) and the build completed successfully and produced `Wordfish-$(RELEASE_TAG)$(BUILD_ARCH_SUFFIX)` binaries.
- Performed a runtime smoke check by invoking the built binary to inspect the version output and confirmed the `engine_version_info()` string uses the runtime base and architecture tag as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6c7adf16c8327b431d0740bf115ac)