### PR TITLE
nnue: stack-allocate propagate buffer

### DIFF
--- a/src/nnue/nnue_architecture.h
+++ b/src/nnue/nnue_architecture.h
@@ -109,17 +109,10 @@ struct NetworkArchitecture {
             alignas(CacheLineSize) typename decltype(ac_1)::OutputBuffer ac_1_out;
             alignas(CacheLineSize) typename decltype(fc_2)::OutputBuffer fc_2_out;
 
-            Buffer() { std::memset(this, 0, sizeof(*this)); }
+            Buffer() { std::memset(ac_sqr_0_out, 0, sizeof(ac_sqr_0_out)); }
         };
 
-#if defined(__clang__) && (__APPLE__)
-        // workaround for a bug reported with xcode 12
-        static thread_local auto tlsBuffer = std::make_unique<Buffer>();
-        // Access TLS only once, cache result.
-        Buffer& buffer = *tlsBuffer;
-#else
-        alignas(CacheLineSize) static thread_local Buffer buffer;
-#endif
+        Buffer buffer;
 
         fc_0.propagate(transformedFeatures, buffer.fc_0_out);
         ac_sqr_0.propagate(buffer.fc_0_out, buffer.ac_sqr_0_out);


### PR DESCRIPTION
### Motivation
- Adapt the upstream Stockfish idea to replace the persistent/thread-local NNUE temporary buffer with a stack-local buffer to simplify lifetime and avoid TLS overhead in the propagate path.
- Make the initialization narrower to avoid unnecessary whole-struct zeroing while ensuring deterministic content for the combined accumulator region.

### Description
- In `src/nnue/nnue_architecture.h` the `Buffer` constructor was changed from `std::memset(this, 0, sizeof(*this))` to `std::memset(ac_sqr_0_out, 0, sizeof(ac_sqr_0_out))` to only zero `ac_sqr_0_out`.
- The persistent `thread_local` buffer and the Apple/Clang `std::make_unique` TLS workaround were removed and replaced with a local stack `Buffer buffer;` used only within `propagate()`.
- All existing `alignas(CacheLineSize)` declarations and the propagation/dataflow calls (`fc_0`, `ac_sqr_0`, `ac_0`, `fc_1`, `ac_1`, `fc_2`) were preserved exactly and no other files were modified.

### Testing
- Ran `make -j2` at the repo root which correctly failed due to no top-level Makefile present, confirming build target location is `src/`.
- Ran `make -j2` in `src/` which succeeded (help/config output) and then `make -j2 build` in `src/` which compiled successfully and produced the engine binary.
- No runtime benchmarks or sanitizers were executed in this validation pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb8c2622cc83279aca041450ee3f97)