### PR TITLE
Retire internal EvalFileSmall loader lifecycle

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -59,15 +59,11 @@ namespace {
 
 const char* primary_default_network_file() { return NN::Adapter::active_eval_file_name(); }
 
-const char* secondary_default_network_file() { return EvalFileDefaultNameSmall; }
 
 void load_primary_network(NN::Networks& networks, const std::string& binaryDirectory, const std::string& file) {
     networks.big.load(binaryDirectory, file);
 }
 
-void load_secondary_network(NN::Networks& networks, const std::string& binaryDirectory, const std::string& file) {
-    networks.small.load(binaryDirectory, file);
-}
 
 }  // namespace
 
@@ -80,7 +76,7 @@ Engine::Engine(std::optional<std::string> path) :
       numaContext,
       // Heap-allocate because sizeof(NN::Networks) is large
       std::make_unique<NN::Networks>(NN::EvalFile{primary_default_network_file(), "None", ""},
-                                     NN::EvalFile{secondary_default_network_file(), "None", ""})) {
+                                     NN::EvalFile{EvalFileDefaultNameSmall, "None", ""})) {
 
     pos.set(StartFEN, false, &states->back());
 
@@ -435,14 +431,6 @@ void Engine::load_big_network(const std::string& file) {
     threads.ensure_network_replicated();
 }
 
-void Engine::load_small_network(const std::string& file) {
-    networks.modify_and_replicate([this, &file](NN::Networks& networks_) {
-        load_secondary_network(networks_, binaryDirectory, file);
-    });
-    threads.clear();
-    networksNeedVerification = true;
-    threads.ensure_network_replicated();
-}
 
 void Engine::save_network(const std::pair<std::optional<std::string>, std::string> files[2]) {
     networks.modify_and_replicate([&files](NN::Networks& networks_) {

--- a/src/engine.h
+++ b/src/engine.h
@@ -86,7 +86,6 @@ class Engine {
     void verify_networks() const;
     void load_networks();
     void load_big_network(const std::string& file);
-    void load_small_network(const std::string& file);
     void save_network(const std::pair<std::optional<std::string>, std::string> files[2]);
 
     std::string get_default_network() const;


### PR DESCRIPTION
### Motivation
- Remove now-unused internal small-net loader/lifecycle plumbing that became unreachable after prior P0M/P0N changes while preserving NNUE small-net data structures for later phases.

### Description
- Deleted `Engine::load_small_network(...)` declaration and definition and removed the local helpers `load_secondary_network(...)` and `secondary_default_network_file()` from `src/engine.h` and `src/engine.cpp`.
- Constructor initialization was adjusted to use `EvalFileDefaultNameSmall` directly for the secondary `EvalFile` while keeping `NNUE::Networks` and `NetworkSmall` intact.
- Only `src/engine.cpp` and `src/engine.h` were modified and no forbidden files or NNUE architecture/data structures were changed.

### Testing
- Built the project with `make -C src -j2 ... COMP=clang` and the build passed with zero warnings and zero errors.
- Ran full smoke tests against the produced binary: `uci`/`isready`, primary `EvalFile` runtime (`bestmove`), negative `setoption EvalFileSmall` (no crash), startup without the small net file (readyok + bestmove), threaded (`Threads=2`), MultiPV (`MultiPV=3`), and `eval` trace, all of which passed.
- Verified no remaining references to `load_small_network(`, `load_secondary_network(`, or `secondary_default_network_file(` and confirmed `"EvalFileSmall"` remains absent from public UCI output and that consumer-boundary checks and preserved feature-surface symbols (e.g. `EvalFileDefaultNameSmall`, `NNUE::Networks`, `NetworkSmall`) remain present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e9dd993e483278314ef442e33b658)