### PR TITLE
Simplify internal NNUE load branch in src/nnue/network.cpp

### DIFF
--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -98,7 +98,7 @@ void NetworkImpl<Arch, Transformer>::load(const std::string& rootDirectory, std:
                 load_user_net(directory, evalfilePath);
             }
 
-            if (directory == "<internal>" && evalfilePath == std::string(evalFile.defaultName))
+            else if (evalfilePath == std::string(evalFile.defaultName))
             {
                 load_internal();
             }


### PR DESCRIPTION
### Motivation

- Simplify the control flow in `NetworkImpl<Arch, Transformer>::load(...)` by collapsing a redundant explicit internal-directory `if` into an `else if` without changing behavior or network authority.

### Description

- Replace the second `if (directory == "<internal>" && evalfilePath == std::string(evalFile.defaultName))` with `else if (evalfilePath == std::string(evalFile.defaultName))` in `src/nnue/network.cpp`, touching only that file and preserving `dirs` order, `DEFAULT_NNUE_DIRECTORY` handling, `evalfilePath.empty()` handling, `load_user_net()` and `load_internal()` semantics.

### Testing

- Ran `make -C src net` (validated and downloaded `nn-71d6d32cb962.nnue` and checked SHA-256), built `make -C src -j2 build ARCH=x86-64-sse41-popcnt COMP=clang ...`, executed UCI smoke (`uci` / `isready` / `go depth 1`), verified `EvalFile` default output, and ran `bench`; all automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bd1e705d883279c1a159659d7f39e)