### PR TITLE
Retire evaluate small-net runtime branch

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -47,8 +47,6 @@ int Eval::simple_eval(const Position& pos) {
          + (pos.non_pawn_material(c) - pos.non_pawn_material(~c));
 }
 
-bool Eval::use_smallnet(const Position& pos) { return std::abs(simple_eval(pos)) > 962; }
-
 // Evaluate is the evaluator for the outer world. It returns a static evaluation
 // of the position from the point of view of the side to move.
 Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
@@ -59,23 +57,10 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
 
     assert(!pos.checkers());
 
-    bool smallNet           = use_smallnet(pos);
-    auto [psqt, positional] =
-      smallNet ? NNUE::Adapter::secondary_network(networks).evaluate(
-                   pos, accumulators, NNUE::Adapter::secondary_cache(caches))
-               : NNUE::Adapter::active_network(networks).evaluate(
-                 pos, accumulators, NNUE::Adapter::active_cache(caches));
+    auto [psqt, positional] = NNUE::Adapter::active_network(networks).evaluate(
+      pos, accumulators, NNUE::Adapter::active_cache(caches));
 
     Value nnue = (125 * psqt + 131 * positional) / 128;
-
-    // Re-evaluate the position when higher eval accuracy is worth the time spent
-    if (smallNet && (std::abs(nnue) < 236))
-    {
-        std::tie(psqt, positional) = NNUE::Adapter::active_network(networks).evaluate(
-          pos, accumulators, NNUE::Adapter::active_cache(caches));
-        nnue                       = (125 * psqt + 131 * positional) / 128;
-        smallNet                   = false;
-    }
 
     // Blend optimism and eval with nnue complexity
     int nnueComplexity = std::abs(psqt - positional);

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -45,7 +45,6 @@ class AccumulatorStack;
 std::string trace(Position& pos, const Eval::NNUE::Networks& networks);
 
 int   simple_eval(const Position& pos);
-bool  use_smallnet(const Position& pos);
 Value evaluate(const NNUE::Networks&          networks,
                const Position&                pos,
                Eval::NNUE::AccumulatorStack&  accumulators,

--- a/src/nnue/singlenet_adapter.h
+++ b/src/nnue/singlenet_adapter.h
@@ -21,21 +21,6 @@ active_cache(const AccumulatorCaches& caches) noexcept {
 }
 
 
-inline NetworkSmall& secondary_network(Networks& networks) noexcept { return networks.small; }
-
-inline const NetworkSmall& secondary_network(const Networks& networks) noexcept {
-    return networks.small;
-}
-
-inline AccumulatorCaches::Cache<TransformedFeatureDimensionsSmall>&
-secondary_cache(AccumulatorCaches& caches) noexcept {
-    return caches.small;
-}
-
-inline const AccumulatorCaches::Cache<TransformedFeatureDimensionsSmall>&
-secondary_cache(const AccumulatorCaches& caches) noexcept {
-    return caches.small;
-}
 
 inline const char* active_eval_file_name() noexcept { return EvalFileDefaultName; }
 


### PR DESCRIPTION
### Motivation
- Continue single-net migration by removing the remaining runtime branch that could select the legacy small NNUE at evaluation time.
- Eliminate unused small-net selection API surface left after prior phases (`use_smallnet`, secondary adapters) to simplify `Eval::evaluate()`.

### Description
- Remove the runtime `smallNet` selection and re-eval path inside `Eval::evaluate()` so evaluation always uses `NNUE::Adapter::active_network(...)` and `NNUE::Adapter::active_cache(...)`.
- Remove the `use_smallnet` declaration/definition from `src/evaluate.h` / `src/evaluate.cpp` because it became unused.
- Remove unused `secondary_network(...)` and `secondary_cache(...)` helper definitions from `src/nnue/singlenet_adapter.h` after confirming there are no remaining call sites.
- Preserve all primary NNUE types and preserved surfaces (`NetworkSmall`, `NetworkBig`, `NNUE::Networks`, etc.) and avoid any forbidden-file edits.

### Testing
- Ran repository scans (`rg`) for `EvalFileSmall`, `EvalFileDefaultNameSmall`, and `nn-47fc8b7fff06` and found no matches (passed).
- Verified removal of runtime small-net branch and helper callsites via targeted `rg` over `src/evaluate.cpp`, `src/nnue/singlenet_adapter.h`, and `src/evaluate.h` (passed).
- Built the project with the small-net file hidden using `make -C src ...` and the strict warning/error/stale-reference gate (no warnings/errors or stale small-net references) (passed).
- Performed UCI smoke (`uci` / `isready`) and validated `option name EvalFile` present and `EvalFileSmall` absent (passed).
- Executed primary runtime smoke (`setoption EvalFile`, `go depth 1`) and confirmed `readyok` and `bestmove` (passed).
- Ran negative `EvalFileSmall` option smoke and confirmed no crash/assert/abort and engine reports no such option (passed).
- Ran threaded and MultiPV smokes (`Threads=2`, `MultiPV=3`) and an `eval` trace smoke and confirmed execution with no crashes or assertions (passed).
- Ran consumer-boundary and preserved-surface checks and confirmed no regressions to NNUE consumer boundaries and preserved facilities (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f26dca4648327a9020206237a8068)