### PR TITLE
Initialize small NNUE network with primary eval file

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -76,7 +76,7 @@ Engine::Engine(std::optional<std::string> path) :
       numaContext,
       // Heap-allocate because sizeof(NN::Networks) is large
       std::make_unique<NN::Networks>(NN::EvalFile{primary_default_network_file(), "None", ""},
-                                     NN::EvalFile{EvalFileDefaultNameSmall, "None", ""})) {
+                                     NN::EvalFile{primary_default_network_file(), "None", ""})) {
 
     pos.set(StartFEN, false, &states->back());
 


### PR DESCRIPTION
### Motivation
- Ensure the small NNUE network is initialized from the same active evaluation file instead of the legacy `EvalFileDefaultNameSmall` to avoid missing/mismatched small network files and simplify configuration.

### Description
- Pass `primary_default_network_file()` for both `NN::EvalFile` entries when constructing `std::make_unique<NN::Networks>`, so both big and small networks use the primary eval file.

### Testing
- Built the project with `make` and ran unit tests with `ctest`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eb21107648327afb4151584debcb1)