### PR TITLE
Retire small member from NNUE Networks holder

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -435,7 +435,6 @@ void Engine::load_big_network(const std::string& file) {
 void Engine::save_network(const std::pair<std::optional<std::string>, std::string> files[2]) {
     networks.modify_and_replicate([&files](NN::Networks& networks_) {
         networks_.big.save(files[0].first);
-        networks_.small.save(files[1].first);
     });
 }
 

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -129,12 +129,9 @@ using NetworkSmall = Network<SmallNetworkArchitecture, SmallFeatureTransformer>;
 
 
 struct Networks {
-    Networks(EvalFile bigFile, EvalFile smallFile) :
-        big(bigFile, EmbeddedNNUEType::BIG),
-        small(smallFile, EmbeddedNNUEType::SMALL) {}
+    Networks(EvalFile bigFile, EvalFile) : big(bigFile, EmbeddedNNUEType::BIG) {}
 
-    NetworkBig   big;
-    NetworkSmall small;
+    NetworkBig big;
 };
 
 
@@ -153,7 +150,6 @@ struct std::hash<Stockfish::Eval::NNUE::Networks> {
     std::size_t operator()(const Stockfish::Eval::NNUE::Networks& networks) const noexcept {
         std::size_t h = 0;
         Stockfish::hash_combine(h, networks.big);
-        Stockfish::hash_combine(h, networks.small);
         return h;
     }
 };

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -98,7 +98,6 @@ struct AccumulatorCaches {
     template<typename Networks>
     void clear(const Networks& networks) {
         big.clear(networks.big);
-        small.clear(networks.small);
     }
 
     Cache<TransformedFeatureDimensionsBig>   big;


### PR DESCRIPTION
### Motivation
- The transitional `NNUE::Networks` holder still contained a dead `small` member that is no longer used by runtime code after prior P0S removals, so it should be removed to progress the single-net migration. 
- Keep `NetworkSmall` and small-architecture symbols intact for later phases to avoid broad architectural churn.

### Description
- Remove the `small` member from `struct Networks` and simplify its constructor to accept the primary `big` eval file only, keeping the holder name intact.
- Update `std::hash<NNUE::Networks>` to combine only `networks.big`.
- Remove now-dead holder-dependent calls that referenced `networks.small`, specifically the `save` call in `Engine::save_network` and the `clear` call in `AccumulatorCaches::clear`.
- Files changed: `src/nnue/network.h`, `src/engine.cpp`, `src/nnue/nnue_accumulator.h`.

### Testing
- Ran repository greps to confirm `EvalFileSmall`, `EvalFileDefaultNameSmall`, and `nn-47fc8b7fff06` are absent; no matches found.
- Consumer-boundary grep passed (`PASS: consumer boundary remains sealed`).
- Built the project with the small net hidden (make in `src`) and the strict warning/error gate passed (`PASS: build succeeds with small net hidden and no stale small-net reference`).
- UCI smoke: `uci`/`isready` returned `uciok`/`readyok`, `option name EvalFile` present and `EvalFileSmall` absent.
- Runtime smokes: primary eval (`readyok` + `bestmove`), negative `EvalFileSmall` option (no crash/assert), threaded, MultiPV and `eval` trace smokes all passed.
- Diff-scope check passed: only allowed files were changed and forbidden-file detector returned clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f2e29ab088327901d984ca03560a0)