### PR TITLE
Update big default NNUE net to nn-83a0d6daf7e5.nnue

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -33,7 +33,7 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultNameBig "nn-fcf986aea78a.nnue"
+#define EvalFileDefaultNameBig "nn-83a0d6daf7e5.nnue"
 #define EvalFileDefaultNameSmall "nn-47fc8b7fff06.nnue"
 
 namespace NNUE {


### PR DESCRIPTION
### Motivation
- Apply the upstream Stockfish main-network update to Wordfish's big NNUE default while preserving the repository's dual-network layout and leaving all other code and macros unchanged.

### Description
- Replace `#define EvalFileDefaultNameBig "nn-fcf986aea78a.nnue"` with `#define EvalFileDefaultNameBig "nn-83a0d6daf7e5.nnue"` in `src/evaluate.h` and keep `EvalFileDefaultNameSmall` and every other file unmodified.

### Testing
- Verified changes with `git diff --name-only` (shows `src/evaluate.h`), `git diff` (one-line macro replacement), and `grep` checks (new big-net macro present, old big-net absent, small-net unchanged); attempted builds showed `profile-build` (`ARCH=x86-64-sse41-popcnt`) failed due to a linker/plugin `LLVMgold.so` error while `build` succeeded for `ARCH=x86-64-avx2`, `ARCH=x86-64-bmi2`, and `ARCH=x86-64-avx512`; a UCI smoke run using `./stockfish` failed because that exact binary name was not produced in this build output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02410089d88327885322c20fbd3449)