### PR TITLE
Detach EvalFileSmall from normal startup lifecycle

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -379,7 +379,6 @@ void Engine::verify_networks() const {
         return;
 
     networks->big.verify(options["EvalFile"], onVerifyNetworks);
-    networks->small.verify(secondary_default_network_file(), onVerifyNetworks);
 
     auto statuses = networks.get_status_and_errors();
     for (size_t i = 0; i < statuses.size(); ++i)
@@ -417,7 +416,6 @@ void Engine::verify_networks() const {
 void Engine::load_networks() {
     networks.modify_and_replicate([this](NN::Networks& networks_) {
         load_primary_network(networks_, binaryDirectory, std::string(options["EvalFile"]));
-        load_secondary_network(networks_, binaryDirectory, secondary_default_network_file());
     });
     threads.clear();
     networksNeedVerification = true;


### PR DESCRIPTION
### Motivation
- After removal of the public `EvalFileSmall` UCI option, automatic startup loading/verification of the small NNUE should be detached from the engine lifecycle to avoid requiring the small net at startup while preserving internal compatibility surfaces.

### Description
- Removed automatic small-net verification from `Engine::verify_networks()` so only `networks->big.verify(options["EvalFile"], ...)` runs during normal verify. 
- Removed automatic small-net loading from `Engine::load_networks()` so `load_primary_network(...)` is the only network loaded at startup; retained `load_small_network(...)`, `secondary_default_network_file()`, `EvalFileDefaultNameSmall` and small-net internals unchanged. 
- Change confined to `src/engine.cpp` only.

### Testing
- Built the project with `make -C src -j2` (clang, `ARCH=x86-64-sse41-popcnt`) and observed `PASS: build has zero warnings and zero errors.`
- Ran UCI smoke which returned `uciok`, `readyok`, `option name EvalFile` present and `EvalFileSmall` absent.
- Ran primary runtime smoke with `setoption name EvalFile ...` and observed `readyok` and `bestmove`.
- Sent a negative `setoption name EvalFileSmall ...` and confirmed it did not crash (engine replied `No such option: EvalFileSmall`).
- Hid the small-net file and ran startup/runtime smoke and confirmed `readyok` and `bestmove`, proving startup no longer requires the small net file.
- Threaded and MultiPV smokes passed (readyok + bestmove), consumer-boundary and preserved-surface checks passed, git/diff scope verification passed, and commit `e99a9f3` was created.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e9b350d0c83278fa7622d1e8b1a70)