### PR TITLE
Prepare Engine NNUE lifecycle for single-net transition

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -55,6 +55,22 @@ constexpr auto StartFEN   = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq 
 constexpr int  MaxHashMB  = Is64Bit ? 33554432 : 2048;
 int            MaxThreads = std::max(1024, 4 * int(get_hardware_concurrency()));
 
+namespace {
+
+const char* primary_default_network_file() { return NN::Adapter::active_eval_file_name(); }
+
+const char* secondary_default_network_file() { return EvalFileDefaultNameSmall; }
+
+void load_primary_network(NN::Networks& networks, const std::string& binaryDirectory, const std::string& file) {
+    networks.big.load(binaryDirectory, file);
+}
+
+void load_secondary_network(NN::Networks& networks, const std::string& binaryDirectory, const std::string& file) {
+    networks.small.load(binaryDirectory, file);
+}
+
+}  // namespace
+
 Engine::Engine(std::optional<std::string> path) :
     binaryDirectory(path ? CommandLine::get_binary_directory(*path) : ""),
     numaContext(NumaConfig::from_system()),
@@ -63,8 +79,8 @@ Engine::Engine(std::optional<std::string> path) :
     networks(
       numaContext,
       // Heap-allocate because sizeof(NN::Networks) is large
-      std::make_unique<NN::Networks>(NN::EvalFile{EvalFileDefaultNameBig, "None", ""},
-                                     NN::EvalFile{EvalFileDefaultNameSmall, "None", ""})) {
+      std::make_unique<NN::Networks>(NN::EvalFile{primary_default_network_file(), "None", ""},
+                                     NN::EvalFile{secondary_default_network_file(), "None", ""})) {
 
     pos.set(StartFEN, false, &states->back());
 
@@ -194,7 +210,7 @@ Engine::Engine(std::optional<std::string> path) :
       }));
 
     options.add(  //
-      "EvalFileSmall", Option(EvalFileDefaultNameSmall, [this](const Option& o) {
+      "EvalFileSmall", Option(secondary_default_network_file(), [this](const Option& o) {
           load_small_network(o);
           return std::nullopt;
       }));
@@ -406,8 +422,8 @@ void Engine::verify_networks() const {
 
 void Engine::load_networks() {
     networks.modify_and_replicate([this](NN::Networks& networks_) {
-        networks_.big.load(binaryDirectory, options["EvalFile"]);
-        networks_.small.load(binaryDirectory, options["EvalFileSmall"]);
+        load_primary_network(networks_, binaryDirectory, std::string(options["EvalFile"]));
+        load_secondary_network(networks_, binaryDirectory, std::string(options["EvalFileSmall"]));
     });
     threads.clear();
     networksNeedVerification = true;
@@ -419,16 +435,18 @@ void Engine::load_network(const std::string& file) {
 }
 
 void Engine::load_big_network(const std::string& file) {
-    networks.modify_and_replicate(
-      [this, &file](NN::Networks& networks_) { networks_.big.load(binaryDirectory, file); });
+    networks.modify_and_replicate([this, &file](NN::Networks& networks_) {
+        load_primary_network(networks_, binaryDirectory, file);
+    });
     threads.clear();
     networksNeedVerification = true;
     threads.ensure_network_replicated();
 }
 
 void Engine::load_small_network(const std::string& file) {
-    networks.modify_and_replicate(
-      [this, &file](NN::Networks& networks_) { networks_.small.load(binaryDirectory, file); });
+    networks.modify_and_replicate([this, &file](NN::Networks& networks_) {
+        load_secondary_network(networks_, binaryDirectory, file);
+    });
     threads.clear();
     networksNeedVerification = true;
     threads.ensure_network_replicated();


### PR DESCRIPTION
### Motivation
- Reduce scattered Engine coupling to explicit big/small lifecycle internals by introducing a narrow transitional surface for primary/secondary NNUE paths.
- Make the constructor and lifecycle callsites delegate through clear helpers so a future single-net core port can replace implementations with lower blast radius.
- Preserve dual-net behavior, public APIs and small-net paths during the adapterization step.

### Description
- Add a small anonymous-namespace surface with `primary_default_network_file()`, `secondary_default_network_file()`, `load_primary_network(...)`, and `load_secondary_network(...)` that still operate on `networks.big` / `networks.small` internally.
- Route constructor defaults to use `primary_default_network_file()` and `secondary_default_network_file()` rather than hard-coded big/small macros.
- Route `load_networks()`, `load_big_network(...)`, and `load_small_network(...)` through the new `load_primary_network`/`load_secondary_network` helpers to centralize primary/secondary intent.
- Keep public Engine API and dual-net internals (`NN::Networks`, `EvalFileSmall`, `load_small_network`, `verify_networks`, etc.) unchanged.

### Testing
- Verified wrapper baseline and presence of required adapter surfaces with `rg` checks for `active_network`, `active_cache`, `active_eval_file_name`, `secondary_network`, `secondary_cache` and engine wrapper symbols.
- Built with `make -C src -j2 build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld"` and validated the build log contained zero `warning:` or `error:` entries.
- Ran UCI smoke (`printf "uci
isready
quit
" | $BIN`) and confirmed `uciok`, `readyok`, `option name EvalFile` and `option name EvalFileSmall`.
- Executed runtime primary and small EvalFile smokes (set `EvalFile`/`EvalFileSmall` + `go depth 1`) and threaded smoke (`Threads=2`, `go depth 2`) and observed `readyok`/`bestmove` with no crash.
- Ran `eval` trace smoke and confirmed no crash/assert; inspected that trace output was produced.
- Confirmed diff scope limited to `src/engine.cpp` only and that no forbidden files were modified.
- All automated checks and builds passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e816fff248327bee01689c15952e0)