### PR TITLE
Neutralize Networks::big member to Networks::network

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -61,7 +61,7 @@ const char* primary_default_network_file() { return NN::Adapter::active_eval_fil
 
 
 void load_primary_network(NN::Networks& networks, const std::string& binaryDirectory, const std::string& file) {
-    networks.big.load(binaryDirectory, file);
+    networks.network.load(binaryDirectory, file);
 }
 
 
@@ -374,7 +374,7 @@ void Engine::verify_networks() const {
     if (!networksNeedVerification)
         return;
 
-    networks->big.verify(options["EvalFile"], onVerifyNetworks);
+    networks->network.verify(options["EvalFile"], onVerifyNetworks);
 
     auto statuses = networks.get_status_and_errors();
     for (size_t i = 0; i < statuses.size(); ++i)
@@ -434,7 +434,7 @@ void Engine::load_big_network(const std::string& file) {
 
 void Engine::save_network(const std::pair<std::optional<std::string>, std::string> files[2]) {
     networks.modify_and_replicate([&files](NN::Networks& networks_) {
-        networks_.big.save(files[0].first);
+        networks_.network.save(files[0].first);
     });
 }
 

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -120,10 +120,10 @@ class Network {
 
 
 struct Networks {
-    Networks(EvalFile bigFile, EvalFile) : big(bigFile, EmbeddedNNUEType::BIG) {}
+    Networks(EvalFile bigFile, EvalFile) : network(bigFile, EmbeddedNNUEType::BIG) {}
 
     Network<NetworkArchitecture<TransformedFeatureDimensionsBig, L2Big, L3Big>,
-            FeatureTransformer<TransformedFeatureDimensionsBig>> big;
+            FeatureTransformer<TransformedFeatureDimensionsBig>> network;
 };
 
 
@@ -141,7 +141,7 @@ template<>
 struct std::hash<Stockfish::Eval::NNUE::Networks> {
     std::size_t operator()(const Stockfish::Eval::NNUE::Networks& networks) const noexcept {
         std::size_t h = 0;
-        Stockfish::hash_combine(h, networks.big);
+        Stockfish::hash_combine(h, networks.network);
         return h;
     }
 };

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -97,7 +97,7 @@ struct AccumulatorCaches {
 
     template<typename Networks>
     void clear(const Networks& networks) {
-        big.clear(networks.big);
+        big.clear(networks.network);
     }
 
     Cache<TransformedFeatureDimensionsBig> big;

--- a/src/nnue/singlenet_adapter.h
+++ b/src/nnue/singlenet_adapter.h
@@ -6,9 +6,9 @@
 
 namespace Stockfish::Eval::NNUE::Adapter {
 
-inline auto& active_network(Networks& networks) noexcept { return networks.big; }
+inline auto& active_network(Networks& networks) noexcept { return networks.network; }
 
-inline const auto& active_network(const Networks& networks) noexcept { return networks.big; }
+inline const auto& active_network(const Networks& networks) noexcept { return networks.network; }
 
 inline AccumulatorCaches::Cache<TransformedFeatureDimensionsBig>&
 active_cache(AccumulatorCaches& caches) noexcept {


### PR DESCRIPTION
### Motivation
- Continue the single-net migration by neutralizing the remaining holder member name `Networks::big` to a neutral single-net name while preserving the `NNUE::Networks` holder and runtime behavior.
- Make the minimal, local source changes required so downstream consumers and public surfaces remain stable for the next phases.
- Preserve all big-named internals that are out-of-scope for this phase (e.g. `accumulatorBig`, `TransformedFeatureDimensionsBig`) to avoid broader architecture churn.

### Description
- Renamed the `NNUE::Networks` member from `big` to `network` and updated `std::hash<NNUE::Networks>` to hash `networks.network` in `src/nnue/network.h`.
- Updated the single-net adapter accessors to return `networks.network` in `src/nnue/singlenet_adapter.h` while leaving `active_network`/`active_cache` wrapper names unchanged.
- Updated engine NNUE lifecycle call sites (`load`, `verify`, `save`) to use the neutral member in `src/engine.cpp`.
- Updated accumulator cache clearing to reference the renamed holder member in `src/nnue/nnue_accumulator.h` and kept internal `big`-named accumulator/cache objects intact.

### Testing
- Ran repository-wide grep checks for retired small/big identifiers and for residual `.big` holder usage and confirmed no stale retired names reappeared and no remaining `networks.big` usages in the targeted files.
- Built the project with the small net hidden (`make -C src ...`) and the strict warning/error gate passed with no matching stale references in the build log.
- Performed UCI and runtime smoke tests (basic `uci`/`isready`, set `EvalFile` runtime `go`, threaded `go`, `MultiPV` `go`), and all produced `uciok`/`readyok` and `bestmove` as expected while `EvalFileSmall` remained absent and `setoption EvalFileSmall` did not crash.
- Ran eval-trace and consumer-boundary regression checks and confirmed `PASS: consumer boundary remains sealed`, no crashes/asserts, and preserved non-NNUE feature surfaces (Experience/Polybook/Syzygy/MCTS/Zobrist) as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ff45a28708327869be5839b302ad2)