### PR TITLE
Simplify embedded NNUE handling and remove EmbeddedNNUEType

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -74,8 +74,7 @@ Engine::Engine(std::optional<std::string> path) :
     networks(
       numaContext,
       // Heap-allocate because sizeof(NN::Network) is large
-      std::make_unique<NN::Network>(NN::EvalFile{primary_default_network_file(), "None", ""},
-                                    NN::EmbeddedNNUEType::BIG)) {
+      std::make_unique<NN::Network>(NN::EvalFile{primary_default_network_file(), "None", ""})) {
 
     pos.set(StartFEN, false, &states->back());
 

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -44,37 +44,11 @@
 //     const unsigned int         gEmbeddedNNUESize;    // the size of the embedded file
 // Note that this does not work in Microsoft Visual Studio.
 #if !defined(_MSC_VER) && !defined(NNUE_EMBEDDING_OFF)
-INCBIN(EmbeddedNNUEBig, EvalFileDefaultName);
+INCBIN(EmbeddedNNUE, EvalFileDefaultName);
 #else
-const unsigned char        gEmbeddedNNUEBigData[1]   = {0x0};
-const unsigned char* const gEmbeddedNNUEBigEnd       = &gEmbeddedNNUEBigData[1];
-const unsigned int         gEmbeddedNNUEBigSize      = 1;
+const unsigned char gEmbeddedNNUEData[1] = {0x0};
+const unsigned int  gEmbeddedNNUESize    = 1;
 #endif
-
-namespace {
-
-struct EmbeddedNNUE {
-    EmbeddedNNUE(const unsigned char* embeddedData,
-                 const unsigned char* embeddedEnd,
-                 const unsigned int   embeddedSize) :
-        data(embeddedData),
-        end(embeddedEnd),
-        size(embeddedSize) {}
-    const unsigned char* data;
-    const unsigned char* end;
-    const unsigned int   size;
-};
-
-using namespace Stockfish::Eval::NNUE;
-
-EmbeddedNNUE get_embedded(EmbeddedNNUEType type) {
-    if (type == EmbeddedNNUEType::BIG)
-        return EmbeddedNNUE(gEmbeddedNNUEBigData, gEmbeddedNNUEBigEnd, gEmbeddedNNUEBigSize);
-    else
-        return EmbeddedNNUE(nullptr, nullptr, 0);
-}
-
-}
 
 
 namespace Stockfish::Eval::NNUE {
@@ -287,10 +261,8 @@ void NetworkImpl<Arch, Transformer>::load_internal() {
         }
     };
 
-    const auto embedded = get_embedded(embeddedType);
-
-    MemoryBuffer buffer(const_cast<char*>(reinterpret_cast<const char*>(embedded.data)),
-                        size_t(embedded.size));
+    MemoryBuffer buffer(const_cast<char*>(reinterpret_cast<const char*>(gEmbeddedNNUEData)),
+                        size_t(gEmbeddedNNUESize));
 
     std::istream stream(&buffer);
     auto         description = load(stream);
@@ -339,7 +311,6 @@ std::size_t NetworkImpl<Arch, Transformer>::get_content_hash() const {
     for (auto&& layerstack : network)
         hash_combine(h, layerstack);
     hash_combine(h, evalFile);
-    hash_combine(h, static_cast<int>(embeddedType));
     return h;
 }
 

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -43,11 +43,6 @@ class Position;
 
 namespace Stockfish::Eval::NNUE {
 
-enum class EmbeddedNNUEType {
-    BIG,
-    SMALL,
-};
-
 using NetworkOutput = std::tuple<Value, Value>;
 
 // The network must be a trivial type, i.e. the memory must be in-line.
@@ -58,9 +53,8 @@ class NetworkImpl {
     static constexpr IndexType FTDimensions = Arch::TransformedFeatureDimensions;
 
    public:
-    NetworkImpl(EvalFile file, EmbeddedNNUEType type) :
-        evalFile(file),
-        embeddedType(type) {}
+    NetworkImpl(EvalFile file) :
+        evalFile(file) {}
 
     NetworkImpl(const NetworkImpl& other) = default;
     NetworkImpl(NetworkImpl&& other)      = default;
@@ -104,8 +98,7 @@ class NetworkImpl {
     // Evaluation function
     Arch network[LayerStacks];
 
-    EvalFile         evalFile;
-    EmbeddedNNUEType embeddedType;
+    EvalFile evalFile;
 
     bool initialized = false;
 


### PR DESCRIPTION
### Motivation

- Simplify the codepath for embedded NNUE data by removing the dual-size embedding variants and related state.
- Reduce maintenance and platform-conditional complexity around the embedded network representation.

### Description

- Remove the `EmbeddedNNUEType` enum and the `embeddedType` member from `NetworkImpl`, and update the constructor to take only `EvalFile`.
- Replace the previous `INCBIN(EmbeddedNNUEBig, ...)` usage with a unified `INCBIN(EmbeddedNNUE, ...)` symbol and simplify the MSVC fallback to `gEmbeddedNNUEData`/`gEmbeddedNNUESize`.
- Eliminate the `get_embedded` helper and the `EmbeddedNNUE` wrapper, and create the memory stream directly from `gEmbeddedNNUEData` and `gEmbeddedNNUESize` in `NetworkImpl::load_internal`.
- Update `get_content_hash` to stop hashing the removed `embeddedType`, and adjust call sites (e.g. engine construction) to use the new `Network` constructor signature.

### Testing

- Built the project with the standard build (`cmake`/`cmake --build .`) and compilation succeeded.
- Ran the test suite with `ctest` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a629ecb948327aaed4685f248c9a1)