### PR TITLE
Remove EvalFileSmall from public UCI options

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -209,12 +209,6 @@ Engine::Engine(std::optional<std::string> path) :
           return std::nullopt;
       }));
 
-    options.add(  //
-      "EvalFileSmall", Option(secondary_default_network_file(), [this](const Option& o) {
-          load_small_network(o);
-          return std::nullopt;
-      }));
-
     load_networks();
     Experience::update_settings(options);
     resize_threads();
@@ -385,7 +379,7 @@ void Engine::verify_networks() const {
         return;
 
     networks->big.verify(options["EvalFile"], onVerifyNetworks);
-    networks->small.verify(options["EvalFileSmall"], onVerifyNetworks);
+    networks->small.verify(secondary_default_network_file(), onVerifyNetworks);
 
     auto statuses = networks.get_status_and_errors();
     for (size_t i = 0; i < statuses.size(); ++i)
@@ -423,7 +417,7 @@ void Engine::verify_networks() const {
 void Engine::load_networks() {
     networks.modify_and_replicate([this](NN::Networks& networks_) {
         load_primary_network(networks_, binaryDirectory, std::string(options["EvalFile"]));
-        load_secondary_network(networks_, binaryDirectory, std::string(options["EvalFileSmall"]));
+        load_secondary_network(networks_, binaryDirectory, secondary_default_network_file());
     });
     threads.clear();
     networksNeedVerification = true;


### PR DESCRIPTION
### Motivation
- Remove the public UCI option named exactly `EvalFileSmall` so the engine no longer exposes the small-net filename to UCI while preserving the internal dual-net implementation and defaults.

### Description
- Deleted the `options.add("EvalFileSmall", ...)` registration and callback from `src/engine.cpp` and kept internal small-net APIs intact.
- Replaced runtime lookups of `options["EvalFileSmall"]` with the internal `secondary_default_network_file()` in `verify_networks()` and `load_networks()` so the small network continues to be loaded/verified using its embedded default.
- Only `src/engine.cpp` was changed; `EvalFileDefaultNameSmall` and all internal small-net symbols remain unchanged.

### Testing
- Performed static/local checks with `rg` to confirm `EvalFileSmall` is no longer present in public option registration and small-net internal symbols remain; gate passed.
- Built `make -C src -j2` with `clang` for `x86-64-sse41-popcnt` and verified zero warnings and zero errors; build passed.
- Ran UCI and runtime smokes using the produced binary: confirmed `uciok`/`readyok`, `option name EvalFile` present, `EvalFileSmall` absent, `go depth 1` produced `bestmove`, `setoption EvalFileSmall ...` produced an unknown-option diagnostic without crashing, and threaded/MultiPV smokes returned `readyok` and `bestmove` — all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e99b26f848327a35657c309bfe092)