### PR TITLE
Singularize NNUE lifecycle API names

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -204,20 +204,20 @@ Engine::Engine(std::optional<std::string> path) :
           return std::nullopt;
       }));
 
-    load_networks();
+    load_network();
     Experience::update_settings(options);
     resize_threads();
 }
 
 std::uint64_t Engine::perft(const std::string& fen, Depth depth, bool isChess960) {
-    verify_networks();
+    verify_network();
 
     return Benchmark::perft(fen, depth, isChess960);
 }
 
 void Engine::go(Search::LimitsType& limits) {
     assert(limits.perft == 0);
-    verify_networks();
+    verify_network();
     threads.ensure_network_replicated();
 
     const bool searchRequested = limits.depth || limits.nodes || limits.mate || limits.infinite
@@ -289,13 +289,9 @@ void Engine::set_on_bestmove(std::function<void(std::string_view, std::string_vi
     updateContext.onBestmove = std::move(f);
 }
 
-void Engine::set_on_verify_networks(std::function<void(std::string_view)>&& f) {
+void Engine::set_on_verify_network(std::function<void(std::string_view)>&& f) {
     onVerifyNetwork = std::move(f);
     networksNeedVerification = true;
-}
-
-void Engine::set_on_verify_network(std::function<void(std::string_view)>&& f) {
-    set_on_verify_networks(std::move(f));
 }
 
 void Engine::wait_for_search_finished() { threads.main_thread()->wait_for_search_finished(); }
@@ -366,10 +362,6 @@ std::string Engine::get_default_network() const {
 }
 
 void Engine::verify_network() const {
-    verify_networks();
-}
-
-void Engine::verify_networks() const {
     if (!networksNeedVerification)
         return;
 
@@ -408,7 +400,7 @@ void Engine::verify_networks() const {
     networksNeedVerification = false;
 }
 
-void Engine::load_networks() {
+void Engine::load_network() {
     networks.modify_and_replicate([this](NN::Network& networks_) {
         load_primary_network(networks_, binaryDirectory, std::string(options["EvalFile"]));
     });
@@ -444,7 +436,7 @@ void Engine::trace_eval() const {
     Position     p;
     p.set(pos.fen(), options["UCI_Chess960"], &trace_states->back());
 
-    verify_networks();
+    verify_network();
 
     sync_cout << "\n" << Eval::trace(p, *networks) << sync_endl;
 }

--- a/src/engine.h
+++ b/src/engine.h
@@ -79,19 +79,17 @@ class Engine {
     void set_on_update_full(std::function<void(const InfoFull&)>&&);
     void set_on_iter(std::function<void(const InfoIter&)>&&);
     void set_on_bestmove(std::function<void(std::string_view, std::string_view)>&&);
-    void set_on_verify_networks(std::function<void(std::string_view)>&&);
+    void set_on_verify_network(std::function<void(std::string_view)>&&);
 
     // network related
 
-    void verify_networks() const;
-    void load_networks();
+    void verify_network() const;
+    void load_network();
     void load_big_network(const std::string& file);
     void save_network(const std::pair<std::optional<std::string>, std::string> files[2]);
 
     std::string get_default_network() const;
     void        load_network(const std::string& file);
-    void        verify_network() const;
-    void        set_on_verify_network(std::function<void(std::string_view)>&&);
 
     // utility functions
 


### PR DESCRIPTION
### Motivation
- The codebase moved to a single NNUE network instance and remaining plural lifecycle APIs are now semantically obsolete; this change finishes the P0AB phase by singularizing lifecycle API names. 
- Preserve existing behavior and callback semantics while removing plural wrappers and preventing duplicated APIs.

### Description
- Rename/remove plural Engine lifecycle surfaces by deleting `load_networks`, `verify_networks`, and `set_on_verify_networks` and keeping/using singular APIs `load_network`, `verify_network`, and `set_on_verify_network` in `src/engine.cpp` and `src/engine.h`.
- Update all internal callsites to invoke the singular APIs (constructor/init, `perft`, `go`, `trace_eval`, and `Options` callback routing remain consistent).
- Preserve behavior: callback semantics (`onVerifyNetwork`), network loading/verifying, and `load_network(const std::string&)` remain unchanged.

### Testing
- Ran repository sanity and grep checks to ensure retired/plural symbols are absent and singular symbols present via `rg` and consumer-boundary checks, which passed.
- Built with the small net hidden using `make -C src ...` and verified the build completed with no warnings/errors or stale plural/retired references.
- Performed UCI and runtime smokes: `uci`/`isready` (uciok/readyok), ensured `option name EvalFile` is present and `EvalFileSmall` is absent, and validated `bestmove` on a depth-1 search; all passed.
- Negative `EvalFileSmall` option smoke, threaded (Threads=2), MultiPV (MultiPV=3), and `eval` trace smokes were executed and produced no crashes/asserts; all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a102c5e0918832797c9932153c70d5a)