### PR TITLE
NNUE: combine hashes, remove weight scaling, use 0..255 clipping; fix threat bitset; update nets and benchmark

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -64,6 +64,7 @@ const std::vector<std::string> Defaults = {
   "r3k2r/3nnpbp/q2pp1p1/p7/Pp1PPPP1/4BNN1/1P5P/R2Q1RK1 w kq - 0 16",
   "3Qb1k1/1r2ppb1/pN1n2q1/Pp1Pp1Pr/4P2p/4BP2/4B1R1/1R5K b - - 11 40",
   "4k3/3q1r2/1N2r1b1/3ppN2/2nPP3/1B1R2n1/2R1Q3/3K4 w - - 5 1",
+  "1r6/1P4bk/3qr1p1/N6p/3pp2P/6R1/3Q1PP1/1R4K1 w - - 1 42",
 
   // Positions with high numbers of changed threats
   "k7/2n1n3/1nbNbn2/2NbRBn1/1nbRQR2/2NBRBN1/3N1N2/7K w - - 0 1",

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -33,8 +33,8 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultNameBig "nn-5227780996d3.nnue"
-#define EvalFileDefaultNameSmall "nn-37f18f62d772.nnue"
+#define EvalFileDefaultNameBig "nn-9a0cc2a62c52.nnue"
+#define EvalFileDefaultNameSmall "nn-47fc8b7fff06.nnue"
 
 namespace NNUE {
 struct Networks;

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -122,9 +122,20 @@ class FeatureTransformer {
 
     static constexpr auto InversePackusEpi16Order = invert_permutation(PackusEpi16Order);
 
+    static constexpr std::uint32_t combine_hash(std::initializer_list<std::uint32_t> hashes) {
+        std::uint32_t hash = 0;
+        for (const auto component_hash : hashes)
+        {
+            hash = (hash << 1) | (hash >> 31);
+            hash ^= component_hash;
+        }
+        return hash;
+    }
+
     // Hash value embedded in the evaluation file
     static constexpr std::uint32_t get_hash_value() {
-        return (UseThreats ? ThreatFeatureSet::HashValue : PSQFeatureSet::HashValue)
+        return (UseThreats ? combine_hash({ThreatFeatureSet::HashValue, PSQFeatureSet::HashValue})
+                           : PSQFeatureSet::HashValue)
              ^ (OutputDimensions * 2);
     }
 
@@ -142,13 +153,6 @@ class FeatureTransformer {
 
         if constexpr (UseThreats)
             permute<8>(threatWeights, InversePackusEpi16Order);
-    }
-
-    inline void scale_weights(bool read) {
-        for (auto& w : weights)
-            w = read ? w * 2 : w / 2;
-        for (auto& b : biases)
-            b = read ? b * 2 : b / 2;
     }
 
     // Read network parameters
@@ -171,9 +175,6 @@ class FeatureTransformer {
 
         permute_weights();
 
-        if constexpr (!UseThreats)
-            scale_weights(true);
-
         return !stream.fail();
     }
 
@@ -182,9 +183,6 @@ class FeatureTransformer {
         std::unique_ptr<FeatureTransformer> copy = std::make_unique<FeatureTransformer>(*this);
 
         copy->unpermute_weights();
-
-        if constexpr (!UseThreats)
-            copy->scale_weights(false);
 
         write_leb_128<BiasType>(stream, copy->biases);
 
@@ -277,7 +275,7 @@ class FeatureTransformer {
             constexpr IndexType NumOutputChunks = HalfDimensions / 2 / OutputChunkSize;
 
             const vec_t Zero = vec_zero();
-            const vec_t One  = vec_set_16(UseThreats ? 255 : 127 * 2);
+            const vec_t One  = vec_set_16(255);
 
             const vec_t* in0 = reinterpret_cast<const vec_t*>(&(accumulation[perspectives[p]][0]));
             const vec_t* in1 =
@@ -397,17 +395,13 @@ class FeatureTransformer {
 
                 if constexpr (UseThreats)
                 {
-                    BiasType sum0t = threatAccumulation[static_cast<int>(perspectives[p])][j + 0];
-                    BiasType sum1t =
+                    sum0 += threatAccumulation[static_cast<int>(perspectives[p])][j + 0];
+                    sum1 +=
                       threatAccumulation[static_cast<int>(perspectives[p])][j + HalfDimensions / 2];
-                    sum0 = std::clamp<BiasType>(sum0 + sum0t, 0, 255);
-                    sum1 = std::clamp<BiasType>(sum1 + sum1t, 0, 255);
                 }
-                else
-                {
-                    sum0 = std::clamp<BiasType>(sum0, 0, 127 * 2);
-                    sum1 = std::clamp<BiasType>(sum1, 0, 127 * 2);
-                }
+
+                sum0 = std::clamp<BiasType>(sum0, 0, 255);
+                sum1 = std::clamp<BiasType>(sum1, 0, 255);
 
                 output[offset + j] = static_cast<OutputType>(unsigned(sum0 * sum1) / 512);
             }

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1043,7 +1043,9 @@ inline void add_dirty_threat(
     if (PutPiece)
     {
         dts->threatenedSqs |= square_bb(threatenedSq);
-        dts->threateningSqs |= square_bb(s);
+        // A bit may only be set if that square actually produces a threat, so we
+        // must guard setting the square accordingly
+        dts->threateningSqs |= Bitboard(bool(threatened)) << s;
     }
 
     dts->list.push_back({pc, threatened, s, threatenedSq, PutPiece});


### PR DESCRIPTION
### Motivation
- Support a combined NNUE/PSQT hash for evaluation files and remove legacy weight-scaling workarounds when threat features are enabled.
- Make feature clipping consistent (use full 0..255 range) for both vectorized and scalar paths to match the combined-threat feature layout.
- Fix an incorrect bit being set in the threat bitsets when no threatened piece exists and add a benchmark position.

### Description
- Updated default network filenames `EvalFileDefaultNameBig` and `EvalFileDefaultNameSmall` to new NNUE filenames.
- Added `combine_hash` and changed `get_hash_value()` to XOR a combined `ThreatFeatureSet::HashValue` and `PSQFeatureSet::HashValue` when `UseThreats` is enabled.
- Removed `scale_weights()` and eliminated weight scaling during `read_parameters()` / `write_parameters()` to reflect the new parameter layout.
- Standardized clipping to 0..255 by setting the vector `One` to `255` and clamping scalar accumulators to `255`, and merged threat accumulations into the main sums before clipping; preserved the final accumulation/division behavior.
- Fixed `add_dirty_threat()` so `threateningSqs` only sets a bit when there is an actual threatened piece via `Bitboard(bool(threatened)) << s` instead of unconditionally setting `square_bb(s)`.
- Added one FEN to the `Defaults` list in `src/benchmark.cpp`.

### Testing
- Built the project with `make`; the build completed successfully.
- Executed the unit/regression test suite and NNUE serialization/deserialize checks; all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b04de0e7a48327aa46de3af8afd390)