### PR TITLE
Enforce Syzygy root authority; disable Experience/PolyBook/MCTS in TB roots; fix PolyGlot EP hashing

### DIFF
--- a/src/Wordfish_zobrist.h
+++ b/src/Wordfish_zobrist.h
@@ -7,6 +7,9 @@
   intentionally lightweight so it can be used in constexpr contexts when
   possible, but also keeps the interface header-only as in the upstream
   project.
+
+  Note: this auxiliary combiner is only for Experience bookkeeping and does
+  not replace Stockfish core Position/TT/pawn/material Zobrist keys.
 */
 
 #ifndef WORDFISH_ZOBRIST_H_INCLUDED

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -226,12 +226,28 @@ void Engine::go(Search::LimitsType& limits) {
 
         if (bookMove != Move::none())
         {
-            const auto bestmove = UCIEngine::move(bookMove, options["UCI_Chess960"]);
+            bool tbRootCovered = false;
+            if (!pos.can_castle(ANY_CASTLING)
+                && pos.count<ALL_PIECES>() <= std::min(int(options["SyzygyProbeLimit"]),
+                                                       Tablebases::MaxCardinality))
+            {
+                Search::RootMoves tbRootMoves;
+                for (const Move m : MoveList<LEGAL>(pos))
+                    tbRootMoves.emplace_back(m);
 
-            if (updateContext.onBestmove)
-                updateContext.onBestmove(bestmove, std::string_view{});
+                if (!tbRootMoves.empty())
+                    tbRootCovered = Tablebases::rank_root_moves(options, pos, tbRootMoves).rootInTB;
+            }
 
-            return;
+            if (!tbRootCovered)
+            {
+                const auto bestmove = UCIEngine::move(bookMove, options["UCI_Chess960"]);
+
+                if (updateContext.onBestmove)
+                    updateContext.onBestmove(bestmove, std::string_view{});
+
+                return;
+            }
         }
     }
 

--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -699,7 +699,8 @@ void on_search_complete(const Position& pos,
                         Value                                 bestScore,
                         Value                                 evalScore,
                         Depth                                 searchedDepth,
-                        const Search::LimitsType&) {
+                        const Search::LimitsType&,
+                        bool                                  rootInTB) {
     std::scoped_lock lock(mutex);
 
     if (!settings.enabled || rootMoves.empty())
@@ -708,6 +709,17 @@ void on_search_complete(const Position& pos,
     if (rootMoves.front().pv.empty())
         return;
 
+    if (rootInTB)
+        return;
+
+    if (searchedDepth <= 0)
+        return;
+
+    if (bestScore == VALUE_INFINITE || bestScore == -VALUE_INFINITE)
+        return;
+
+    if (rootMoves.front().scoreLowerbound || rootMoves.front().scoreUpperbound)
+        return;
     if (searchedDepth < settings.bookMinDepth)
         return;
 

--- a/src/experience.h
+++ b/src/experience.h
@@ -40,7 +40,8 @@ void on_search_complete(const Position&               pos,
                         Value                           bestScore,
                         Value                           evalScore,
                         Depth                           searchedDepth,
-                        const Search::LimitsType&       limits);
+                        const Search::LimitsType&       limits,
+                        bool                             rootInTB);
 
 // Called on ucinewgame/reset events to make sure the experience file is safely
 // written to disk.

--- a/src/polybook.cpp
+++ b/src/polybook.cpp
@@ -579,7 +579,9 @@ Key PolyBook::polyglot_key(const Position& pos) {
     if (pos.can_castle(BLACK_OOO))
         key ^= PG.Zobrist.castle[3];
 
-    if (pos.ep_square() != SQ_NONE)
+    if (pos.ep_square() != SQ_NONE
+        && (attacks_bb<PAWN>(pos.ep_square(), ~pos.side_to_move())
+            & pos.pieces(pos.side_to_move(), PAWN)))
         key ^= PG.Zobrist.enpassant[file_of(pos.ep_square())];
 
     if (pos.side_to_move() == WHITE)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -229,7 +229,7 @@ void Search::Worker::start_searching() {
     const bool strategyRequestsMcts = options.count("Search Strategy")
                                       && (options["Search Strategy"] == "MCTS"
                                           || options["Search Strategy"] == "Montecarlo");
-    const bool useMcts = strategyRequestsMcts || mctsEnabled;
+    const bool useMcts = (strategyRequestsMcts || mctsEnabled) && !tbConfig.rootInTB;
 
     auto ensure_root_moves = [&]() {
         if (!rootMoves.empty())
@@ -316,7 +316,8 @@ void Search::Worker::start_searching() {
                                    bestScore,
                                    evalScore,
                                    bestThread->completedDepth,
-                                   bestThread->limits);
+                                   bestThread->limits,
+                                   bestThread->tbConfig.rootInTB);
 
     auto bestmove = UCIEngine::move(bestThread->rootMoves[0].pv[0], rootPos.is_chess960());
     main_manager()->updates.onBestmove(bestmove, ponder);

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -271,7 +271,8 @@ void ThreadPool::start_thinking(const OptionsMap&  options,
     if (!limits.infinite && !limits.ponderMode)
         tbConfig = Tablebases::rank_root_moves(options, pos, rootMoves);
 
-    Experience::on_new_position(pos, rootMoves);
+    if (!tbConfig.rootInTB)
+        Experience::on_new_position(pos, rootMoves);
 
     // After ownership transfer 'states' becomes empty, so if we stop the search
     // and call 'go' again without setting a new position states.get() == nullptr.

--- a/tests/test_experience.py
+++ b/tests/test_experience.py
@@ -221,6 +221,31 @@ class PolyglotBookTests(EngineTestCase):
         self.engine.clear_output()
         return lines
 
+    def test_polyglot_key_ignores_non_capturable_ep_square(self):
+        fen_without_ep = "4k3/8/8/8/8/8/4P3/4K3 w - - 0 1"
+        fen_with_ep = "4k3/8/8/8/8/8/4P3/4K3 w - e6 0 1"
+
+        def read_for_fen(fen):
+            key_line = None
+
+            def parser(output):
+                nonlocal key_line
+                if output.startswith("info string polyglot key "):
+                    key_line = output
+                    return True
+
+            self.engine.send_command(f"position fen {fen}")
+            self.engine.send_command("book key")
+            self.engine.check_output(parser)
+            self.engine.clear_output()
+
+            if key_line is None:
+                self.fail("Engine did not report a polyglot key")
+
+            return int(key_line.rsplit(" ", 1)[-1])
+
+        self.assertEqual(read_for_fen(fen_without_ep), read_for_fen(fen_with_ep))
+
     def test_polyglot_book_generated_in_test(self):
         key       = self._read_polyglot_key()
         book_path = self._write_book(key)


### PR DESCRIPTION
### Motivation
- Prevent Wordfish-specific layers (Experience, PolyBook, MCTS, auxiliary Zobrist/book logic) from overriding authoritative Syzygy tablebase results at TB-covered root positions.
- Apply minimal, forensic changes that preserve existing Wordfish behaviour outside tablebase roots and avoid changing on-disk experience formats or adding remote TB dependencies.

### Description
- Gate Experience root-time reordering in `ThreadPool::start_thinking` so `Experience::on_new_position(...)` is skipped when `tbConfig.rootInTB` is true, preserving the TB-ranked root ordering. (`src/thread.cpp`)
- Prevent early PolyBook bestmove emission in `Engine::go()` by checking local Syzygy coverage using `Tablebases::rank_root_moves(...)` and only emitting a book move when the root is not covered by TB; behaviour is unchanged when TB probing is disabled. (`src/engine.cpp`)
- Disable the MCTS path automatically for TB roots by making effective MCTS usage conditional on `!tbConfig.rootInTB` in `Search::Worker::start_searching`. (`src/search.cpp`)
- Extend Experience completion to accept a `rootInTB` flag and gate writes: Experience now skips writes when the searched root was in TB and also rejects untrusted final states (non-positive depth, infinite scores, or bound-only root results) while preserving existing filters and no-format changes. (`src/experience.h`, `src/experience.cpp`, `src/search.cpp`)
- Fix PolyGlot en-passant hashing so the EP file key is XOR'd only when an actual legal en-passant capture exists (Stockfish-style condition) and add a regression test proving a non-capturable EP square does not change the polyglot key. (`src/polybook.cpp`, `tests/test_experience.py`)
- Add a clarifying comment in `Wordfish_zobrist.h` that the file is an auxiliary Experience hash combiner and does not replace core Stockfish Zobrist keys. (`src/Wordfish_zobrist.h`)

### Testing
- Ran `git diff --name-only` and confirmed changed files: `src/thread.cpp`, `src/engine.cpp`, `src/search.cpp`, `src/experience.h`, `src/experience.cpp`, `src/polybook.cpp`, `src/Wordfish_zobrist.h`, and `tests/test_experience.py` (succeeded). 
- Built the engine with `make -C src -j2 build ARCH=x86-64 NNUE_EMBEDDING_OFF=yes` which produced a runnable binary (succeeded). 
- Ran profile build `make -C src -j2 profile-build ARCH=x86-64` which failed in this environment due to linker/gcov toolchain symbols (`__gcov_*`) unrelated to the patch (environment/tooling issue). 
- Executed the new regression test with `python -m pytest tests/test_experience.py -k "polyglot_key_ignores_non_capturable_ep_square"` which passed. 
- Performed a UCI smoke exercise: `uci`, `isready`, `ucinewgame`, `position startpos`, `go depth 1`, `quit` using the built binary which returned normal engine UCI output (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05836599bc8327a21961b644659803)