### PR TITLE
Adapterize evaluate NNUE branch access

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -61,7 +61,8 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
 
     bool smallNet           = use_smallnet(pos);
     auto [psqt, positional] =
-      smallNet ? networks.small.evaluate(pos, accumulators, caches.small)
+      smallNet ? NNUE::Adapter::secondary_network(networks).evaluate(
+                   pos, accumulators, NNUE::Adapter::secondary_cache(caches))
                : NNUE::Adapter::active_network(networks).evaluate(
                  pos, accumulators, NNUE::Adapter::active_cache(caches));
 

--- a/src/nnue/singlenet_adapter.h
+++ b/src/nnue/singlenet_adapter.h
@@ -20,6 +20,23 @@ active_cache(const AccumulatorCaches& caches) noexcept {
     return caches.big;
 }
 
+
+inline NetworkSmall& secondary_network(Networks& networks) noexcept { return networks.small; }
+
+inline const NetworkSmall& secondary_network(const Networks& networks) noexcept {
+    return networks.small;
+}
+
+inline AccumulatorCaches::Cache<TransformedFeatureDimensionsSmall>&
+secondary_cache(AccumulatorCaches& caches) noexcept {
+    return caches.small;
+}
+
+inline const AccumulatorCaches::Cache<TransformedFeatureDimensionsSmall>&
+secondary_cache(const AccumulatorCaches& caches) noexcept {
+    return caches.small;
+}
+
 inline const char* active_eval_file_name() noexcept { return EvalFileDefaultName; }
 
 }  // namespace Stockfish::Eval::NNUE::Adapter


### PR DESCRIPTION
### Motivation
- Reduce `evaluate.cpp`’s structural coupling to the dual-net layout by routing both primary and secondary NNUE accesses through transitional adapter helpers while preserving exact existing evaluation behavior.

### Description
- Added transitional helpers `secondary_network(...)` and `secondary_cache(...)` (non-const and const overloads) to `src/nnue/singlenet_adapter.h` and kept `active_network(...)`/`active_cache(...)` unchanged; replaced direct `networks.small`/`caches.small` uses in `src/evaluate.cpp` with `NNUE::Adapter::secondary_network(networks)` / `NNUE::Adapter::secondary_cache(caches)` leaving all formulas and logic intact.

### Testing
- Verified adapter symbols with `rg`, confirmed `src/evaluate.cpp` no longer directly references `networks.big|networks.small|caches.big|caches.small`, built the project with zero warnings/errors, and ran UCI, runtime and threaded smoke tests (`uciok`, `readyok`, `option name EvalFile`, and `bestmove`) which all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e70e61e748327aa7262798e179297)