### PR TITLE
Rename NetworkBig type surface to neutral Network

### DIFF
--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -117,16 +117,13 @@ class Network {
 };
 
 // Definitions of the network types
-using BigFeatureTransformer  = FeatureTransformer<TransformedFeatureDimensionsBig>;
-using BigNetworkArchitecture = NetworkArchitecture<TransformedFeatureDimensionsBig, L2Big, L3Big>;
-
-using NetworkBig = Network<BigNetworkArchitecture, BigFeatureTransformer>;
 
 
 struct Networks {
     Networks(EvalFile bigFile, EvalFile) : big(bigFile, EmbeddedNNUEType::BIG) {}
 
-    NetworkBig big;
+    Network<NetworkArchitecture<TransformedFeatureDimensionsBig, L2Big, L3Big>,
+            FeatureTransformer<TransformedFeatureDimensionsBig>> big;
 };
 
 

--- a/src/nnue/singlenet_adapter.h
+++ b/src/nnue/singlenet_adapter.h
@@ -6,9 +6,9 @@
 
 namespace Stockfish::Eval::NNUE::Adapter {
 
-inline NetworkBig& active_network(Networks& networks) noexcept { return networks.big; }
+inline auto& active_network(Networks& networks) noexcept { return networks.big; }
 
-inline const NetworkBig& active_network(const Networks& networks) noexcept { return networks.big; }
+inline const auto& active_network(const Networks& networks) noexcept { return networks.big; }
 
 inline AccumulatorCaches::Cache<TransformedFeatureDimensionsBig>&
 active_cache(AccumulatorCaches& caches) noexcept {


### PR DESCRIPTION
### Motivation
- The `NetworkBig` typedef and related `Big*` aliases were misleading after small-net removal and needed to be replaced with a neutral single-net type surface to reflect the active NNUE design. 
- Preserve the `NNUE::Networks` holder and `Networks::big` member while making the active network type explicitly neutral to simplify upcoming single-net work.

### Description
- Replaced the `NetworkBig` alias block by making `Networks::big` hold the concrete `Network<NetworkArchitecture<TransformedFeatureDimensionsBig, L2Big, L3Big>, FeatureTransformer<TransformedFeatureDimensionsBig>>` type directly in `src/nnue/network.h`.
- Updated single-net adapter accessors in `src/nnue/singlenet_adapter.h` to return `auto&` / `const auto&` so consumers bind to the neutral active network without referencing `NetworkBig`.
- Left higher-level holder plumbing (`NNUE::Networks` and `Networks::big`) and big-dimension symbols (`TransformedFeatureDimensionsBig`, `L2Big`, `L3Big`, `accumulatorBig`) intact to keep the change local and non-invasive.

### Testing
- Confirmed retired small-net surfaces are absent via `rg` for small-net symbols and validated there are no matches.
- Built the project with the small net hidden using the provided make invocation (`make -C src -j2 ...`) and the strict warning/error gate, and the build succeeded with no warnings or errors.
- Performed UCI smoke and runtime smokes including `uci`/`isready`, primary `EvalFile` runtime (`go depth 1`), threaded (`Threads=2`), `MultiPV=3`, and `eval` trace, and all produced expected `uciok`/`readyok`/`bestmove` outputs without crashes.
- Ran the negative `EvalFileSmall` option smoke and the consumer-boundary grep checks, which showed no crash/assert and `PASS: consumer boundary remains sealed.`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fed5b24ec8327a4255ce2a3b6f733)