### PR TITLE
Fix Playchess/Syzygy UCI bestmove latency: gate root TB, instance callbacks, atomic bestmove

### DIFF
--- a/docs/playchess_tb_latency.md
+++ b/docs/playchess_tb_latency.md
@@ -1,0 +1,31 @@
+# Playchess Syzygy bestmove latency repro
+
+This patch targets a Playchess timeout pattern seen when a Syzygy root hit returns a bestmove in a very low-time search.
+
+## Real Windows-oriented repro
+
+Use a native Windows build and real 6-man KRBvKRB Syzygy files for the authoritative repro:
+
+```powershell
+python tests/uci_latency_harness.py --engine .\src\<WORDFISH_BINARY>.exe --syzygy-path <real_6man_syzygy_path> --iterations 1000 --warmup 5 --wtime 200 500 1000 --fen "8/8/4k3/8/8/1r1K1B2/1b6/5R2 w - - 0 86" "8/8/6B1/7R/8/4b1k1/r7/4K3 w - - 84 128" --assert-max-ms 20 --json artifacts\playchess_syzygy_latency.json
+```
+
+## Local smoke coverage
+
+Container or Linux runs are only smoke coverage. They are useful for checking that the engine still answers quickly with local Syzygy files, but they do not replace the real Windows + Playchess repro.
+
+Example smoke command:
+
+```bash
+python3 tests/uci_latency_harness.py \
+  --engine src/<WORDFISH_BINARY_NAME> \
+  --syzygy-path <local_test_syzygy_path> \
+  --iterations 20 \
+  --warmup 5 \
+  --wtime 200 500 1000 \
+  --fen '4k3/PP6/8/8/8/8/8/4K3 w - - 0 1' \
+  --assert-max-ms 50 \
+  --json artifacts/uci_latency_4man_after.json
+```
+
+The real Playchess issue requires the actual 6-man KRBvKRB Syzygy set.

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -266,7 +266,10 @@ void ThreadPool::start_thinking(const OptionsMap&  options,
         for (const auto& m : legalmoves)
             rootMoves.emplace_back(m);
 
-    Tablebases::Config tbConfig = Tablebases::rank_root_moves(options, pos, rootMoves);
+    Tablebases::Config tbConfig;
+
+    if (!limits.infinite && !limits.ponderMode)
+        tbConfig = Tablebases::rank_root_moves(options, pos, rootMoves);
 
     Experience::on_new_position(pos, rootMoves);
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -79,11 +79,11 @@ UCIEngine::UCIEngine(int argc, char** argv) :
 }
 
 void UCIEngine::init_search_update_listeners() {
-    engine.set_on_iter([](const auto& i) { on_iter(i); });
-    engine.set_on_update_no_moves([](const auto& i) { on_update_no_moves(i); });
+    engine.set_on_iter([this](const auto& i) { on_iter(i); });
+    engine.set_on_update_no_moves([this](const auto& i) { on_update_no_moves(i); });
     engine.set_on_update_full(
-      [this](const auto& i) { on_update_full(i, engine.get_options()["UCI_ShowWDL"]); });
-    engine.set_on_bestmove([](const auto& bm, const auto& p) { on_bestmove(bm, p); });
+      [this](const auto& i) { on_update_full(i); });
+    engine.set_on_bestmove([this](const auto& bm, const auto& p) { on_bestmove(bm, p); });
     engine.set_on_verify_networks([](const auto& s) { print_info_string(s); });
 }
 
@@ -332,6 +332,10 @@ Search::LimitsType UCIEngine::parse_limits(std::istream& is) {
 void UCIEngine::go(std::istringstream& is) {
 
     Search::LimitsType limits = parse_limits(is);
+    suppressLowTimeInfo       = !limits.infinite && !limits.ponderMode
+                           && ((limits.time[WHITE] && limits.time[WHITE] <= 1000)
+                               || (limits.time[BLACK] && limits.time[BLACK] <= 1000)
+                               || (limits.movetime && limits.movetime <= 1000));
 
     if (limits.perft)
         perft(limits);
@@ -343,11 +347,9 @@ void UCIEngine::bench(std::istream& args) {
     std::string token;
     uint64_t    num, nodes = 0, cnt = 1;
     uint64_t    nodesSearched = 0;
-    const auto& options       = engine.get_options();
-
     engine.set_on_update_full([&](const auto& i) {
         nodesSearched = i.nodes;
-        on_update_full(i, options["UCI_ShowWDL"]);
+        on_update_full(i);
     });
 
     std::vector<std::string> list = Benchmark::setup_bench(engine.fen(), args);
@@ -405,7 +407,7 @@ void UCIEngine::bench(std::istream& args) {
               << "\nNodes/second    : " << 1000 * nodes / elapsed << std::endl;
 
     // reset callback, to not capture a dangling reference to nodesSearched
-    engine.set_on_update_full([&](const auto& i) { on_update_full(i, options["UCI_ShowWDL"]); });
+    engine.set_on_update_full([this](const auto& i) { on_update_full(i); });
 }
 
 void UCIEngine::benchmark(std::istream& args) {
@@ -730,10 +732,17 @@ Move UCIEngine::to_move(const Position& pos, std::string str) {
 }
 
 void UCIEngine::on_update_no_moves(const Engine::InfoShort& info) {
+    if (suppressLowTimeInfo)
+        return;
+
     sync_cout << "info depth " << info.depth << " score " << format_score(info.score) << sync_endl;
 }
 
-void UCIEngine::on_update_full(const Engine::InfoFull& info, bool showWDL) {
+void UCIEngine::on_update_full(const Engine::InfoFull& info) {
+    if (suppressLowTimeInfo)
+        return;
+
+    const bool showWDL = engine.get_options()["UCI_ShowWDL"];
     std::stringstream ss;
 
     ss << "info";
@@ -759,6 +768,9 @@ void UCIEngine::on_update_full(const Engine::InfoFull& info, bool showWDL) {
 }
 
 void UCIEngine::on_iter(const Engine::InfoIter& info) {
+    if (suppressLowTimeInfo)
+        return;
+
     std::stringstream ss;
 
     ss << "info";
@@ -770,10 +782,9 @@ void UCIEngine::on_iter(const Engine::InfoIter& info) {
 }
 
 void UCIEngine::on_bestmove(std::string_view bestmove, std::string_view ponder) {
-    sync_cout << "bestmove " << bestmove;
-    if (!ponder.empty())
-        std::cout << " ponder " << ponder;
-    std::cout << sync_endl;
+    sync_cout << "bestmove " << bestmove
+              << (ponder.empty() ? "" : " ponder ")
+              << (ponder.empty() ? std::string_view{} : ponder) << sync_endl;
 }
 
 }  // namespace Stockfish

--- a/src/uci.h
+++ b/src/uci.h
@@ -58,6 +58,8 @@ class UCIEngine {
     Engine      engine;
     CommandLine cli;
 
+    bool suppressLowTimeInfo = false;
+
     static void print_info_string(std::string_view str);
 
     void          go(std::istringstream& is);
@@ -67,10 +69,10 @@ class UCIEngine {
     void          setoption(std::istringstream& is);
     std::uint64_t perft(const Search::LimitsType&);
 
-    static void on_update_no_moves(const Engine::InfoShort& info);
-    static void on_update_full(const Engine::InfoFull& info, bool showWDL);
-    static void on_iter(const Engine::InfoIter& info);
-    static void on_bestmove(std::string_view bestmove, std::string_view ponder);
+    void on_update_no_moves(const Engine::InfoShort& info);
+    void on_update_full(const Engine::InfoFull& info);
+    void on_iter(const Engine::InfoIter& info);
+    void on_bestmove(std::string_view bestmove, std::string_view ponder);
 
     void init_search_update_listeners();
 };

--- a/tests/uci_latency_harness.py
+++ b/tests/uci_latency_harness.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import statistics
+import subprocess
+import time
+from pathlib import Path
+
+
+def send(proc, line):
+    proc.stdin.write((line + "\n").encode("utf-8"))
+    proc.stdin.flush()
+
+
+def read_until(proc, predicate, timeout):
+    deadline = time.monotonic() + timeout
+    lines = []
+    while time.monotonic() < deadline:
+        line = proc.stdout.readline().decode("utf-8", errors="replace").rstrip("\r\n")
+        if not line:
+            continue
+        lines.append(line)
+        if predicate(line):
+            return lines
+    raise TimeoutError(f"Timed out waiting for engine output: {lines[-10:]}")
+
+
+def launch_engine(engine_path):
+    return subprocess.Popen(
+        [str(engine_path)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        bufsize=0,
+    )
+
+
+def handshake(proc, syzygy_path):
+    send(proc, "uci")
+    read_until(proc, lambda line: line == "uciok", 10.0)
+    send(proc, f"setoption name SyzygyPath value {syzygy_path}")
+    send(proc, "isready")
+    read_until(proc, lambda line: line == "readyok", 10.0)
+
+
+def run_case(proc, fen, wtime_ms):
+    send(proc, f"position fen {fen}")
+    send(proc, f"go wtime {wtime_ms} btime {wtime_ms}")
+    started = time.perf_counter_ns()
+    lines = read_until(proc, lambda line: line.startswith("bestmove "), 10.0)
+    elapsed_ms = (time.perf_counter_ns() - started) / 1_000_000.0
+    bestmove = next(line for line in reversed(lines) if line.startswith("bestmove "))
+    return {"fen": fen, "wtime": wtime_ms, "latency_ms": elapsed_ms, "bestmove": bestmove}
+
+
+def summarize(samples):
+    latencies = [sample["latency_ms"] for sample in samples]
+    return {
+        "count": len(latencies),
+        "min_ms": min(latencies),
+        "max_ms": max(latencies),
+        "mean_ms": statistics.fmean(latencies),
+        "median_ms": statistics.median(latencies),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Measure UCI bestmove latency for Syzygy root hits.")
+    parser.add_argument("--engine", required=True)
+    parser.add_argument("--syzygy-path", required=True)
+    parser.add_argument("--iterations", type=int, default=20)
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--wtime", nargs="+", type=int, required=True)
+    parser.add_argument("--fen", nargs="+", required=True)
+    parser.add_argument("--assert-max-ms", type=float, default=None)
+    parser.add_argument("--json", required=True)
+    args = parser.parse_args()
+
+    engine_path = Path(args.engine)
+    syzygy_path = Path(args.syzygy_path)
+    output_path = Path(args.json)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    proc = launch_engine(engine_path)
+    try:
+        handshake(proc, syzygy_path)
+
+        for _ in range(args.warmup):
+            for fen in args.fen:
+                for wtime_ms in args.wtime:
+                    run_case(proc, fen, wtime_ms)
+
+        samples = []
+        for _ in range(args.iterations):
+            for fen in args.fen:
+                for wtime_ms in args.wtime:
+                    sample = run_case(proc, fen, wtime_ms)
+                    if args.assert_max_ms is not None and sample["latency_ms"] > args.assert_max_ms:
+                        raise AssertionError(
+                            f"Latency {sample['latency_ms']:.3f}ms exceeded {args.assert_max_ms}ms for {fen}"
+                        )
+                    samples.append(sample)
+    finally:
+        try:
+            send(proc, "quit")
+        except Exception:
+            pass
+        proc.kill()
+        proc.wait()
+
+    result = {
+        "engine": str(engine_path),
+        "syzygy_path": str(syzygy_path),
+        "iterations": args.iterations,
+        "warmup": args.warmup,
+        "wtime": args.wtime,
+        "fens": args.fen,
+        "summary": summarize(samples),
+        "samples": samples,
+    }
+
+    output_path.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(result["summary"], indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Port the validated Deepalienist Playchess/Syzygy/UCI latency fix into Wordfish with the minimal semantic changes needed to avoid Playchess timeouts when a Syzygy root hit returns an immediate bestmove. 
- Keep all Wordfish branding, UCI identity, NNUE handling and unrelated behavior unchanged while ensuring infinite/ponder searches do not trigger the problematic root-TB shortcut.

### Description
- Gate the root-tablebase fast path so the root TB shortcut is skipped for `go infinite` and for ponder mode by invoking `Tablebases::rank_root_moves` only when `!limits.infinite && !limits.ponderMode` (applied in `src/thread.cpp`).
- Convert UCI search update callbacks from static-style handlers to instance methods and bind them through `this` consistently, adding an instance flag `suppressLowTimeInfo` to confine low-time suppression logic to non-static handlers (`src/uci.h`, `src/uci.cpp`).
- Make `bestmove` emission atomic and Stockfish-like by using a single synchronized output chain (`sync_cout << ... << sync_endl`) and appending optional `ponder` text in the same chain, removing any mixed `std::cout` writes (`src/uci.cpp`).
- Add a small Playchess-oriented latency test harness and repro doc adapted for Wordfish naming to allow later Windows/6-man Syzygy validation (`tests/uci_latency_harness.py`, `docs/playchess_tb_latency.md`).
- Files changed: `src/thread.cpp`, `src/uci.cpp`, `src/uci.h`, `tests/uci_latency_harness.py`, `docs/playchess_tb_latency.md`.

### Testing
- Built the project with the requested command `make -C src build -j4 ARCH=x86-64-modern`, which compiled sources and progressed to link/LTO steps in this environment but the container could not complete a full LTO-linked interactive smoke run (build invocation was executed as requested). 
- Ran `git diff --check` with no trailing-whitespace or check errors reported. 
- Checked Python harness syntax with `python3 -m py_compile tests/uci_latency_harness.py`, which succeeded. 
- Attempted a local smoke latency run using the harness (`python3 tests/uci_latency_harness.py --engine src/Wordfish-4.40-100326-x86-64-modern --syzygy-path /tmp/empty_syzygy --iterations 1 --warmup 0 --wtime 200 500 1000 --fen '4k3/PP6/8/8/8/8/8/4K3 w - - 0 1' --json /tmp/uci_latency_smoke_no_syzygy.json`) but it failed to exercise Syzygy root behavior because no real Syzygy set was available and the container could not run the Windows/Playchess repro; the harness and its JSON output path were created successfully. 
- The real Windows + 6-man KRBvKRB Playchess repro is documented in `docs/playchess_tb_latency.md` and was not executed here due to environment constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc0a33915083279a56b96807bd96cf)