### PR TITLE
Port Stockfish IIR condition simplification to Wordfish

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1139,7 +1139,7 @@ Value Search::Worker::search(
     // Step 10. Internal iterative reductions
     // At sufficient depth, reduce depth for PV/Cut nodes without a TTMove.
     // (*Scaler) Making IIR more aggressive scales poorly.
-    if (!allNode && depth >= 6 && !ttData.move && priorReduction <= 3)
+    if (!allNode && depth >= 6 && !ttData.move)
         depth--;
 
     // Step 11. ProbCut


### PR DESCRIPTION
### Motivation
- Port the minimal semantic delta from official-stockfish/Stockfish commit `b1053e60b7e0fe3187006c4d7f38dbd22eaff763` to simplify the Internal Iterative Reductions (IIR) condition by removing the `priorReduction <= 3` gate while preserving the local Wordfish search topology and the previously accepted P0 time-management guard from commit `7404e5130aa9e582b55417dca768227908e14f47`.

### Description
- Modify `src/search.cpp` to remove only the `&& priorReduction <= 3` clause in the Step 10 IIR condition, changing `if (!allNode && depth >= 6 && !ttData.move && priorReduction <= 3)` to `if (!allNode && depth >= 6 && !ttData.move)` and preserving all surrounding comments and guards.
- Exact file changed: `src/search.cpp`; commit created: `f05e93a5fc18d79f324df7487c1a77713309e1e0`.
- No other files or forbidden scopes were modified and the P0 stop-on-forced-mate guard remains present and unchanged.

### Testing
- Ran diff and semantic checks with `git diff --name-only` and `grep` to confirm only `src/search.cpp` changed and the `priorReduction <= 3` gate was removed, and both checks passed.
- Built the engine with `make -C src -j2 build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld" NNUE_EMBEDDING_OFF=yes` and the build completed successfully with no warning/error patterns in the log.
- Performed UCI smoke (`uci`, `isready`, `ucinewgame`, `position startpos`, `go depth 1`) which reported `uciok`, `readyok`, and `bestmove`, and ran bench smoke (`$BIN bench`) which reported `Nodes searched` (test output present); both passed.
- Final repository cleanliness checks (`git diff --check`, `git status --short --branch`) passed and the working tree contains only the intended change to `src/search.cpp`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a4f4ab9f88327a6ed58149654f9b8)