### PR TITLE
Align qsearch TT write and minimal NNUE snapshot changes from Stockfish bb4eb04

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -40,6 +40,15 @@ std::string pretty(Bitboard b);
 
 }  // namespace Stockfish::Bitboards
 
+#ifdef USE_AVX512
+// clang-format off
+inline const __m512i AllSquares = _mm512_set_epi8(
+    63, 62, 61, 60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42, 41,
+    40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18,
+    17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
+// clang-format on
+#endif
+
 constexpr Bitboard FileABB = 0x0101010101010101ULL;
 constexpr Bitboard FileBBB = FileABB << 1;
 constexpr Bitboard FileCBB = FileABB << 2;
@@ -153,6 +162,10 @@ template<Color C>
 constexpr Bitboard pawn_attacks_bb(Bitboard b) {
     return C == WHITE ? shift<NORTH_WEST>(b) | shift<NORTH_EAST>(b)
                       : shift<SOUTH_WEST>(b) | shift<SOUTH_EAST>(b);
+}
+
+constexpr Bitboard pawn_single_push_bb(Color c, Bitboard b) {
+    return c == WHITE ? shift<NORTH>(b) : shift<SOUTH>(b);
 }
 
 
@@ -392,6 +405,18 @@ inline constexpr auto PseudoAttacks = []() constexpr {
         attacks[KNIGHT][s1] = Bitboards::pseudo_attacks(KNIGHT, s1);
         attacks[QUEEN][s1] = attacks[BISHOP][s1] = Bitboards::pseudo_attacks(BISHOP, s1);
         attacks[QUEEN][s1] |= attacks[ROOK][s1]  = Bitboards::pseudo_attacks(ROOK, s1);
+    }
+
+    return attacks;
+}();
+
+inline constexpr auto PawnPushOrAttacks = []() constexpr {
+    std::array<std::array<Bitboard, SQUARE_NB>, COLOR_NB> attacks{};
+
+    for (Square s1 = SQ_A1; s1 <= SQ_H8; ++s1)
+    {
+        attacks[WHITE][s1] = pawn_single_push_bb(WHITE, square_bb(s1)) | PseudoAttacks[WHITE][s1];
+        attacks[BLACK][s1] = pawn_single_push_bb(BLACK, square_bb(s1)) | PseudoAttacks[BLACK][s1];
     }
 
     return attacks;

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -33,7 +33,7 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultNameBig "nn-9a0cc2a62c52.nnue"
+#define EvalFileDefaultNameBig "nn-7bf13f9655c8.nnue"
 #define EvalFileDefaultNameSmall "nn-47fc8b7fff06.nnue"
 
 namespace NNUE {

--- a/src/misc.h
+++ b/src/misc.h
@@ -202,6 +202,12 @@ class ValueList {
         assert(size_ < MaxSize);
         values_[size_++] = value;
     }
+    // pushes back value if value < max
+    void push_back_if_lt(const T& value, const T& max) {
+        assert(size_ < MaxSize);
+        values_[size_] = value;
+        size_ += (value < max);
+    }
     const T* begin() const { return values_; }
     const T* end() const { return values_ + size_; }
     const T& operator[](int index) const { return values_[index]; }

--- a/src/nnue/features/full_threats.cpp
+++ b/src/nnue/features/full_threats.cpp
@@ -21,7 +21,7 @@
 #include "full_threats.h"
 
 #include <array>
-#include <cstddef>
+#include <cassert>
 #include <cstdint>
 #include <initializer_list>
 #include <utility>
@@ -72,7 +72,7 @@ constexpr auto make_piece_indices_piece() {
 
     for (Square from = SQ_A1; from <= SQ_H8; ++from)
     {
-        Bitboard attacks = PseudoAttacks[C][from];
+        Bitboard attacks = PawnPushOrAttacks[C][from];
 
         for (Square to = SQ_A1; to <= SQ_H8; ++to)
         {
@@ -135,8 +135,8 @@ constexpr auto init_threat_offsets() {
 
             else if (from >= SQ_A2 && from <= SQ_H7)
             {
-                Bitboard attacks = (pieceIdx < 8) ? pawn_attacks_bb<WHITE>(square_bb(from))
-                                                  : pawn_attacks_bb<BLACK>(square_bb(from));
+                Bitboard attacks =
+                  (pieceIdx < 8) ? PawnPushOrAttacks[WHITE][from] : PawnPushOrAttacks[BLACK][from];
                 cumulativePieceOffset += constexpr_popcount(attacks);
             }
         }
@@ -209,6 +209,7 @@ inline sf_always_inline IndexType FullThreats::make_index(
 void FullThreats::append_active_indices(Color perspective, const Position& pos, IndexList& active) {
     Square   ksq      = pos.square<KING>(perspective);
     Bitboard occupied = pos.pieces();
+    Bitboard pawns    = pos.pieces(PAWN);
 
     for (Color color : {WHITE, BLACK})
     {
@@ -234,8 +235,7 @@ void FullThreats::append_active_indices(Color perspective, const Position& pos, 
                     Piece     attacked = pos.piece_on(to);
                     IndexType index    = make_index(perspective, attacker, from, to, attacked, ksq);
 
-                    if (index < Dimensions)
-                        active.push_back(index);
+                    active.push_back_if_lt(index, Dimensions);
                 }
 
                 while (attacks_right)
@@ -245,8 +245,20 @@ void FullThreats::append_active_indices(Color perspective, const Position& pos, 
                     Piece     attacked = pos.piece_on(to);
                     IndexType index    = make_index(perspective, attacker, from, to, attacked, ksq);
 
-                    if (index < Dimensions)
-                        active.push_back(index);
+                    active.push_back_if_lt(index, Dimensions);
+                }
+
+                // Set of pawns which are prevented from movement by a pawn in front of them
+                Bitboard pushers = pawn_single_push_bb(~c, pawns) & pos.pieces(c, PAWN);
+                while (pushers)
+                {
+                    Square from     = pop_lsb(pushers);
+                    Square to       = from + pawn_push(c);
+                    Piece  attacked = pos.piece_on(to);
+                    assert(type_of(attacked) == PAWN);
+
+                    IndexType index = make_index(perspective, attacker, from, to, attacked, ksq);
+                    active.push_back_if_lt(index, Dimensions);
                 }
             }
             else
@@ -263,8 +275,7 @@ void FullThreats::append_active_indices(Color perspective, const Position& pos, 
                         IndexType index =
                           make_index(perspective, attacker, from, to, attacked, ksq);
 
-                        if (index < Dimensions)
-                            active.push_back(index);
+                        active.push_back_if_lt(index, Dimensions);
                     }
                 }
             }
@@ -326,13 +337,10 @@ void FullThreats::append_changed_indices(Color                   perspective,
         auto&           insert = add ? added : removed;
         const IndexType index  = make_index(perspective, attacker, from, to, attacked, ksq);
 
-        if (index < Dimensions)
-        {
-            if (prefetchBase)
-                prefetch<PrefetchRw::READ, PrefetchLoc::LOW>(
-                  prefetchBase + static_cast<std::ptrdiff_t>(index) * prefetchStride);
-            insert.push_back(index);
-        }
+        if (prefetchBase)
+            prefetch<PrefetchRw::READ, PrefetchLoc::LOW>(reinterpret_cast<const void*>(
+              reinterpret_cast<uintptr_t>(prefetchBase) + index * prefetchStride));
+        insert.push_back_if_lt(index, Dimensions);
     }
 }
 

--- a/src/nnue/features/full_threats.h
+++ b/src/nnue/features/full_threats.h
@@ -42,7 +42,7 @@ class FullThreats {
     static constexpr std::uint32_t HashValue = 0x8f234cb8u;
 
     // Number of feature dimensions
-    static constexpr IndexType Dimensions = 60144;
+    static constexpr IndexType Dimensions = 60720;
 
     // clang-format off
     // Orient a square according to perspective (rotates by 180 for black)

--- a/src/nnue/features/half_ka_v2_hm.cpp
+++ b/src/nnue/features/half_ka_v2_hm.cpp
@@ -27,6 +27,62 @@
 
 namespace Stockfish::Eval::NNUE::Features {
 
+#if defined(USE_AVX512ICL)
+void HalfKAv2_hm::write_indices(const std::array<Piece, SQUARE_NB>& oldPieces,
+                                const std::array<Piece, SQUARE_NB>& newPieces,
+                                Bitboard                            removedBB,
+                                Bitboard                            addedBB,
+                                Color                               perspective,
+                                Square                              ksq,
+                                IndexList&                          removed,
+                                IndexList&                          added) {
+
+    auto* write_removed = removed.make_space(popcount(removedBB));
+    auto* write_added   = added.make_space(popcount(addedBB));
+
+    const __m512i vecOldPieces = _mm512_loadu_si512(oldPieces.data());
+    const __m512i vecNewPieces = _mm512_loadu_si512(newPieces.data());
+
+    alignas(64) static constexpr uint16_t psiTable[COLOR_NB][16] = {
+      {PS_NONE, PS_W_PAWN, PS_W_KNIGHT, PS_W_BISHOP, PS_W_ROOK, PS_W_QUEEN, PS_KING, PS_NONE,
+       PS_NONE, PS_B_PAWN, PS_B_KNIGHT, PS_B_BISHOP, PS_B_ROOK, PS_B_QUEEN, PS_KING, PS_NONE},
+      {PS_NONE, PS_B_PAWN, PS_B_KNIGHT, PS_B_BISHOP, PS_B_ROOK, PS_B_QUEEN, PS_KING, PS_NONE,
+       PS_NONE, PS_W_PAWN, PS_W_KNIGHT, PS_W_BISHOP, PS_W_ROOK, PS_W_QUEEN, PS_KING, PS_NONE}};
+
+    const uint16_t flip   = 56 * perspective;
+    const __m512i  orient = _mm512_set1_epi16((uint16_t) OrientTBL[ksq] ^ flip);
+    const __m512i  psi =
+      _mm512_zextsi256_si512(_mm256_loadu_si256((const __m256i*) psiTable[perspective]));
+    const __m512i psi_plus_bucket =
+      _mm512_add_epi16(psi, _mm512_set1_epi16((uint16_t) KingBuckets[int(ksq) ^ flip]));
+
+    __m512i removed_squares = _mm512_maskz_compress_epi8(removedBB, AllSquares);
+    __m512i added_squares   = _mm512_maskz_compress_epi8(addedBB, AllSquares);
+    __m512i removed_pieces  = _mm512_maskz_compress_epi8(removedBB, vecOldPieces);
+    __m512i added_pieces    = _mm512_maskz_compress_epi8(addedBB, vecNewPieces);
+
+    removed_squares = _mm512_cvtepi8_epi16(_mm512_castsi512_si256(removed_squares));
+    added_squares   = _mm512_cvtepi8_epi16(_mm512_castsi512_si256(added_squares));
+    removed_pieces  = _mm512_cvtepi8_epi16(_mm512_castsi512_si256(removed_pieces));
+    added_pieces    = _mm512_cvtepi8_epi16(_mm512_castsi512_si256(added_pieces));
+
+    const __m512i removed_indices =
+      _mm512_or_si512(_mm512_xor_si512(removed_squares, orient),
+                      _mm512_permutexvar_epi16(removed_pieces, psi_plus_bucket));
+    const __m512i added_indices =
+      _mm512_or_si512(_mm512_xor_si512(added_squares, orient),
+                      _mm512_permutexvar_epi16(added_pieces, psi_plus_bucket));
+
+    _mm512_storeu_si512(write_removed,
+                        _mm512_cvtepu16_epi32(_mm512_castsi512_si256(removed_indices)));
+    _mm512_storeu_si512(write_removed + 16,
+                        _mm512_cvtepu16_epi32(_mm512_extracti64x4_epi64(removed_indices, 1)));
+    _mm512_storeu_si512(write_added, _mm512_cvtepu16_epi32(_mm512_castsi512_si256(added_indices)));
+    _mm512_storeu_si512(write_added + 16,
+                        _mm512_cvtepu16_epi32(_mm512_extracti64x4_epi64(added_indices, 1)));
+}
+#endif
+
 // Index of a feature for a given king position and another piece on some square
 
 IndexType HalfKAv2_hm::make_index(Color perspective, Square s, Piece pc, Square ksq) {

--- a/src/nnue/features/half_ka_v2_hm.h
+++ b/src/nnue/features/half_ka_v2_hm.h
@@ -106,6 +106,18 @@ class HalfKAv2_hm {
     using IndexList                                = ValueList<IndexType, MaxActiveDimensions>;
     using DiffType                                 = DirtyPiece;
 
+#if defined(USE_AVX512ICL)
+    // Compute all changed feature indices and write them to the given lists
+    static void write_indices(const std::array<Piece, SQUARE_NB>& oldPieces,
+                              const std::array<Piece, SQUARE_NB>& newPieces,
+                              Bitboard                            removedBB,
+                              Bitboard                            addedBB,
+                              Color                               perspective,
+                              Square                              ksq,
+                              IndexList&                          removed,
+                              IndexList&                          added);
+#endif
+
     // Index of a feature for a given king position and another piece on some square
 
     static IndexType make_index(Color perspective, Square s, Piece pc, Square ksq);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1795,9 +1795,8 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
             if (!is_decisive(bestValue))
                 bestValue = (bestValue + beta) / 2;
             if (!ss->ttHit)
-                ttWriter.write(posKey, value_to_tt(bestValue, ss->ply), false, BOUND_LOWER,
-                               DEPTH_UNSEARCHED, Move::none(), unadjustedStaticEval,
-                               tt.generation());
+                ttWriter.write(posKey, VALUE_NONE, false, BOUND_LOWER, DEPTH_UNSEARCHED,
+                               Move::none(), unadjustedStaticEval, tt.generation());
             return bestValue;
         }
 


### PR DESCRIPTION
### Motivation
- Apply the exact upstream change in `qsearch()` stand-pat cutoff so the transposition table stores `VALUE_NONE` instead of the stand‑pat value, matching Stockfish commit `bb4eb04a5024...`. 
- Bring Wordfish's NNUE-related pieces in line with the same official snapshot so the engine uses the official big net name and NNUE index/infrastructure where required. 
- Keep the integration surgical and traceable, avoiding wholesale tree replacement or unrelated refactors while ensuring the project still compiles and initializes NNUE.

### Description
- In `src/search.cpp` changed the stand‑pat TT write in `qsearch()` to write `VALUE_NONE` instead of `value_to_tt(bestValue, ...)` (the exact hunk requested) via `ttWriter.write(posKey, VALUE_NONE, ...)`.
- In `src/evaluate.h` set `EvalFileDefaultNameBig` to the snapshot name ``nn-7bf13f9655c8.nnue`` to align the default big net with the official release.
- In `src/bitboard.h` ported the AVX512 helper `AllSquares`, added `pawn_single_push_bb(Color, Bitboard)` and `PawnPushOrAttacks` tables required by the snapshot NNUE code paths.
- In `src/nnue/features/full_threats.h` / `src/nnue/features/full_threats.cpp` applied only the snapshot changes required: `Dimensions = 60720`, use of `PawnPushOrAttacks`, blocked‑pawn `pushers` handling, `push_back_if_lt` insertion pattern and the snapshot-style `prefetch` usage, and a small include change (`<cassert>` where needed).
- In `src/nnue/features/half_ka_v2_hm.h` and `.cpp` added the AVX512ICL `write_indices()` declaration and implementation matching the snapshot (guarded by `USE_AVX512ICL`) and using `AllSquares` consistently.
- Minimal, compilation‑necessary addition in `src/misc.h`: implemented `ValueList::push_back_if_lt(...)` because the snapshot usage expects it and Wordfish did not previously provide it; this is the only adaptation added solely to preserve build parity with the snapshot.
- No wholesale `src/` replacements, no changes to Wordfish identity, banners, authors, experience, MCTS, polybook, tablebase, or other project‑specific modules beyond the precise hunks above.

### Testing
- Built the project: ran `make -C src -j4 build`, which completed successfully and validated/downloaded the NNUE nets (the build finished and linked the Wordfish binary).
- Performed a UCI smoke test: `printf 'uci
isready
quit
' | ./src/Wordfish-*-sse41popcnt` and verified the engine initialized, reported the default `EvalFile` as `nn-7bf13f9655c8.nnue`, and returned `uciok` and `readyok` (smoke test passed).
- No automated tests failed during the build and linking stage; the changes were limited to the listed files and the build produced a functioning UCI binary.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc95a343248327a4a43b2eedd29afc)