### PR TITLE
Refactor NNUE network API: replace `Networks` wrapper with single `Network` and internal `NetworkImpl`

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -60,8 +60,8 @@ namespace {
 const char* primary_default_network_file() { return NN::Adapter::active_eval_file_name(); }
 
 
-void load_primary_network(NN::Networks& networks, const std::string& binaryDirectory, const std::string& file) {
-    networks.network.load(binaryDirectory, file);
+void load_primary_network(NN::Network& networks, const std::string& binaryDirectory, const std::string& file) {
+    networks.load(binaryDirectory, file);
 }
 
 
@@ -74,9 +74,9 @@ Engine::Engine(std::optional<std::string> path) :
     threads(),
     networks(
       numaContext,
-      // Heap-allocate because sizeof(NN::Networks) is large
-      std::make_unique<NN::Networks>(NN::EvalFile{primary_default_network_file(), "None", ""},
-                                     NN::EvalFile{primary_default_network_file(), "None", ""})) {
+      // Heap-allocate because sizeof(NN::Network) is large
+      std::make_unique<NN::Network>(NN::EvalFile{primary_default_network_file(), "None", ""},
+                                    NN::EmbeddedNNUEType::BIG)) {
 
     pos.set(StartFEN, false, &states->back());
 
@@ -374,7 +374,7 @@ void Engine::verify_networks() const {
     if (!networksNeedVerification)
         return;
 
-    networks->network.verify(options["EvalFile"], onVerifyNetworks);
+    networks->verify(options["EvalFile"], onVerifyNetworks);
 
     auto statuses = networks.get_status_and_errors();
     for (size_t i = 0; i < statuses.size(); ++i)
@@ -410,7 +410,7 @@ void Engine::verify_networks() const {
 }
 
 void Engine::load_networks() {
-    networks.modify_and_replicate([this](NN::Networks& networks_) {
+    networks.modify_and_replicate([this](NN::Network& networks_) {
         load_primary_network(networks_, binaryDirectory, std::string(options["EvalFile"]));
     });
     threads.clear();
@@ -423,7 +423,7 @@ void Engine::load_network(const std::string& file) {
 }
 
 void Engine::load_big_network(const std::string& file) {
-    networks.modify_and_replicate([this, &file](NN::Networks& networks_) {
+    networks.modify_and_replicate([this, &file](NN::Network& networks_) {
         load_primary_network(networks_, binaryDirectory, file);
     });
     threads.clear();
@@ -433,8 +433,8 @@ void Engine::load_big_network(const std::string& file) {
 
 
 void Engine::save_network(const std::pair<std::optional<std::string>, std::string> files[2]) {
-    networks.modify_and_replicate([&files](NN::Networks& networks_) {
-        networks_.network.save(files[0].first);
+    networks.modify_and_replicate([&files](NN::Network& networks_) {
+        networks_.save(files[0].first);
     });
 }
 

--- a/src/engine.h
+++ b/src/engine.h
@@ -123,7 +123,7 @@ class Engine {
     OptionsMap                                         options;
     ThreadPool                                         threads;
     TranspositionTable                                 tt;
-    LazyNumaReplicatedSystemWide<Eval::NNUE::Networks> networks;
+    LazyNumaReplicatedSystemWide<Eval::NNUE::Network> networks;
 
     Search::SearchManager::UpdateContext  updateContext;
     std::function<void(std::string_view)> onVerifyNetworks;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -49,7 +49,7 @@ int Eval::simple_eval(const Position& pos) {
 
 // Evaluate is the evaluator for the outer world. It returns a static evaluation
 // of the position from the point of view of the side to move.
-Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
+Value Eval::evaluate(const Eval::NNUE::Network&    networks,
                      const Position&                pos,
                      Eval::NNUE::AccumulatorStack&  accumulators,
                      Eval::NNUE::AccumulatorCaches& caches,
@@ -57,7 +57,7 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
 
     assert(!pos.checkers());
 
-    auto [psqt, positional] = NNUE::Adapter::active_network(networks).evaluate(
+    auto [psqt, positional] = networks.evaluate(
       pos, accumulators, NNUE::Adapter::active_cache(caches));
 
     Value nnue = (125 * psqt + 131 * positional) / 128;
@@ -83,7 +83,7 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
 // a string (suitable for outputting to stdout) that contains the detailed
 // descriptions and values of each evaluation term. Useful for debugging.
 // Trace scores are from white's point of view
-std::string Eval::trace(Position& pos, const Eval::NNUE::Networks& networks) {
+std::string Eval::trace(Position& pos, const Eval::NNUE::Network& networks) {
 
     if (pos.checkers())
         return "Final evaluation: none (in check)";
@@ -97,7 +97,7 @@ std::string Eval::trace(Position& pos, const Eval::NNUE::Networks& networks) {
 
     ss << std::showpoint << std::showpos << std::fixed << std::setprecision(2) << std::setw(15);
 
-    auto [psqt, positional] = NNUE::Adapter::active_network(networks).evaluate(
+    auto [psqt, positional] = networks.evaluate(
       pos, *accumulators, NNUE::Adapter::active_cache(*caches));
     Value v                 = psqt + positional;
     v                       = pos.side_to_move() == WHITE ? v : -v;

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -37,15 +37,15 @@ namespace Eval {
 #define EvalFileDefaultName "nn-83a0d6daf7e5.nnue"
 
 namespace NNUE {
-struct Networks;
+class Network;
 struct AccumulatorCaches;
 class AccumulatorStack;
 }
 
-std::string trace(Position& pos, const Eval::NNUE::Networks& networks);
+std::string trace(Position& pos, const Eval::NNUE::Network& networks);
 
 int   simple_eval(const Position& pos);
-Value evaluate(const NNUE::Networks&          networks,
+Value evaluate(const NNUE::Network&          networks,
                const Position&                pos,
                Eval::NNUE::AccumulatorStack&  accumulators,
                Eval::NNUE::AccumulatorCaches& caches,

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -104,7 +104,7 @@ bool write_parameters(std::ostream& stream, const T& reference) {
 }  // namespace Detail
 
 template<typename Arch, typename Transformer>
-void Network<Arch, Transformer>::load(const std::string& rootDirectory, std::string evalfilePath) {
+void NetworkImpl<Arch, Transformer>::load(const std::string& rootDirectory, std::string evalfilePath) {
 #if defined(DEFAULT_NNUE_DIRECTORY)
     std::vector<std::string> dirs = {"<internal>", "", rootDirectory,
                                      stringify(DEFAULT_NNUE_DIRECTORY)};
@@ -134,7 +134,7 @@ void Network<Arch, Transformer>::load(const std::string& rootDirectory, std::str
 
 
 template<typename Arch, typename Transformer>
-bool Network<Arch, Transformer>::save(const std::optional<std::string>& filename) const {
+bool NetworkImpl<Arch, Transformer>::save(const std::optional<std::string>& filename) const {
     std::string actualFilename;
     std::string msg;
 
@@ -166,7 +166,7 @@ bool Network<Arch, Transformer>::save(const std::optional<std::string>& filename
 
 template<typename Arch, typename Transformer>
 NetworkOutput
-Network<Arch, Transformer>::evaluate(const Position&                         pos,
+NetworkImpl<Arch, Transformer>::evaluate(const Position&                         pos,
                                      AccumulatorStack&                       accumulatorStack,
                                      AccumulatorCaches::Cache<FTDimensions>& cache) const {
 
@@ -186,7 +186,7 @@ Network<Arch, Transformer>::evaluate(const Position&                         pos
 
 
 template<typename Arch, typename Transformer>
-void Network<Arch, Transformer>::verify(std::string                                  evalfilePath,
+void NetworkImpl<Arch, Transformer>::verify(std::string                                  evalfilePath,
                                         const std::function<void(std::string_view)>& f) const {
     if (evalfilePath.empty())
         evalfilePath = evalFile.defaultName;
@@ -228,7 +228,7 @@ void Network<Arch, Transformer>::verify(std::string                             
 
 template<typename Arch, typename Transformer>
 NnueEvalTrace
-Network<Arch, Transformer>::trace_evaluate(const Position&                         pos,
+NetworkImpl<Arch, Transformer>::trace_evaluate(const Position&                         pos,
                                            AccumulatorStack&                       accumulatorStack,
                                            AccumulatorCaches::Cache<FTDimensions>& cache) const {
 
@@ -256,7 +256,7 @@ Network<Arch, Transformer>::trace_evaluate(const Position&                      
 
 
 template<typename Arch, typename Transformer>
-void Network<Arch, Transformer>::load_user_net(const std::string& dir,
+void NetworkImpl<Arch, Transformer>::load_user_net(const std::string& dir,
                                                const std::string& evalfilePath) {
     std::string fullPath = dir;
 
@@ -277,7 +277,7 @@ void Network<Arch, Transformer>::load_user_net(const std::string& dir,
 
 
 template<typename Arch, typename Transformer>
-void Network<Arch, Transformer>::load_internal() {
+void NetworkImpl<Arch, Transformer>::load_internal() {
     // C++ way to prepare a buffer for a memory stream
     class MemoryBuffer: public std::basic_streambuf<char> {
        public:
@@ -304,13 +304,13 @@ void Network<Arch, Transformer>::load_internal() {
 
 
 template<typename Arch, typename Transformer>
-void Network<Arch, Transformer>::initialize() {
+void NetworkImpl<Arch, Transformer>::initialize() {
     initialized = true;
 }
 
 
 template<typename Arch, typename Transformer>
-bool Network<Arch, Transformer>::save(std::ostream&      stream,
+bool NetworkImpl<Arch, Transformer>::save(std::ostream&      stream,
                                       const std::string& name,
                                       const std::string& netDescription) const {
     if (name.empty() || name == "None")
@@ -321,7 +321,7 @@ bool Network<Arch, Transformer>::save(std::ostream&      stream,
 
 
 template<typename Arch, typename Transformer>
-std::optional<std::string> Network<Arch, Transformer>::load(std::istream& stream) {
+std::optional<std::string> NetworkImpl<Arch, Transformer>::load(std::istream& stream) {
     initialize();
     std::string description;
 
@@ -330,7 +330,7 @@ std::optional<std::string> Network<Arch, Transformer>::load(std::istream& stream
 
 
 template<typename Arch, typename Transformer>
-std::size_t Network<Arch, Transformer>::get_content_hash() const {
+std::size_t NetworkImpl<Arch, Transformer>::get_content_hash() const {
     if (!initialized)
         return 0;
 
@@ -345,7 +345,7 @@ std::size_t Network<Arch, Transformer>::get_content_hash() const {
 
 // Read network header
 template<typename Arch, typename Transformer>
-bool Network<Arch, Transformer>::read_header(std::istream&  stream,
+bool NetworkImpl<Arch, Transformer>::read_header(std::istream&  stream,
                                              std::uint32_t* hashValue,
                                              std::string*   desc) const {
     std::uint32_t version, size;
@@ -363,7 +363,7 @@ bool Network<Arch, Transformer>::read_header(std::istream&  stream,
 
 // Write network header
 template<typename Arch, typename Transformer>
-bool Network<Arch, Transformer>::write_header(std::ostream&      stream,
+bool NetworkImpl<Arch, Transformer>::write_header(std::ostream&      stream,
                                               std::uint32_t      hashValue,
                                               const std::string& desc) const {
     write_little_endian<std::uint32_t>(stream, Version);
@@ -375,12 +375,12 @@ bool Network<Arch, Transformer>::write_header(std::ostream&      stream,
 
 
 template<typename Arch, typename Transformer>
-bool Network<Arch, Transformer>::read_parameters(std::istream& stream,
+bool NetworkImpl<Arch, Transformer>::read_parameters(std::istream& stream,
                                                  std::string&  netDescription) {
     std::uint32_t hashValue;
     if (!read_header(stream, &hashValue, &netDescription))
         return false;
-    if (hashValue != Network::hash)
+    if (hashValue != NetworkImpl<Arch, Transformer>::hash)
         return false;
     if (!Detail::read_parameters(stream, featureTransformer))
         return false;
@@ -394,9 +394,9 @@ bool Network<Arch, Transformer>::read_parameters(std::istream& stream,
 
 
 template<typename Arch, typename Transformer>
-bool Network<Arch, Transformer>::write_parameters(std::ostream&      stream,
+bool NetworkImpl<Arch, Transformer>::write_parameters(std::ostream&      stream,
                                                   const std::string& netDescription) const {
-    if (!write_header(stream, Network::hash, netDescription))
+    if (!write_header(stream, NetworkImpl<Arch, Transformer>::hash, netDescription))
         return false;
     if (!Detail::write_parameters(stream, featureTransformer))
         return false;
@@ -410,7 +410,7 @@ bool Network<Arch, Transformer>::write_parameters(std::ostream&      stream,
 
 // Explicit template instantiations
 
-template class Network<NetworkArchitecture<TransformedFeatureDimensions, L2, L3>,
+template class NetworkImpl<NetworkArchitecture<TransformedFeatureDimensions, L2, L3>,
                        FeatureTransformer<TransformedFeatureDimensions>>;
 
 

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -54,19 +54,19 @@ using NetworkOutput = std::tuple<Value, Value>;
 // This is required to allow sharing the network via shared memory, as
 // there is no way to run destructors.
 template<typename Arch, typename Transformer>
-class Network {
+class NetworkImpl {
     static constexpr IndexType FTDimensions = Arch::TransformedFeatureDimensions;
 
    public:
-    Network(EvalFile file, EmbeddedNNUEType type) :
+    NetworkImpl(EvalFile file, EmbeddedNNUEType type) :
         evalFile(file),
         embeddedType(type) {}
 
-    Network(const Network& other) = default;
-    Network(Network&& other)      = default;
+    NetworkImpl(const NetworkImpl& other) = default;
+    NetworkImpl(NetworkImpl&& other)      = default;
 
-    Network& operator=(const Network& other) = default;
-    Network& operator=(Network&& other)      = default;
+    NetworkImpl& operator=(const NetworkImpl& other) = default;
+    NetworkImpl& operator=(NetworkImpl&& other)      = default;
 
     void load(const std::string& rootDirectory, std::string evalfilePath);
     bool save(const std::optional<std::string>& filename) const;
@@ -119,30 +119,28 @@ class Network {
 // Definitions of the network types
 
 
-struct Networks {
-    Networks(EvalFile bigFile, EvalFile) : network(bigFile, EmbeddedNNUEType::BIG) {}
-
-    Network<NetworkArchitecture<TransformedFeatureDimensions, L2, L3>,
-            FeatureTransformer<TransformedFeatureDimensions>> network;
+class Network:
+    public NetworkImpl<NetworkArchitecture<TransformedFeatureDimensions, L2, L3>,
+                       FeatureTransformer<TransformedFeatureDimensions>> {
+   public:
+    using NetworkImpl::NetworkImpl;
 };
 
 
 }  // namespace Stockfish
 
 template<typename ArchT, typename FeatureTransformerT>
-struct std::hash<Stockfish::Eval::NNUE::Network<ArchT, FeatureTransformerT>> {
+struct std::hash<Stockfish::Eval::NNUE::NetworkImpl<ArchT, FeatureTransformerT>> {
     std::size_t operator()(
-      const Stockfish::Eval::NNUE::Network<ArchT, FeatureTransformerT>& network) const noexcept {
+      const Stockfish::Eval::NNUE::NetworkImpl<ArchT, FeatureTransformerT>& network) const noexcept {
         return network.get_content_hash();
     }
 };
 
 template<>
-struct std::hash<Stockfish::Eval::NNUE::Networks> {
-    std::size_t operator()(const Stockfish::Eval::NNUE::Networks& networks) const noexcept {
-        std::size_t h = 0;
-        Stockfish::hash_combine(h, networks.network);
-        return h;
+struct std::hash<Stockfish::Eval::NNUE::Network> {
+    std::size_t operator()(const Stockfish::Eval::NNUE::Network& network) const noexcept {
+        return network.get_content_hash();
     }
 };
 

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -60,9 +60,9 @@ struct alignas(CacheLineSize) Accumulator {
 // is commonly referred to as "Finny Tables".
 struct AccumulatorCaches {
 
-    template<typename Networks>
-    AccumulatorCaches(const Networks& networks) {
-        clear(networks);
+    template<typename NetType>
+    AccumulatorCaches(const NetType& network) {
+        clear(network);
     }
 
     template<IndexType Size>
@@ -95,9 +95,9 @@ struct AccumulatorCaches {
         std::array<std::array<Entry, COLOR_NB>, SQUARE_NB> entries;
     };
 
-    template<typename Networks>
-    void clear(const Networks& networks) {
-        cache.clear(networks.network);
+    template<typename NetType>
+    void clear(const NetType& network) {
+        cache.clear(network);
     }
 
     Cache<TransformedFeatureDimensions> cache;

--- a/src/nnue/nnue_misc.cpp
+++ b/src/nnue/nnue_misc.cpp
@@ -97,7 +97,7 @@ void format_cp_aligned_dot(Value v, std::stringstream& stream, const Position& p
 // Returns a string with the value of each piece on a board,
 // and a table for (PSQT, Layers) values bucket by bucket.
 std::string
-trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::AccumulatorCaches& caches) {
+trace(Position& pos, const Eval::NNUE::Network& networks, Eval::NNUE::AccumulatorCaches& caches) {
 
     std::stringstream ss;
 
@@ -126,7 +126,7 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
     // We estimate the value of each piece by doing a differential evaluation from
     // the current base eval, simulating the removal of the piece from its square.
     auto [psqt, positional] =
-      Adapter::active_network(networks).evaluate(pos, *accumulators, Adapter::active_cache(caches));
+      networks.evaluate(pos, *accumulators, Adapter::active_cache(caches));
     Value base              = psqt + positional;
     base                    = pos.side_to_move() == WHITE ? base : -base;
 
@@ -142,7 +142,7 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
                 pos.remove_piece(sq);
 
                 accumulators->reset();
-                std::tie(psqt, positional) = Adapter::active_network(networks).evaluate(
+                std::tie(psqt, positional) = networks.evaluate(
                   pos, *accumulators, Adapter::active_cache(caches));
                 Value eval                 = psqt + positional;
                 eval                       = pos.side_to_move() == WHITE ? eval : -eval;
@@ -160,7 +160,7 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
     ss << '\n';
 
     accumulators->reset();
-    auto t = Adapter::active_network(networks).trace_evaluate(
+    auto t = networks.trace_evaluate(
       pos, *accumulators, Adapter::active_cache(caches));
 
     ss << " NNUE network contributions "

--- a/src/nnue/nnue_misc.h
+++ b/src/nnue/nnue_misc.h
@@ -52,10 +52,10 @@ struct NnueEvalTrace {
     std::size_t correctBucket;
 };
 
-struct Networks;
+class Network;
 struct AccumulatorCaches;
 
-std::string trace(Position& pos, const Networks& networks, AccumulatorCaches& caches);
+std::string trace(Position& pos, const Network& networks, AccumulatorCaches& caches);
 
 }  // namespace Stockfish::Eval::NNUE
 }  // namespace Stockfish

--- a/src/nnue/singlenet_adapter.h
+++ b/src/nnue/singlenet_adapter.h
@@ -6,10 +6,6 @@
 
 namespace Stockfish::Eval::NNUE::Adapter {
 
-inline auto& active_network(Networks& networks) noexcept { return networks.network; }
-
-inline const auto& active_network(const Networks& networks) noexcept { return networks.network; }
-
 inline AccumulatorCaches::Cache<TransformedFeatureDimensions>&
 active_cache(AccumulatorCaches& caches) noexcept {
     return caches.cache;

--- a/src/search.h
+++ b/src/search.h
@@ -136,20 +136,20 @@ struct SharedState {
     SharedState(const OptionsMap&                                         optionsMap,
                 ThreadPool&                                               threadPool,
                 TranspositionTable&                                       transpositionTable,
-                const LazyNumaReplicatedSystemWide<Eval::NNUE::Networks>& nets) :
+                const LazyNumaReplicatedSystemWide<Eval::NNUE::Network>& nets) :
         options(optionsMap),
         threads(threadPool),
         tt(transpositionTable),
         networks(nets) {}
 
-    const LazyNumaReplicatedSystemWide<Eval::NNUE::Networks>& nnue_networks() const {
+    const LazyNumaReplicatedSystemWide<Eval::NNUE::Network>& nnue_networks() const {
         return networks;
     }
 
     const OptionsMap&                                         options;
     ThreadPool&                                               threads;
     TranspositionTable&                                       tt;
-    const LazyNumaReplicatedSystemWide<Eval::NNUE::Networks>& networks;
+    const LazyNumaReplicatedSystemWide<Eval::NNUE::Network>& networks;
 };
 
 class Worker;
@@ -359,8 +359,8 @@ class Worker {
     const OptionsMap&                                         options;
     ThreadPool&                                               threads;
     TranspositionTable&                                       tt;
-    const LazyNumaReplicatedSystemWide<Eval::NNUE::Networks>& networks;
-    const LazyNumaReplicatedSystemWide<Eval::NNUE::Networks>& nnue_networks() const {
+    const LazyNumaReplicatedSystemWide<Eval::NNUE::Network>& networks;
+    const LazyNumaReplicatedSystemWide<Eval::NNUE::Network>& nnue_networks() const {
         return networks;
     }
 


### PR DESCRIPTION
### Motivation

- Simplify and unify the NNUE network representation by removing the older `Networks` wrapper and exposing a single network type for use throughout the engine.
- Make the internal templated implementation explicit (`NetworkImpl`) while providing a concrete `Network` alias that is trivial and shareable across processes.

### Description

- Introduced `NetworkImpl<...>` as the templated internal implementation and added a concrete `Network` class that inherits the implementation for the engine's single-network use-case.`
- Replaced uses of `Eval::NNUE::Networks` (and its nested `.network`) with `Eval::NNUE::Network` throughout headers and sources, including `engine.*`, `evaluate.*`, `nnue/*`, `search.h`, and misc utilities.
- Updated NNUE APIs and function/templated signatures to match the new types (`evaluate`, `trace`, `verify`, `load`, `save`, `get_content_hash`, etc.), and adapted `AccumulatorCaches` templates to accept the single network type.
- Removed the `active_network` adapter indirection and adjusted `load_primary_network` and related engine logic to call the revised `Network` methods, and updated hash specializations accordingly.

### Testing

- Built the project with the changes (`make`) and the compilation completed successfully.
- Ran the automated test suite (`make test` / existing unit/regression tests) and all tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1017ddeaac83279b7df4a730a32da0)