### PR TITLE
Demote EvalFileDefaultNameBig to compatibility macro

### DIFF
--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -44,7 +44,7 @@
 //     const unsigned int         gEmbeddedNNUESize;    // the size of the embedded file
 // Note that this does not work in Microsoft Visual Studio.
 #if !defined(_MSC_VER) && !defined(NNUE_EMBEDDING_OFF)
-INCBIN(EmbeddedNNUEBig, EvalFileDefaultNameBig);
+INCBIN(EmbeddedNNUEBig, EvalFileDefaultName);
 INCBIN(EmbeddedNNUESmall, EvalFileDefaultNameSmall);
 #else
 const unsigned char        gEmbeddedNNUEBigData[1]   = {0x0};


### PR DESCRIPTION
### Motivation
- Remove the last non-definition consumer of `EvalFileDefaultNameBig` and ensure `EvalFileDefaultName` is the single authority for the primary/default NNUE path while keeping the Big macro as a compatibility alias.

### Description
- Replaced the embedded big NNUE include from `INCBIN(EmbeddedNNUEBig, EvalFileDefaultNameBig)` to `INCBIN(EmbeddedNNUEBig, EvalFileDefaultName)` in `src/nnue/network.cpp` and left the `#define EvalFileDefaultNameBig` macro intact in `src/evaluate.h`.

### Testing
- Ran exact grep checks for `EvalFileDefaultNameBig` and verified only the compatibility macro remains, the consumer-boundary regression check passed, and preserved-surface checks executed successfully.
- Performed a full build with `make -C src` using `ARCH=x86-64-sse41-popcnt` / `COMP=clang` and found zero warnings and zero errors.
- Executed UCI, runtime primary/small-net, threaded and MultiPV smokes against the built binary and observed expected `uciok`, `readyok`, `option name EvalFile`, `option name EvalFileSmall`, and `bestmove` outputs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e955534c0832790ecce4cb75454f5)