### PR TITLE
Make EvalFileDefaultName direct primary NNUE authority

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -35,7 +35,7 @@ namespace Eval {
 // in the Makefile/Fishtest.
 #define EvalFileDefaultNameBig "nn-83a0d6daf7e5.nnue"
 #define EvalFileDefaultNameSmall "nn-47fc8b7fff06.nnue"
-#define EvalFileDefaultName EvalFileDefaultNameBig
+#define EvalFileDefaultName "nn-83a0d6daf7e5.nnue"
 
 namespace NNUE {
 struct Networks;


### PR DESCRIPTION
### Motivation
- Convert the transitional alias facade into a direct Stockfish-style authority so `EvalFileDefaultName` is a direct string while retaining `EvalFileDefaultNameBig`/`EvalFileDefaultNameSmall` for compatibility.

### Description
- Edit `src/evaluate.h` to replace `#define EvalFileDefaultName EvalFileDefaultNameBig` with `#define EvalFileDefaultName "nn-83a0d6daf7e5.nnue"` and preserve `#define EvalFileDefaultNameBig "nn-83a0d6daf7e5.nnue"` and `#define EvalFileDefaultNameSmall "nn-47fc8b7fff06.nnue"`.

### Testing
- Performed automated validation: preflight `git` checks, verified only `src/evaluate.h` changed, built (`make -C src` with `ARCH=x86-64-sse41-popcnt`, `COMP=clang`, `EXTRALDFLAGS="-fuse-ld=lld"`) with zero warnings/errors, located the binary and ran UCI handshake and runtime smokes (set `EvalFile`/`EvalFileSmall`, depth-1/2 searches, threaded run, `eval` trace, `MultiPV=3`) and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e8c14aea883278179643d7259ec35)