### PR TITLE
Port Stockfish stop-on-forced-mate time-management guard

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -716,8 +716,11 @@ void Search::Worker::iterative_deepening() {
                     threads.stop = true;
             }
 
-            // Stop the search if we have exceeded the totalTime or maximum
-            if (elapsedTime > std::min(totalTime, double(mainThread->tm.maximum())))
+            // Stop the search if we have exceeded totalTime or maximum time,
+            // or if we know that there are no better moves in the analysed line(s)
+            if (elapsedTime > std::min(totalTime, double(mainThread->tm.maximum()))
+                || rootMoves[multiPV - 1].score >= mate_in(3)
+                || rootMoves[0].score == mated_in(2))
             {
                 // If we are allowed to ponder do not stop the search now but
                 // keep pondering until the GUI sends "ponderhit" or "stop".


### PR DESCRIPTION
### Motivation
- Port the semantic delta from upstream commit `7b37032885b20d95472ef08fd38bad16f07ada25` so time-management stops early when the analysed line(s) prove there are no better moves. 

### Description
- In `src/search.cpp` update the time-management stop comment and guard to include the mate checks so the condition becomes `if (elapsedTime > std::min(totalTime, double(mainThread->tm.maximum())) || rootMoves[multiPV - 1].score >= mate_in(3) || rootMoves[0].score == mated_in(2))`, keeping the change strictly limited to that file. 

### Testing
- Ran the mandatory automated gates: `git diff --name-only` (changed file `src/search.cpp` only), literal grep checks for the new comment and mate conditions, forbidden-file diff gate, full build via `make -C src -j2 build ...`, warning/error grep on the build log, UCI depth-1 smoke (downloaded the engine NNUE as advised by the engine), and the optional forced-mate smoke, and all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a4c2c2478832798322c38a6ae0b73)