### PR TITLE
Port Stockfish AMD Excavator slow-BMI2 native detection to Wordfish

### DIFF
--- a/scripts/get_native_properties.sh
+++ b/scripts/get_native_properties.sh
@@ -19,11 +19,11 @@ get_flags() {
   flags=$(awk '/^flags[ \t]*:|^Features[ \t]*:/{gsub(/^flags[ \t]*:[ \t]*|^Features[ \t]*:[ \t]*|[_.]/, ""); line=$0} END{print line}' /proc/cpuinfo)
 }
 
-# Check for gcc march "znver1" or "znver2" https://en.wikichip.org/wiki/amd/cpuid
-check_znver_1_2() {
+# Check for AMD Excavator/Zen1/2 slow BMI2 CPUs
+check_slow_bmi2() {
   vendor_id=$(awk '/^vendor_id/{print $3; exit}' /proc/cpuinfo)
   cpu_family=$(awk '/^cpu family/{print $4; exit}' /proc/cpuinfo)
-  [ "$vendor_id" = "AuthenticAMD" ] && [ "$cpu_family" = "23" ] && znver_1_2=true
+  [ "$vendor_id" = "AuthenticAMD" ] && { [ "$cpu_family" = "21" ] || [ "$cpu_family" = "23" ]; } && slow_bmi2=true
 }
 
 # Set the file CPU loongarch64 architecture
@@ -47,7 +47,7 @@ set_arch_x86_64() {
     true_arch='x86-64-avx512'
   elif check_flags 'avxvnni'; then
     true_arch='x86-64-avxvnni'
-  elif [ -z "${znver_1_2+1}" ] && check_flags 'bmi2'; then
+  elif [ -z "${slow_bmi2+1}" ] && check_flags 'bmi2'; then
     true_arch='x86-64-bmi2'
   elif check_flags 'avx2'; then
     true_arch='x86-64-avx2'
@@ -98,7 +98,7 @@ case $uname_s in
     case $uname_m in
       'x86_64')
         file_os='ubuntu'
-        check_znver_1_2
+        check_slow_bmi2
         set_arch_x86_64
         ;;
       'i686')
@@ -142,7 +142,7 @@ case $uname_s in
     ;;
   'CYGWIN'*|'MINGW'*|'MSYS'*) # Windows x86_64system with POSIX compatibility layer
     get_flags
-    check_znver_1_2
+    check_slow_bmi2
     set_arch_x86_64
     file_os='windows'
     file_ext='zip'


### PR DESCRIPTION
### Motivation
- The native detection script used a Zen1/2-only predicate (`check_znver_1_2` / `znver_1_2`) to exclude BMI2 on some AMD CPUs; the upstream Stockfish change broadens this exclusion to include AMD Excavator (family 21) as well as Zen1/Zen2 (family 23).
- Update the script-native detection to avoid enabling BMI2 on AMD families with known slow BMI2 behavior while preserving all other architecture/packaging logic.

### Description
- Replaced `check_znver_1_2` with a new slow-BMI2 predicate `check_slow_bmi2` that sets `slow_bmi2=true` for `AuthenticAMD` CPU family `21` or `23` (Excavator and Zen1/Zen2) in `scripts/get_native_properties.sh`.
- Replaced all calls to `check_znver_1_2` with `check_slow_bmi2` in Linux and CYGWIN/MSYS/MINGW x86_64 detection paths in `scripts/get_native_properties.sh`.
- Replaced the BMI2 gate from `elif [ -z "${znver_1_2+1}" ] && check_flags 'bmi2'; then` to `elif [ -z "${slow_bmi2+1}" ] && check_flags 'bmi2'; then` so AMD families 21 and 23 are excluded from selecting `x86-64-bmi2`.
- Preserved all other detection tiers, ordering, OS handling, file naming, and unrelated source files; only `scripts/get_native_properties.sh` was changed and `src/universal/entry_x86.cpp` was not created or modified.

### Testing
- Verified preflight topology markers and upstream commit `0c1001c93e694bc84845006ed0ebf452ff208eef` contents via `git fetch` and `git show` (matched expected upstream patch surface).
- Shell syntax check: `sh -n scripts/get_native_properties.sh` — passed.
- Script runtime smoke: `sh scripts/get_native_properties.sh` produced the expected two-field output (architecture and file name) — passed.
- NNUE preservation: `make -C src net` downloaded and validated `nn-71d6d32cb962.nnue` and `sha256sum` began with `71d6d32cb962` — passed.
- Build: `make -C src -j2 build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld" NNUE_EMBEDDING_OFF=yes` completed and the warning/error grep over the build log found no matches — passed.
- Runtime/UCI smoke: launched built binary, verified `uciok`, `readyok`, `bestmove`, NNUE load and `EvalFile` default referencing `nn-71d6d32cb962.nnue` — passed.
- Bench: invoked bench and observed `Nodes searched` output — passed.
- Source/diff gates: `git diff --name-only` before commit and final staged files contained only `scripts/get_native_properties.sh`; no `src/` files were changed or added and no `.nnue` files were committed — passed.
- Commit created: `ae338cf3cc7bdcad68aabaf505e50e2451a1a28a` (message `P4-R5-SF20260606: broaden slow BMI2 native detection`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bbc413d14832787cfb1b60375846f)