### PR TITLE
Use EvalFileDefaultName as primary net script authority

### DIFF
--- a/scripts/net.sh
+++ b/scripts/net.sh
@@ -73,7 +73,8 @@ link_or_copy() {
 
 get_nnue_filename() {
   # Extract nn-<12hex>.nnue from the macro line in evaluate.h
-  grep "$1" "$evaluate_file" | grep "#define" | sed -n 's/.*\(nn-[a-z0-9]\{12\}\.nnue\).*/\1/p'
+  grep -E "^#define[[:space:]]+$1[[:space:]]+\"[^\"]+\"" "$evaluate_file" \
+    | sed -n 's/.*"\(nn-[a-z0-9]\{12\}\.nnue\)".*/\1/p'
 }
 
 validate_network() {
@@ -144,6 +145,6 @@ fetch_network() {
   exit 1
 }
 
-# BIG and SMALL (bytes)
-fetch_network EvalFileDefaultNameBig 50000000
+# PRIMARY and SMALL (bytes)
+fetch_network EvalFileDefaultName 50000000
 fetch_network EvalFileDefaultNameSmall 1000000


### PR DESCRIPTION
### Motivation
- Route the primary/default NNUE network authority used by the net management script to the direct macro `EvalFileDefaultName` in `src/evaluate.h` instead of `EvalFileDefaultNameBig`, to match the P0I baseline transition.

### Description
- Tighten `get_nnue_filename()` to match the exact macro name using an anchored `grep -E '^#define[[:space:]]+$1[[:space:]]+"[^"]+"'` and `sed` to extract the `nn-<12hex>.nnue` token. 
- Change the primary fetch invocation from `fetch_network EvalFileDefaultNameBig 50000000` to `fetch_network EvalFileDefaultName 50000000` while preserving `fetch_network EvalFileDefaultNameSmall 1000000` for small-net compatibility.
- Only `scripts/net.sh` was modified; no other files were touched.

### Testing
- Preflight and build: repository was clean, `bash -n scripts/net.sh` passed and `make -C src -j2 build ...` completed with zero `warning:`/`error:` entries in the log. 
- Script and runtime smokes: executed `scripts/net.sh` (downloads/validation ran), ran UCI smoke and runtime smokes including `setoption` for `EvalFile` and `EvalFileSmall`, threaded and MultiPV smokes, and observed required `uciok`, `readyok`, and `bestmove` signals. 
- Scope and commit: consumer-boundary and preserved-surface checks passed, diff was limited to `scripts/net.sh`, and the change was committed as `11a25e5`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e90f3f2208327b36aac6bb7e044cf)