### PR TITLE
Update EvalFileDefaultNameBig to nn-fcf986aea78a and add Tony Wang to AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -253,6 +253,7 @@ Tobias Steinmann
 Tomasz Sobczyk (Sopel97)
 Tom Truscott
 Tom Vijlbrief (tomtor)
+Tony Wang (TonyCongqianWang)
 Torsten Franz (torfranz, tfranzer)
 Torsten Hellwig (Torom)
 Tracey Emery (basepr1me)

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -33,7 +33,7 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultNameBig "nn-7bf13f9655c8.nnue"
+#define EvalFileDefaultNameBig "nn-fcf986aea78a.nnue"
 #define EvalFileDefaultNameSmall "nn-47fc8b7fff06.nnue"
 
 namespace NNUE {


### PR DESCRIPTION
### Motivation
- Sync the main/default NNUE network name to the upstream Stockfish update while preserving Wordfish's dual-network structure and avoiding unrelated upstream changes.

### Description
- Change the `EvalFileDefaultNameBig` macro in `src/evaluate.h` from `"nn-7bf13f9655c8.nnue"` to `"nn-fcf986aea78a.nnue"` and insert `Tony Wang (TonyCongqianWang)` into `AUTHORS` immediately after `Tom Vijlbrief (tomtor)`.

### Testing
- Ran `git diff --check` which reported no whitespace or patch errors and confirmed only `AUTHORS` and `src/evaluate.h` changed. 
- Verified `EvalFileDefaultNameSmall` remains `nn-47fc8b7fff06.nnue` and that references to `EvalFileDefaultNameBig` / `EvalFileDefaultNameSmall` exist in `src/engine.cpp`, `src/nnue/network.cpp`, and `scripts/net.sh` using `rg -n`.
- Ran `make -C src clean` and `make -C src -j build ARCH=x86-64-avx2 COMP=clang`; NNUE fetch succeeded for both `nn-fcf986aea78a.nnue` and `nn-47fc8b7fff06.nnue`, compilation succeeded up to linking, but the final link failed in this environment due to a missing `LLVMgold.so` LTO plugin (environment/toolchain issue), so a full end-to-end linkable build could not be completed here; therefore not marked safe to merge until linking can be validated in the target CI/toolchain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8b03ec3348327bb4f69f328ffac0e)