### PR TITLE
Prepare Search NNUE holder access for single-net transition

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -193,15 +193,15 @@ Search::Worker::Worker(SharedState&                    sharedState,
     options(sharedState.options),
     threads(sharedState.threads),
     tt(sharedState.tt),
-    networks(sharedState.networks),
-    refreshTable(networks[token]) {
+    networks(sharedState.nnue_networks()),
+    refreshTable(nnue_networks()[token]) {
     clear();
 }
 
 void Search::Worker::ensure_network_replicated() {
     // Access once to force lazy initialization.
     // We do this because we want to avoid initialization during search.
-    (void) (networks[numaAccessToken]);
+    (void) (nnue_networks()[numaAccessToken]);
 }
 
 void Search::Worker::start_searching() {
@@ -811,7 +811,7 @@ void Search::Worker::clear() {
     for (size_t i = 1; i < reductions.size(); ++i)
         reductions[i] = int(2809 / 128.0 * std::log(i));
 
-    refreshTable.clear(networks[numaAccessToken]);
+    refreshTable.clear(nnue_networks()[numaAccessToken]);
 }
 
 
@@ -1957,7 +1957,7 @@ TimePoint Search::Worker::elapsed_time() const { return main_manager()->tm.elaps
 
 Value Search::Worker::evaluate(const Position& pos) {
 
-    Value v = Eval::evaluate(networks[numaAccessToken], pos, accumulatorStack, refreshTable,
+    Value v = Eval::evaluate(nnue_networks()[numaAccessToken], pos, accumulatorStack, refreshTable,
                              optimism[pos.side_to_move()]);
 
     if (kingSafetySetting != 100)

--- a/src/search.h
+++ b/src/search.h
@@ -142,6 +142,10 @@ struct SharedState {
         tt(transpositionTable),
         networks(nets) {}
 
+    const LazyNumaReplicatedSystemWide<Eval::NNUE::Networks>& nnue_networks() const {
+        return networks;
+    }
+
     const OptionsMap&                                         options;
     ThreadPool&                                               threads;
     TranspositionTable&                                       tt;
@@ -356,6 +360,9 @@ class Worker {
     ThreadPool&                                               threads;
     TranspositionTable&                                       tt;
     const LazyNumaReplicatedSystemWide<Eval::NNUE::Networks>& networks;
+    const LazyNumaReplicatedSystemWide<Eval::NNUE::Networks>& nnue_networks() const {
+        return networks;
+    }
 
     // Used by NNUE
     Eval::NNUE::AccumulatorStack  accumulatorStack;


### PR DESCRIPTION
### Motivation
- Reduce Search-layer coupling to the plural NNUE holder name and prepare for a future single-net transition while preserving existing ownership and runtime behavior.

### Description
- Add narrow transitional accessors `nnue_networks()` to `Search::SharedState`/`Search::Worker` and route local callsites in `Search::Worker` to use `nnue_networks()[token]` (constructor init, lazy replication touch, `refreshTable.clear`, and `Eval::evaluate`) instead of direct `networks[...]` access.

### Testing
- Built with zero warnings/errors and ran UCI smoke, runtime (depth 1), threaded (Threads=2, depth 2) and MultiPV (MultiPV=3, depth 2) smokes; all reported `uciok`/`readyok`, `option name EvalFile` and `EvalFileSmall` present, and returned `bestmove` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e7f041e88832784b535ab5ed73fc1)