### PR TITLE
Neutralize big NNUE accumulator and dimension names

### DIFF
--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -410,8 +410,8 @@ bool Network<Arch, Transformer>::write_parameters(std::ostream&      stream,
 
 // Explicit template instantiations
 
-template class Network<NetworkArchitecture<TransformedFeatureDimensionsBig, L2Big, L3Big>,
-                       FeatureTransformer<TransformedFeatureDimensionsBig>>;
+template class Network<NetworkArchitecture<TransformedFeatureDimensions, L2, L3>,
+                       FeatureTransformer<TransformedFeatureDimensions>>;
 
 
 }  // namespace Stockfish::Eval::NNUE

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -122,8 +122,8 @@ class Network {
 struct Networks {
     Networks(EvalFile bigFile, EvalFile) : network(bigFile, EmbeddedNNUEType::BIG) {}
 
-    Network<NetworkArchitecture<TransformedFeatureDimensionsBig, L2Big, L3Big>,
-            FeatureTransformer<TransformedFeatureDimensionsBig>> network;
+    Network<NetworkArchitecture<TransformedFeatureDimensions, L2, L3>,
+            FeatureTransformer<TransformedFeatureDimensions>> network;
 };
 
 

--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -142,7 +142,7 @@ template<IndexType Dimensions>
 void AccumulatorStack::evaluate(const Position&                       pos,
                                 const FeatureTransformer<Dimensions>& featureTransformer,
                                 AccumulatorCaches::Cache<Dimensions>& cache) noexcept {
-    constexpr bool UseThreats = (Dimensions == TransformedFeatureDimensionsBig);
+    constexpr bool UseThreats = (Dimensions == TransformedFeatureDimensions);
 
     evaluate_side<PSQFeatureSet>(WHITE, pos, featureTransformer, cache);
 
@@ -279,10 +279,10 @@ void AccumulatorStack::backward_update_incremental(
 }
 
 // Explicit template instantiations
-template void AccumulatorStack::evaluate<TransformedFeatureDimensionsBig>(
+template void AccumulatorStack::evaluate<TransformedFeatureDimensions>(
   const Position&                                            pos,
-  const FeatureTransformer<TransformedFeatureDimensionsBig>& featureTransformer,
-  AccumulatorCaches::Cache<TransformedFeatureDimensionsBig>& cache) noexcept;
+  const FeatureTransformer<TransformedFeatureDimensions>& featureTransformer,
+  AccumulatorCaches::Cache<TransformedFeatureDimensions>& cache) noexcept;
 
 
 namespace {

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -97,39 +97,39 @@ struct AccumulatorCaches {
 
     template<typename Networks>
     void clear(const Networks& networks) {
-        big.clear(networks.network);
+        cache.clear(networks.network);
     }
 
-    Cache<TransformedFeatureDimensionsBig> big;
+    Cache<TransformedFeatureDimensions> cache;
 };
 
 
 template<typename FeatureSet>
 struct AccumulatorState {
-    Accumulator<TransformedFeatureDimensionsBig> accumulatorBig;
+    Accumulator<TransformedFeatureDimensions> accumulator;
     typename FeatureSet::DiffType                  diff;
 
     template<IndexType Size>
     auto& acc() noexcept {
-        static_assert(Size == TransformedFeatureDimensionsBig, "Invalid size for accumulator");
+        static_assert(Size == TransformedFeatureDimensions, "Invalid size for accumulator");
 
-        return accumulatorBig;
+        return accumulator;
     }
 
     template<IndexType Size>
     const auto& acc() const noexcept {
-        static_assert(Size == TransformedFeatureDimensionsBig, "Invalid size for accumulator");
+        static_assert(Size == TransformedFeatureDimensions, "Invalid size for accumulator");
 
-        return accumulatorBig;
+        return accumulator;
     }
 
     void reset(const typename FeatureSet::DiffType& dp) noexcept {
         diff = dp;
-        accumulatorBig.computed.fill(false);
+        accumulator.computed.fill(false);
     }
 
     typename FeatureSet::DiffType& reset() noexcept {
-        accumulatorBig.computed.fill(false);
+        accumulator.computed.fill(false);
         return diff;
     }
 };

--- a/src/nnue/nnue_architecture.h
+++ b/src/nnue/nnue_architecture.h
@@ -40,9 +40,9 @@ using ThreatFeatureSet = Features::FullThreats;
 using PSQFeatureSet    = Features::HalfKAv2_hm;
 
 // Number of input feature dimensions after conversion
-constexpr IndexType TransformedFeatureDimensionsBig = 1024;
-constexpr int       L2Big                           = 31;
-constexpr int       L3Big                           = 32;
+constexpr IndexType TransformedFeatureDimensions = 1024;
+constexpr int       L2                           = 31;
+constexpr int       L3                           = 32;
 
 
 constexpr IndexType PSQTBuckets = 8;

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -81,7 +81,7 @@ void permute(std::array<T, N>& data, const std::array<std::size_t, OrderSize>& o
 template<IndexType TransformedFeatureDimensions>
 class FeatureTransformer {
     static constexpr bool UseThreats =
-      (TransformedFeatureDimensions == TransformedFeatureDimensionsBig);
+      (TransformedFeatureDimensions == ::Stockfish::Eval::NNUE::TransformedFeatureDimensions);
     // Number of output dimensions for one side
     static constexpr IndexType HalfDimensions = TransformedFeatureDimensions;
 

--- a/src/nnue/singlenet_adapter.h
+++ b/src/nnue/singlenet_adapter.h
@@ -10,14 +10,14 @@ inline auto& active_network(Networks& networks) noexcept { return networks.netwo
 
 inline const auto& active_network(const Networks& networks) noexcept { return networks.network; }
 
-inline AccumulatorCaches::Cache<TransformedFeatureDimensionsBig>&
+inline AccumulatorCaches::Cache<TransformedFeatureDimensions>&
 active_cache(AccumulatorCaches& caches) noexcept {
-    return caches.big;
+    return caches.cache;
 }
 
-inline const AccumulatorCaches::Cache<TransformedFeatureDimensionsBig>&
+inline const AccumulatorCaches::Cache<TransformedFeatureDimensions>&
 active_cache(const AccumulatorCaches& caches) noexcept {
-    return caches.big;
+    return caches.cache;
 }
 
 


### PR DESCRIPTION
### Motivation
- Continue the P0X→P0Y migration by retiring remaining Big-suffixed NNUE internal surfaces so single-net internals use neutral names without changing numeric topology or public surfaces.
- Make the accumulator and dimension symbols local/neutral while preserving the transitional `NNUE::Networks` holder and consumer wrappers.

### Description
- Renamed NNUE architecture constants `TransformedFeatureDimensionsBig` → `TransformedFeatureDimensions`, `L2Big` → `L2`, and `L3Big` → `L3` in `src/nnue/nnue_architecture.h` without changing numeric values.
- Replaced accumulator storage `accumulatorBig` with `accumulator` and updated accessors, `static_assert`s and reset logic in `src/nnue/nnue_accumulator.h` and `src/nnue/nnue_accumulator.cpp`.
- Renamed the local accumulator cache member `big` → `cache` and updated `AccumulatorCaches` usage and the adapter accessors in `src/nnue/singlenet_adapter.h` to return `caches.cache` safely within NNUE internals.
- Updated network type instantiations and explicit template instantiations to use the neutral dimension symbols in `src/nnue/network.h` and `src/nnue/network.cpp`.
- Applied one small compile-fix in `src/nnue/nnue_feature_transformer.h` to reference the renamed constant via the qualified name so `FeatureTransformer` continues to detect `UseThreats` correctly.

### Testing
- Preflight grep checks for retired small/big symbols were run and produced no matches for retired surfaces (pass).
- Inventory and consumer-boundary scans via `rg` confirmed only allowed NNUE internals were touched and that consumer boundary files remained sealed (pass).
- Full build with the small net hidden using `make -C src -j2 build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld"` completed successfully with no warnings or stale retired references in the build log (pass).
- UCI smoke via piping `uci`/`isready` validated `uciok`/`readyok` and showed `option name EvalFile` present while `EvalFileSmall` remained absent (pass).
- Primary runtime smoke (set `EvalFile` and `go depth 1`) returned `bestmove` (pass).
- Negative `EvalFileSmall` option smoke ran and produced no crash/assert/abort (pass).
- Threaded and MultiPV smokes (2 threads, `go depth 2`, `MultiPV=3`) produced `readyok` and `bestmove` (pass).
- Eval trace smoke (`eval`) produced no asserts/aborts (pass).
- Diff scope check confirmed only the intended NNUE files were modified and no forbidden files were changed (pass).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ff65f0e28832798350a0910a02d53)