### PR TITLE
Retire accumulatorSmall surface

### DIFF
--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -283,10 +283,6 @@ template void AccumulatorStack::evaluate<TransformedFeatureDimensionsBig>(
   const Position&                                            pos,
   const FeatureTransformer<TransformedFeatureDimensionsBig>& featureTransformer,
   AccumulatorCaches::Cache<TransformedFeatureDimensionsBig>& cache) noexcept;
-template void AccumulatorStack::evaluate<TransformedFeatureDimensionsSmall>(
-  const Position&                                              pos,
-  const FeatureTransformer<TransformedFeatureDimensionsSmall>& featureTransformer,
-  AccumulatorCaches::Cache<TransformedFeatureDimensionsSmall>& cache) noexcept;
 
 
 namespace {

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -100,50 +100,36 @@ struct AccumulatorCaches {
         big.clear(networks.big);
     }
 
-    Cache<TransformedFeatureDimensionsBig>   big;
-    Cache<TransformedFeatureDimensionsSmall> small;
+    Cache<TransformedFeatureDimensionsBig> big;
 };
 
 
 template<typename FeatureSet>
 struct AccumulatorState {
-    Accumulator<TransformedFeatureDimensionsBig>   accumulatorBig;
-    Accumulator<TransformedFeatureDimensionsSmall> accumulatorSmall;
+    Accumulator<TransformedFeatureDimensionsBig> accumulatorBig;
     typename FeatureSet::DiffType                  diff;
 
     template<IndexType Size>
     auto& acc() noexcept {
-        static_assert(Size == TransformedFeatureDimensionsBig
-                        || Size == TransformedFeatureDimensionsSmall,
-                      "Invalid size for accumulator");
+        static_assert(Size == TransformedFeatureDimensionsBig, "Invalid size for accumulator");
 
-        if constexpr (Size == TransformedFeatureDimensionsBig)
-            return accumulatorBig;
-        else if constexpr (Size == TransformedFeatureDimensionsSmall)
-            return accumulatorSmall;
+        return accumulatorBig;
     }
 
     template<IndexType Size>
     const auto& acc() const noexcept {
-        static_assert(Size == TransformedFeatureDimensionsBig
-                        || Size == TransformedFeatureDimensionsSmall,
-                      "Invalid size for accumulator");
+        static_assert(Size == TransformedFeatureDimensionsBig, "Invalid size for accumulator");
 
-        if constexpr (Size == TransformedFeatureDimensionsBig)
-            return accumulatorBig;
-        else if constexpr (Size == TransformedFeatureDimensionsSmall)
-            return accumulatorSmall;
+        return accumulatorBig;
     }
 
     void reset(const typename FeatureSet::DiffType& dp) noexcept {
         diff = dp;
         accumulatorBig.computed.fill(false);
-        accumulatorSmall.computed.fill(false);
     }
 
     typename FeatureSet::DiffType& reset() noexcept {
         accumulatorBig.computed.fill(false);
-        accumulatorSmall.computed.fill(false);
         return diff;
     }
 };

--- a/src/nnue/nnue_architecture.h
+++ b/src/nnue/nnue_architecture.h
@@ -44,9 +44,6 @@ constexpr IndexType TransformedFeatureDimensionsBig = 1024;
 constexpr int       L2Big                           = 31;
 constexpr int       L3Big                           = 32;
 
-constexpr IndexType TransformedFeatureDimensionsSmall = 128;
-constexpr int       L2Small                           = 15;
-constexpr int       L3Small                           = 32;
 
 constexpr IndexType PSQTBuckets = 8;
 constexpr IndexType LayerStacks = 8;


### PR DESCRIPTION
### Motivation
- Continue the single-net migration by retiring the now-dead small-net accumulator surface (`accumulatorSmall`) once grep confirms it is not used by active runtime code.
- Reduce dead internal surface area (small caches and related small-dimension plumbing) while preserving `NetworkBig`, `NNUE::Networks`, and runtime behaviour.

### Description
- Removed `AccumulatorCaches::small` and kept only the big cache in `AccumulatorCaches` (`src/nnue/nnue_accumulator.h`).
- Removed `AccumulatorState::accumulatorSmall` and simplified `acc<Size>()` accessors and reset paths to only support the big accumulator (`src/nnue/nnue_accumulator.h`).
- Deleted the explicit small-dimension template instantiation of `AccumulatorStack::evaluate` from `src/nnue/nnue_accumulator.cpp`.
- Removed unused small NNUE architecture constants (`TransformedFeatureDimensionsSmall`, `L2Small`, `L3Small`) from `src/nnue/nnue_architecture.h`.
- Kept `accumulatorBig` naming and all big-network surfaces intact per phase constraints; edits were limited to the allowed files.

### Testing
- Verified absence of public small-net names via targeted `rg` checks; no stale `EvalFileSmall`/`NetworkSmall` symbols were found (passed).
- Built with the historical small net hidden and enforced strict warning/error gate; the build completed successfully with no warnings/errors or stale small-net references (passed).
- Ran UCI smoke and primary runtime smokes which reported `uciok`, `readyok`, `option name EvalFile` present and `EvalFileSmall` absent, and returned `bestmove` for a depth-1 search (passed).
- Ran negative `EvalFileSmall` option, threaded (`Threads=2`), `MultiPV=3`, and `eval` trace smokes; none crashed or asserted and all returned expected outputs (passed).
- Consumer-boundary and preserved-surface greps confirmed `NetworkBig`, `NNUE::Networks`, Experience/Book/Syzygy/MCTS/Zobrist surfaces remain present and no forbidden files were changed (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f4c2369f48327b8a106d757be2f13)