### PR TITLE
Allow negative SEE margin in capture pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1284,7 +1284,7 @@ moves_loop:  // When in check, search starts here
 
                 // SEE based pruning for captures and checks
                 // Avoid pruning sacrifices of our last piece for stalemate
-                int margin = std::max(157 * depth + captHist / 29, 0);
+                int margin = 157 * depth + captHist / 29;
                 if ((alpha >= VALUE_DRAW || pos.non_pawn_material(us) != PieceValue[movedPiece])
                     && !pos.see_ge(move, -margin))
                     continue;


### PR DESCRIPTION
### Motivation
- Remove the non-negative clamp on the SEE pruning margin so that the margin can be negative and reflect depth and capture-history influences more accurately.

### Description
- Update in `src/search.cpp` to compute `int margin = 157 * depth + captHist / 29;` instead of using `std::max(..., 0)`, allowing negative margins in SEE-based pruning for captures and checks.

### Testing
- Built the project with `make` and ran the automated test suite with `make test`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a525bfae88327837619ddb8b8ff93)