### PR TITLE
Retire NetworkSmall type surface

### DIFF
--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -413,7 +413,5 @@ bool Network<Arch, Transformer>::write_parameters(std::ostream&      stream,
 template class Network<NetworkArchitecture<TransformedFeatureDimensionsBig, L2Big, L3Big>,
                        FeatureTransformer<TransformedFeatureDimensionsBig>>;
 
-template class Network<NetworkArchitecture<TransformedFeatureDimensionsSmall, L2Small, L3Small>,
-                       FeatureTransformer<TransformedFeatureDimensionsSmall>>;
 
 }  // namespace Stockfish::Eval::NNUE

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -117,15 +117,10 @@ class Network {
 };
 
 // Definitions of the network types
-using SmallFeatureTransformer = FeatureTransformer<TransformedFeatureDimensionsSmall>;
-using SmallNetworkArchitecture =
-  NetworkArchitecture<TransformedFeatureDimensionsSmall, L2Small, L3Small>;
-
 using BigFeatureTransformer  = FeatureTransformer<TransformedFeatureDimensionsBig>;
 using BigNetworkArchitecture = NetworkArchitecture<TransformedFeatureDimensionsBig, L2Big, L3Big>;
 
-using NetworkBig   = Network<BigNetworkArchitecture, BigFeatureTransformer>;
-using NetworkSmall = Network<SmallNetworkArchitecture, SmallFeatureTransformer>;
+using NetworkBig = Network<BigNetworkArchitecture, BigFeatureTransformer>;
 
 
 struct Networks {


### PR DESCRIPTION
### Motivation
- Remove the now-dead `NetworkSmall` type surface and its direct aliases after prior phases detached small-net runtime lifecycle, while leaving accumulator internals and `NetworkBig`/`NNUE::Networks` unchanged.

### Description
- Remove `SmallFeatureTransformer`, `SmallNetworkArchitecture`, and `NetworkSmall` aliases from `src/nnue/network.h` and remove the explicit `Network<...Small...>` template instantiation from `src/nnue/network.cpp`, keeping `NetworkBig` and `NNUE::Networks` intact.
- Changes are confined to `src/nnue/network.h` and `src/nnue/network.cpp` and avoid touching small-accumulator internals, public UCI options, or broader NNUE architecture.

### Testing
- Verified absence of `EvalFileDefaultNameSmall`, `EvalFileSmall`, and `nn-47fc8b7fff06` with `rg` and checked for remaining `NetworkSmall`/small-type references with targeted `rg` runs, with no active runtime matches and a consumer-boundary check reporting `PASS`.
- Built with the small net hidden via `make -C src` (strict warning/error gate passed) and executed automated UCI smoke (`uci/isready`), primary runtime (`go depth 1`), negative `EvalFileSmall` option smoke, threaded and MultiPV smokes, and eval trace smoke, all of which passed; change committed as `b0c5443`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f34b9ca708327a33f3ac0c175a22a)