### PR TITLE
Route high-level NNUE consumers through single-net wrappers

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -289,6 +289,10 @@ void Engine::set_on_verify_networks(std::function<void(std::string_view)>&& f) {
     networksNeedVerification = true;
 }
 
+void Engine::set_on_verify_network(std::function<void(std::string_view)>&& f) {
+    set_on_verify_networks(std::move(f));
+}
+
 void Engine::wait_for_search_finished() { threads.main_thread()->wait_for_search_finished(); }
 
 void Engine::set_position(const std::string& fen, const std::vector<std::string>& moves) {

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -84,7 +84,7 @@ void UCIEngine::init_search_update_listeners() {
     engine.set_on_update_full(
       [this](const auto& i) { on_update_full(i); });
     engine.set_on_bestmove([this](const auto& bm, const auto& p) { on_bestmove(bm, p); });
-    engine.set_on_verify_networks([](const auto& s) { print_info_string(s); });
+    engine.set_on_verify_network([](const auto& s) { print_info_string(s); });
 }
 
 void UCIEngine::loop() {
@@ -423,7 +423,7 @@ void UCIEngine::benchmark(std::istream& args) {
     engine.set_on_iter([](const auto&) {});
     engine.set_on_update_no_moves([](const auto&) {});
     engine.set_on_bestmove([](const auto&, const auto&) {});
-    engine.set_on_verify_networks([](const auto&) {});
+    engine.set_on_verify_network([](const auto&) {});
 
     Benchmark::BenchmarkSetup setup = Benchmark::setup_benchmark(args);
 


### PR DESCRIPTION
### Motivation
- Reduce high-level coupling to the dual-net NNUE internals by routing UCI-level verification listeners through the singular transitional wrapper so future single-net migration has less blast radius.

### Description
- Replaced UCI high-level calls in `src/uci.cpp` to use `engine.set_on_verify_network(...)` and added `Engine::set_on_verify_network(...)` in `src/engine.cpp` which delegates to `set_on_verify_networks(...)`, preserving existing dual-net verification semantics.

### Testing
- Built with `make -C src -j2 build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS='-fuse-ld=lld'` (zero warnings/errors), found the `Wordfish` binary, and ran UCI, runtime (depth 1) and threaded (depth 2) smoke tests which all returned `uciok`, `readyok`, and `bestmove` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e6cbb8fc08327a83228b02be2cba5)