### PR TITLE
Remove embedded small NNUE network and stop fetching it

### DIFF
--- a/scripts/net.sh
+++ b/scripts/net.sh
@@ -147,4 +147,3 @@ fetch_network() {
 
 # PRIMARY and SMALL (bytes)
 fetch_network EvalFileDefaultName 50000000
-fetch_network EvalFileDefaultNameSmall 1000000

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -45,14 +45,10 @@
 // Note that this does not work in Microsoft Visual Studio.
 #if !defined(_MSC_VER) && !defined(NNUE_EMBEDDING_OFF)
 INCBIN(EmbeddedNNUEBig, EvalFileDefaultName);
-INCBIN(EmbeddedNNUESmall, EvalFileDefaultNameSmall);
 #else
 const unsigned char        gEmbeddedNNUEBigData[1]   = {0x0};
 const unsigned char* const gEmbeddedNNUEBigEnd       = &gEmbeddedNNUEBigData[1];
 const unsigned int         gEmbeddedNNUEBigSize      = 1;
-const unsigned char        gEmbeddedNNUESmallData[1] = {0x0};
-const unsigned char* const gEmbeddedNNUESmallEnd     = &gEmbeddedNNUESmallData[1];
-const unsigned int         gEmbeddedNNUESmallSize    = 1;
 #endif
 
 namespace {
@@ -75,7 +71,7 @@ EmbeddedNNUE get_embedded(EmbeddedNNUEType type) {
     if (type == EmbeddedNNUEType::BIG)
         return EmbeddedNNUE(gEmbeddedNNUEBigData, gEmbeddedNNUEBigEnd, gEmbeddedNNUEBigSize);
     else
-        return EmbeddedNNUE(gEmbeddedNNUESmallData, gEmbeddedNNUESmallEnd, gEmbeddedNNUESmallSize);
+        return EmbeddedNNUE(nullptr, nullptr, 0);
 }
 
 }


### PR DESCRIPTION
### Motivation

- Simplify handling of embedded NNUE assets by removing the separate "small" network embedding and fetch, reducing binary size and maintenance burden.

### Description

- Removed the `INCBIN` invocation and MSVC fallback data for the small NNUE file (`EvalFileDefaultNameSmall`) in `src/nnue/network.cpp`.
- Changed `get_embedded` to return `nullptr, nullptr, 0` for the `SMALL` `EmbeddedNNUEType` instead of returning removed data pointers.
- Stopped fetching the small network in the download script by removing the `fetch_network EvalFileDefaultNameSmall 1000000` call from `scripts/net.sh`.

### Testing

- Built the project on Linux with default options using `make`, and the build completed successfully.
- Ran the project's automated test suite with `make test` (via CTest), and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ef0be28248327b85f439b4b2dcde1)