### PR TITLE
Migrate Wordfish attack tables to Stockfish dev attacks topology

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -49,14 +49,14 @@ BINDIR = $(PREFIX)/bin
 PGOBENCH = $(WINE_PATH) ./$(EXE) bench
 
 ### Source and object files
-SRCS = benchmark.cpp bitboard.cpp evaluate.cpp experience.cpp main.cpp \
+SRCS = attacks.cpp benchmark.cpp bitboard.cpp evaluate.cpp experience.cpp main.cpp \
         misc.cpp movegen.cpp movepick.cpp mcts.cpp polybook.cpp position.cpp \
         search.cpp thread.cpp timeman.cpp tt.cpp uci.cpp ucioption.cpp tune.cpp syzygy/tbprobe.cpp \
         nnue/nnue_accumulator.cpp nnue/nnue_misc.cpp nnue/network.cpp \
         nnue/features/half_ka_v2_hm.cpp nnue/features/full_threats.cpp \
         engine.cpp score.cpp memory.cpp
 
-HEADERS = benchmark.h bitboard.h evaluate.h experience.h experience_compat.h Wordfish_zobrist.h misc.h movegen.h movepick.h mcts.h history.h polybook.h \
+HEADERS = attacks.h benchmark.h bitboard.h evaluate.h experience.h experience_compat.h Wordfish_zobrist.h misc.h movegen.h movepick.h mcts.h history.h polybook.h \
                 nnue/nnue_misc.h nnue/features/half_ka_v2_hm.h nnue/features/full_threats.h \
                 nnue/layers/affine_transform.h nnue/layers/affine_transform_sparse_input.h \
                 nnue/layers/clipped_relu.h nnue/layers/sqr_clipped_relu.h nnue/nnue_accumulator.h \

--- a/src/attacks.cpp
+++ b/src/attacks.cpp
@@ -1,0 +1,273 @@
+/*
+  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+  Copyright (C) 2004-2026 The Stockfish developers (see AUTHORS file)
+
+  Stockfish is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Stockfish is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "attacks.h"
+
+#include <array>
+
+#include "misc.h"
+
+namespace Stockfish::Attacks {
+
+Bitboard LineBB[SQUARE_NB][SQUARE_NB];
+Bitboard BetweenBB[SQUARE_NB][SQUARE_NB];
+Bitboard RayPassBB[SQUARE_NB][SQUARE_NB];
+
+namespace {
+
+#ifdef USE_DUAL_HYPERBOLA_QUINT
+alignas(64) DualMagic DualMagics[SQUARE_NB];
+#else
+alignas(64) Magic Magics[SQUARE_NB][2];
+#endif
+
+}
+
+#ifdef USE_PEXT
+using MagicMask = std::uint16_t;
+#else
+using MagicMask = Bitboard;
+#endif
+
+[[maybe_unused]] static Bitboard line_mask(Square sq, Direction d1, Direction d2) {
+    Bitboard mask = 0, dest;
+    for (Direction d : {d1, d2})
+    {
+        Square s = sq;
+        while ((dest = safe_destination(s, d)))
+        {
+            mask |= dest;
+            s += d;
+        }
+    }
+    return mask;
+}
+
+#ifdef USE_HYPERBOLA_QUINT
+static void init_magics(Magic magics[][2]) {
+    for (Square s = SQ_A1; s <= SQ_H8; ++s)
+    {
+        Magic& rook = magics[s][ROOK - BISHOP];
+        rook.mask1  = line_mask(s, NORTH, SOUTH);
+        rook.mask2  = line_mask(s, EAST, WEST);
+
+        Magic& bishop = magics[s][BISHOP - BISHOP];
+        bishop.mask1  = line_mask(s, NORTH_EAST, SOUTH_WEST);
+        bishop.mask2  = line_mask(s, NORTH_WEST, SOUTH_EAST);
+    }
+}
+
+#elif defined(USE_DUAL_HYPERBOLA_QUINT)
+
+// Sliding attacks within a rank, indexed by the slider's file and the
+// 8-bit rank occupancy, yielding the 8-bit attack set on that rank
+constexpr auto RankAttacks = []() {
+    std::array<std::array<std::uint8_t, 256>, FILE_NB> table{};
+    for (int file = 0; file < 8; ++file)
+        for (int occ = 0; occ < 256; ++occ)
+            table[file][occ] = std::uint8_t(sliding_attack(ROOK, Square(file), occ));
+    return table;
+}();
+
+static void init_dual_magics(DualMagic magics[]) {
+    for (Square s = SQ_A1; s <= SQ_H8; ++s)
+    {
+        DualMagic& m        = magics[s];
+        m.maskFile          = line_mask(s, NORTH, SOUTH);
+        m.maskDiag          = line_mask(s, NORTH_EAST, SOUTH_WEST);
+        m.maskNone          = 0;
+        m.maskAntidiag      = line_mask(s, NORTH_WEST, SOUTH_EAST);
+        m.r                 = square_bb(s) * 2;
+        m.rr                = square_bb(Square(63 - int(s))) * 2;
+        m.rankAttacksLookup = RankAttacks[int(file_of(s))].data();
+        m.shift             = 8 * int(rank_of(s));
+    }
+}
+
+#else
+
+namespace {
+[[maybe_unused]] constexpr Bitboard constexpr_pext(Bitboard b, Bitboard m) {
+    Bitboard result = 0, bit = 0;
+    while (m)
+    {
+        Bitboard last = m & -m;
+        result |= bool(b & last) << bit++;
+        m ^= last;
+    }
+    return result;
+}
+
+    #ifdef USE_COMPTIME_ATTACKS
+constexpr
+    #endif
+  void
+  init_magics(PieceType             pt,
+              MagicMask             table[],
+              Magic                 magics[][2],
+              [[maybe_unused]] bool tableAlreadyInit) {
+    #if !defined(USE_COMPTIME_ATTACKS)
+    tableAlreadyInit = false;
+    #endif
+
+    #ifndef USE_PEXT
+    int seeds[][RANK_NB] = {{8977, 44560, 54343, 38998, 5731, 95205, 104912, 17020},
+                            {728, 10316, 55013, 32803, 12281, 15100, 16645, 255}};
+
+    Bitboard occupancy[4096];
+    int      epoch[4096] = {}, cnt = 0;
+    Bitboard reference[4096] = {};
+    #endif
+    int size = 0;
+
+    for (Square s = SQ_A1; s <= SQ_H8; ++s)
+    {
+        Bitboard edges = ((Rank1BB | Rank8BB) & ~rank_bb(s)) | ((FileABB | FileHBB) & ~file_bb(s));
+
+        Magic&   m       = magics[s][pt - BISHOP];
+        Bitboard attacks = sliding_attack(pt, s, 0);
+        m.mask           = attacks & ~edges;
+    #ifdef USE_PEXT
+        m.pseudoAttacks = attacks;
+    #else
+        m.shift = (Is64Bit ? 64 : 32) - popcount(m.mask);
+    #endif
+        m.attacks = s == SQ_A1 ? table : magics[s - 1][pt - BISHOP].attacks + size;
+        size      = 0;
+
+        Bitboard                  b           = 0;
+        [[maybe_unused]] Bitboard prevSliding = -1;
+        do
+        {
+    #ifdef USE_PEXT
+            if (!tableAlreadyInit)
+            {
+                Bitboard sliding = sliding_attack(pt, s, b);
+                m.attacks[size] =
+                  sliding != prevSliding ? constexpr_pext(sliding, attacks) : m.attacks[size - 1];
+                prevSliding = sliding;
+            }
+    #else
+            occupancy[size] = b;
+            reference[size] = sliding_attack(pt, s, b);
+    #endif
+
+            size++;
+            b = (b - m.mask) & m.mask;
+        } while (b);
+
+    #ifndef USE_PEXT
+        PRNG rng(seeds[Is64Bit][rank_of(s)]);
+
+        for (int i = 0; i < size;)
+        {
+            for (m.magic = 0; popcount((m.magic * m.mask) >> 56) < 6;)
+                m.magic = rng.sparse_rand<Bitboard>();
+
+            for (++cnt, i = 0; i < size; ++i)
+            {
+                unsigned idx = m.index(occupancy[i]);
+
+                if (epoch[idx] < cnt)
+                {
+                    epoch[idx]     = cnt;
+                    m.attacks[idx] = reference[i];
+                }
+                else if (m.attacks[idx] != reference[i])
+                    break;
+            }
+        }
+    #endif
+    }
+}
+
+    #if defined(USE_COMPTIME_ATTACKS) && defined(USE_PEXT)
+constexpr auto RookTable = []() {
+    std::array<std::uint16_t, 0x19000> result{};
+    Magic                    magics[64][2] = {};
+    init_magics(ROOK, result.data(), magics, false);
+    return result;
+}();
+constexpr auto BishopTable = []() {
+    std::array<std::uint16_t, 0x1480> result{};
+    Magic                   magics[64][2] = {};
+    init_magics(BISHOP, result.data(), magics, false);
+    return result;
+}();
+    #elif !defined(USE_DUAL_HYPERBOLA_QUINT) && !defined(USE_HYPERBOLA_QUINT)
+std::array<MagicMask, 0x19000> RookTable;
+std::array<MagicMask, 0x1480>  BishopTable;
+    #endif
+}
+
+#endif
+
+void init() {
+
+#ifdef USE_HYPERBOLA_QUINT
+    init_magics(Magics);
+#elif defined(USE_DUAL_HYPERBOLA_QUINT)
+    init_dual_magics(DualMagics);
+#else
+    init_magics(ROOK, const_cast<MagicMask*>(RookTable.data()), Magics, true);
+    init_magics(BISHOP, const_cast<MagicMask*>(BishopTable.data()), Magics, true);
+#endif
+
+    for (Square s1 = SQ_A1; s1 <= SQ_H8; ++s1)
+    {
+        for (PieceType pt : {BISHOP, ROOK})
+            for (Square s2 = SQ_A1; s2 <= SQ_H8; ++s2)
+            {
+                if (PseudoAttacks[pt][s1] & s2)
+                {
+                    LineBB[s1][s2] = (attacks_bb(pt, s1, 0) & attacks_bb(pt, s2, 0)) | s1 | s2;
+                    BetweenBB[s1][s2] =
+                      (attacks_bb(pt, s1, square_bb(s2)) & attacks_bb(pt, s2, square_bb(s1)));
+                    RayPassBB[s1][s2] =
+                      attacks_bb(pt, s1, 0) & (attacks_bb(pt, s2, square_bb(s1)) | s2);
+                }
+                BetweenBB[s1][s2] |= s2;
+            }
+    }
+}
+
+#ifdef USE_DUAL_HYPERBOLA_QUINT
+const DualMagic& dual_magic(Square s) { return DualMagics[s]; }
+#else
+const Magic& magic(Square s, PieceType pt) {
+    assert((pt == BISHOP || pt == ROOK) && is_ok(s));
+    return Magics[s][pt - BISHOP];
+}
+#endif
+
+Bitboard line_bb(Square s1, Square s2) {
+    assert(is_ok(s1) && is_ok(s2));
+    return LineBB[s1][s2];
+}
+
+Bitboard between_bb(Square s1, Square s2) {
+    assert(is_ok(s1) && is_ok(s2));
+    return BetweenBB[s1][s2];
+}
+
+Bitboard ray_pass_bb(Square s1, Square s2) {
+    assert(is_ok(s1) && is_ok(s2));
+    return RayPassBB[s1][s2];
+}
+
+}  // namespace Stockfish::Attacks

--- a/src/attacks.h
+++ b/src/attacks.h
@@ -1,0 +1,357 @@
+/*
+  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+  Copyright (C) 2004-2026 The Stockfish developers (see AUTHORS file)
+
+  Stockfish is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Stockfish is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef ATTACKS_H_INCLUDED
+#define ATTACKS_H_INCLUDED
+
+#include <cassert>
+#include <cstdint>
+#include <array>
+#include <initializer_list>
+
+#include "types.h"
+#include "bitboard.h"
+
+#ifdef __aarch64__
+    #include <arm_acle.h>
+    #define USE_HYPERBOLA_QUINT
+#elif defined(__loongarch__) && __loongarch_grlen == 64
+    #define USE_HYPERBOLA_QUINT
+#elif defined(USE_AVX2) && !defined(USE_PEXT)
+    #include <immintrin.h>
+    #define USE_DUAL_HYPERBOLA_QUINT
+#endif
+
+namespace Stockfish::Attacks {
+
+void init();
+
+#ifdef USE_HYPERBOLA_QUINT
+
+inline Bitboard reverse_bb(Bitboard bb) {
+    #ifdef __aarch64__
+    return __rbitll(bb);
+    #else  // loongarch
+    Bitboard out;
+    asm("bitrev.d %0, %1" : "=r"(out) : "r"(bb));
+    return out;
+    #endif
+}
+
+// Hyperbola quintessence implementation for ARM, thanks to the availability of an
+// efficient bit reversal instruction.
+// See https://www.chessprogramming.org/Hyperbola_Quintessence
+struct Magic {
+    // For rooks: file attacks, rank attacks. For bishops: diagonal/antidiagonal
+    Bitboard mask1, mask2;
+
+    Bitboard hyperbola(Square s, Bitboard occupied, Bitboard mask) const {
+        Bitboard o   = occupied & mask;
+        Bitboard fwd = o - square_bb(s);
+        Bitboard rev = reverse_bb(o) - square_bb(Square(63 - int(s)));
+        return (fwd ^ reverse_bb(rev)) & mask;
+    }
+
+    Bitboard attacks_bb(Square s, Bitboard occupied) const {
+        return hyperbola(s, occupied, mask1) | hyperbola(s, occupied, mask2);
+    }
+};
+
+const Magic& magic(Square s, PieceType pt);
+
+#elif defined(USE_DUAL_HYPERBOLA_QUINT)
+
+struct DualMagic {
+    // file, diagonal, unused, antidiagonal
+    Bitboard maskFile, maskDiag, maskNone, maskAntidiag;
+    // Precomputed 2 * square_bb(sq), 2 * reverse(square_bb(sq))
+    Bitboard r, rr;
+
+    const std::uint8_t* RESTRICT rankAttacksLookup;
+    // 8 * rank_of(sq)
+    int shift;
+
+    // We always compute [bishop, rook] attacks at once, then rely on
+    // compiler's DCE and CSE to eliminate unneeded re-computations or extractions.
+    //
+    // When using hyperbola quintessence, file, diagonal and antidiagonal attacks
+    // can use a byte reversal rather than a full bit reversal (because all squares
+    // reside in different bytes). Rank atttacks cannot. Thus, for rank attacks
+    // only, we use a compact lookup table indexed by the 8 bits of the rank's occupancy.
+    std::pair<Bitboard, Bitboard> both_attacks_bb(Bitboard occupied) const {
+        // Byteswap within 64-bit elements
+        const auto bswap = [](__m256i v) {
+            return _mm256_shuffle_epi8(v, _mm256_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+                                                          13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                                                          10, 11, 12, 13, 14, 15));
+        };
+
+        // Each lane contains a mask and we follow the same HQ algorithm as
+        // given above in the ARM64 code path
+        const __m256i mask = _mm256_load_si256(reinterpret_cast<const __m256i*>(this));
+        const __m256i rs   = _mm256_set1_epi64x(r);
+        const __m256i rrs  = _mm256_set1_epi64x(rr);
+
+        __m256i o      = _mm256_and_si256(mask, _mm256_set1_epi64x(occupied));
+        __m256i fwd    = _mm256_sub_epi64(o, rs);
+        __m256i rev    = bswap(_mm256_sub_epi64(bswap(o), rrs));
+        __m256i result = _mm256_and_si256(_mm256_xor_si256(fwd, rev), mask);
+
+        // Lane 0: rook attacks (file only); lane 1: bishop attacks
+        __m128i rookBishop =
+          _mm_or_si128(_mm256_extracti128_si256(result, 1), _mm256_castsi256_si128(result));
+
+        Bitboard rowOccupancy = rankAttacksLookup[(occupied >> shift) & 0xff];
+        Bitboard rankAttacks  = rowOccupancy << shift;
+
+        // [bishop, rook]
+        return {_mm_extract_epi64(rookBishop, 1), _mm_cvtsi128_si64(rookBishop) + rankAttacks};
+    }
+};
+
+const DualMagic& dual_magic(Square s);
+
+#else
+// Magic holds all magic bitboards relevant data for a single square
+struct Magic {
+    Bitboard mask;
+    #ifdef USE_PEXT
+    std::uint16_t*     attacks;
+    Bitboard pseudoAttacks;
+    #else
+    Bitboard* attacks;
+    Bitboard  magic;
+    unsigned  shift;
+    #endif
+
+    // Compute the attack's index using the 'magic bitboards' approach
+    unsigned index(Bitboard occupied) const {
+
+    #ifdef USE_PEXT
+        return unsigned(pext(occupied, mask));
+    #else
+        if (Is64Bit)
+            return unsigned(((occupied & mask) * magic) >> shift);
+
+        unsigned lo = unsigned(occupied) & unsigned(mask);
+        unsigned hi = unsigned(occupied >> 32) & unsigned(mask >> 32);
+        return (lo * unsigned(magic) ^ hi * unsigned(magic >> 32)) >> shift;
+    #endif
+    }
+
+    Bitboard attacks_bb([[maybe_unused]] Square s, Bitboard occupied) const {
+    #ifdef USE_PEXT
+        return pdep(attacks[index(occupied)], pseudoAttacks);
+    #else
+        return attacks[index(occupied)];
+    #endif
+    }
+};
+
+const Magic& magic(Square s, PieceType pt);
+
+#endif
+
+extern Bitboard LineBB[SQUARE_NB][SQUARE_NB];
+extern Bitboard BetweenBB[SQUARE_NB][SQUARE_NB];
+extern Bitboard RayPassBB[SQUARE_NB][SQUARE_NB];
+
+Bitboard line_bb(Square s1, Square s2);
+Bitboard between_bb(Square s1, Square s2);
+Bitboard ray_pass_bb(Square s1, Square s2);
+
+// Returns the bitboard of target square for the given step
+// from the given square. If the step is off the board, returns empty bitboard.
+constexpr Bitboard safe_destination(Square s, int step) {
+    constexpr auto abs = [](int v) { return v < 0 ? -v : v; };
+    Square         to  = Square(s + step);
+    return is_ok(to) && abs(file_of(s) - file_of(to)) <= 2 ? square_bb(to) : Bitboard(0);
+}
+
+constexpr Bitboard sliding_attack(PieceType pt, Square sq, Bitboard occupied) {
+    Bitboard            attacks = 0, dest = 0;
+    constexpr Direction RookDirections[4]   = {NORTH, SOUTH, EAST, WEST};
+    constexpr Direction BishopDirections[4] = {NORTH_EAST, SOUTH_EAST, SOUTH_WEST, NORTH_WEST};
+
+    for (Direction d : (pt == ROOK ? RookDirections : BishopDirections))
+    {
+        Square s = sq;
+        while ((dest = safe_destination(s, d)))
+        {
+            attacks |= dest;
+            s += d;
+            if (occupied & dest)
+            {
+                break;
+            }
+        }
+    }
+
+    return attacks;
+}
+
+constexpr Bitboard knight_attack(Square sq) {
+    Bitboard b = {};
+    for (int step : {-17, -15, -10, -6, 6, 10, 15, 17})
+        b |= safe_destination(sq, step);
+    return b;
+}
+
+constexpr Bitboard king_attack(Square sq) {
+    Bitboard b = {};
+    for (int step : {-9, -8, -7, -1, 1, 7, 8, 9})
+        b |= safe_destination(sq, step);
+    return b;
+}
+
+constexpr Bitboard pseudo_attacks(PieceType pt, Square sq) {
+    switch (pt)
+    {
+    case PieceType::ROOK :
+    case PieceType::BISHOP :
+        return sliding_attack(pt, sq, 0);
+    case PieceType::QUEEN :
+        return sliding_attack(PieceType::ROOK, sq, 0) | sliding_attack(PieceType::BISHOP, sq, 0);
+    case PieceType::KNIGHT :
+        return knight_attack(sq);
+    case PieceType::KING :
+        return king_attack(sq);
+    default :
+        assert(false);
+        return 0;
+    }
+}
+
+inline constexpr auto PseudoAttacks = []() constexpr {
+    std::array<std::array<Bitboard, SQUARE_NB>, PIECE_TYPE_NB> attacks{};
+
+    for (Square s1 = SQ_A1; s1 <= SQ_H8; ++s1)
+    {
+        attacks[WHITE][s1] = pawn_attacks_bb<WHITE>(square_bb(s1));
+        attacks[BLACK][s1] = pawn_attacks_bb<BLACK>(square_bb(s1));
+
+        attacks[KING][s1]   = pseudo_attacks(KING, s1);
+        attacks[KNIGHT][s1] = pseudo_attacks(KNIGHT, s1);
+        attacks[QUEEN][s1] = attacks[BISHOP][s1] = pseudo_attacks(BISHOP, s1);
+        attacks[QUEEN][s1] |= attacks[ROOK][s1]  = pseudo_attacks(ROOK, s1);
+    }
+
+    return attacks;
+}();
+
+inline constexpr auto PawnPushOrAttacks = []() constexpr {
+    std::array<std::array<Bitboard, SQUARE_NB>, COLOR_NB> attacks{};
+
+    for (Square s1 = SQ_A1; s1 <= SQ_H8; ++s1)
+    {
+        attacks[WHITE][s1] = pawn_single_push_bb(WHITE, square_bb(s1)) | PseudoAttacks[WHITE][s1];
+        attacks[BLACK][s1] = pawn_single_push_bb(BLACK, square_bb(s1)) | PseudoAttacks[BLACK][s1];
+    }
+
+    return attacks;
+}();
+
+// Returns the pseudo attacks of the given piece type
+// assuming an empty board.
+template<PieceType Pt>
+inline Bitboard attacks_bb(Square s, Color c = COLOR_NB) {
+
+    assert((Pt != PAWN || c < COLOR_NB) && is_ok(s));
+    return Pt == PAWN ? PseudoAttacks[c][s] : PseudoAttacks[Pt][s];
+}
+
+// Returns the attacks by the given piece
+// assuming the board is occupied according to the passed Bitboard.
+// Sliding piece attacks do not continue passed an occupied square.
+template<PieceType Pt>
+inline Bitboard attacks_bb(Square s, Bitboard occupied) {
+
+    assert(Pt != PAWN && is_ok(s));
+
+#ifdef USE_DUAL_HYPERBOLA_QUINT
+    const auto [bishop, rook] = dual_magic(s).both_attacks_bb(occupied);
+
+    switch (Pt)
+    {
+    case BISHOP :
+        return bishop;
+    case ROOK :
+        return rook;
+    case QUEEN :
+        return bishop | rook;
+    default :
+        return PseudoAttacks[Pt][s];
+    }
+#else
+    switch (Pt)
+    {
+    case BISHOP :
+    case ROOK :
+        return magic(s, Pt).attacks_bb(s, occupied);
+    case QUEEN :
+        return attacks_bb<BISHOP>(s, occupied) | attacks_bb<ROOK>(s, occupied);
+    default :
+        return PseudoAttacks[Pt][s];
+    }
+#endif
+}
+
+// Returns the attacks by the given piece
+// assuming the board is occupied according to the passed Bitboard.
+// Sliding piece attacks do not continue passed an occupied square.
+inline Bitboard attacks_bb(PieceType pt, Square s, Bitboard occupied) {
+
+    assert(pt != PAWN && is_ok(s));
+
+    switch (pt)
+    {
+    case BISHOP :
+        return attacks_bb<BISHOP>(s, occupied);
+    case ROOK :
+        return attacks_bb<ROOK>(s, occupied);
+    case QUEEN :
+        return attacks_bb<BISHOP>(s, occupied) | attacks_bb<ROOK>(s, occupied);
+    default :
+        return PseudoAttacks[pt][s];
+    }
+}
+
+inline Bitboard attacks_bb(Piece pc, Square s, Bitboard occupied) {
+    return type_of(pc) == PAWN ? PseudoAttacks[color_of(pc)][s]
+                               : attacks_bb(type_of(pc), s, occupied);
+}
+
+}  // namespace Stockfish::Attacks
+
+namespace Stockfish {
+
+// Preserve Wordfish's existing unqualified attack call sites while the
+// implementation and tables live in the official Attacks namespace.
+using Attacks::attacks_bb;
+using Attacks::between_bb;
+using Attacks::BetweenBB;
+using Attacks::line_bb;
+using Attacks::LineBB;
+using Attacks::PawnPushOrAttacks;
+using Attacks::PseudoAttacks;
+using Attacks::ray_pass_bb;
+using Attacks::RayPassBB;
+
+}  // namespace Stockfish
+
+#endif  // #ifndef ATTACKS_H_INCLUDED

--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -18,30 +18,12 @@
 
 #include "bitboard.h"
 
-#include <algorithm>
 #include <bitset>
-#include <initializer_list>
-
-#include "misc.h"
 
 namespace Stockfish {
 
-uint8_t PopCnt16[1 << 16];
-uint8_t SquareDistance[SQUARE_NB][SQUARE_NB];
-
-Bitboard LineBB[SQUARE_NB][SQUARE_NB];
-Bitboard BetweenBB[SQUARE_NB][SQUARE_NB];
-Bitboard RayPassBB[SQUARE_NB][SQUARE_NB];
-
-alignas(64) Magic Magics[SQUARE_NB][2];
-
-namespace {
-
-Bitboard RookTable[0x19000];   // To store rook attacks
-Bitboard BishopTable[0x1480];  // To store bishop attacks
-
-void init_magics(PieceType pt, Bitboard table[], Magic magics[][2]);
-}
+std::uint8_t PopCnt16[1 << 16];
+std::uint8_t SquareDistance[SQUARE_NB][SQUARE_NB];
 
 // Returns an ASCII representation of a bitboard suitable
 // to be printed to standard output. Useful for debugging.
@@ -64,126 +46,16 @@ std::string Bitboards::pretty(Bitboard b) {
     return s;
 }
 
-
 // Initializes various bitboard tables. It is called at
 // startup and relies on global objects to be already zero-initialized.
 void Bitboards::init() {
 
     for (unsigned i = 0; i < (1 << 16); ++i)
-        PopCnt16[i] = uint8_t(std::bitset<16>(i).count());
+        PopCnt16[i] = std::uint8_t(std::bitset<16>(i).count());
 
     for (Square s1 = SQ_A1; s1 <= SQ_H8; ++s1)
         for (Square s2 = SQ_A1; s2 <= SQ_H8; ++s2)
             SquareDistance[s1][s2] = std::max(distance<File>(s1, s2), distance<Rank>(s1, s2));
-
-    init_magics(ROOK, RookTable, Magics);
-    init_magics(BISHOP, BishopTable, Magics);
-
-    for (Square s1 = SQ_A1; s1 <= SQ_H8; ++s1)
-    {
-        for (PieceType pt : {BISHOP, ROOK})
-            for (Square s2 = SQ_A1; s2 <= SQ_H8; ++s2)
-            {
-                if (PseudoAttacks[pt][s1] & s2)
-                {
-                    LineBB[s1][s2] = (attacks_bb(pt, s1, 0) & attacks_bb(pt, s2, 0)) | s1 | s2;
-                    BetweenBB[s1][s2] =
-                      (attacks_bb(pt, s1, square_bb(s2)) & attacks_bb(pt, s2, square_bb(s1)));
-                    RayPassBB[s1][s2] =
-                      attacks_bb(pt, s1, 0) & (attacks_bb(pt, s2, square_bb(s1)) | s2);
-                }
-                BetweenBB[s1][s2] |= s2;
-            }
-    }
-}
-
-namespace {
-// Computes all rook and bishop attacks at startup. Magic
-// bitboards are used to look up attacks of sliding pieces. As a reference see
-// https://www.chessprogramming.org/Magic_Bitboards. In particular, here we use
-// the so called "fancy" approach.
-void init_magics(PieceType pt, Bitboard table[], Magic magics[][2]) {
-
-#ifndef USE_PEXT
-    // Optimal PRNG seeds to pick the correct magics in the shortest time
-    int seeds[][RANK_NB] = {{8977, 44560, 54343, 38998, 5731, 95205, 104912, 17020},
-                            {728, 10316, 55013, 32803, 12281, 15100, 16645, 255}};
-
-    Bitboard occupancy[4096];
-    int      epoch[4096] = {}, cnt = 0;
-#endif
-    Bitboard reference[4096];
-    int      size = 0;
-
-    for (Square s = SQ_A1; s <= SQ_H8; ++s)
-    {
-        // Board edges are not considered in the relevant occupancies
-        Bitboard edges = ((Rank1BB | Rank8BB) & ~rank_bb(s)) | ((FileABB | FileHBB) & ~file_bb(s));
-
-        // Given a square 's', the mask is the bitboard of sliding attacks from
-        // 's' computed on an empty board. The index must be big enough to contain
-        // all the attacks for each possible subset of the mask and so is 2 power
-        // the number of 1s of the mask. Hence we deduce the size of the shift to
-        // apply to the 64 or 32 bits word to get the index.
-        Magic& m = magics[s][pt - BISHOP];
-        m.mask   = Bitboards::sliding_attack(pt, s, 0) & ~edges;
-#ifndef USE_PEXT
-        m.shift = (Is64Bit ? 64 : 32) - popcount(m.mask);
-#endif
-        // Set the offset for the attacks table of the square. We have individual
-        // table sizes for each square with "Fancy Magic Bitboards".
-        m.attacks = s == SQ_A1 ? table : magics[s - 1][pt - BISHOP].attacks + size;
-        size      = 0;
-
-        // Use Carry-Rippler trick to enumerate all subsets of masks[s] and
-        // store the corresponding sliding attack bitboard in reference[].
-        Bitboard b = 0;
-        do
-        {
-#ifndef USE_PEXT
-            occupancy[size] = b;
-#endif
-            reference[size] = Bitboards::sliding_attack(pt, s, b);
-
-            if (HasPext)
-                m.attacks[pext(b, m.mask)] = reference[size];
-
-            size++;
-            b = (b - m.mask) & m.mask;
-        } while (b);
-
-#ifndef USE_PEXT
-        PRNG rng(seeds[Is64Bit][rank_of(s)]);
-
-        // Find a magic for square 's' picking up an (almost) random number
-        // until we find the one that passes the verification test.
-        for (int i = 0; i < size;)
-        {
-            for (m.magic = 0; popcount((m.magic * m.mask) >> 56) < 6;)
-                m.magic = rng.sparse_rand<Bitboard>();
-
-            // A good magic must map every possible occupancy to an index that
-            // looks up the correct sliding attack in the attacks[s] database.
-            // Note that we build up the database for square 's' as a side
-            // effect of verifying the magic. Keep track of the attempt count
-            // and save it in epoch[], little speed-up trick to avoid resetting
-            // m.attacks[] after every failed attempt.
-            for (++cnt, i = 0; i < size; ++i)
-            {
-                unsigned idx = m.index(occupancy[i]);
-
-                if (epoch[idx] < cnt)
-                {
-                    epoch[idx]     = cnt;
-                    m.attacks[idx] = reference[i];
-                }
-                else if (m.attacks[idx] != reference[i])
-                    break;
-            }
-        }
-#endif
-    }
-}
 }
 
 }  // namespace Stockfish

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -21,15 +21,14 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstdint>
 #include <cmath>
 #include <cstring>
-#include <cstdint>
 #include <cstdlib>
 #include <string>
-#include <initializer_list>
-#include <array>
 
 #include "types.h"
+#include "misc.h"
 
 namespace Stockfish {
 
@@ -67,41 +66,8 @@ constexpr Bitboard Rank6BB = Rank1BB << (8 * 5);
 constexpr Bitboard Rank7BB = Rank1BB << (8 * 6);
 constexpr Bitboard Rank8BB = Rank1BB << (8 * 7);
 
-extern uint8_t PopCnt16[1 << 16];
-extern uint8_t SquareDistance[SQUARE_NB][SQUARE_NB];
-
-extern Bitboard BetweenBB[SQUARE_NB][SQUARE_NB];
-extern Bitboard LineBB[SQUARE_NB][SQUARE_NB];
-extern Bitboard RayPassBB[SQUARE_NB][SQUARE_NB];
-
-// Magic holds all magic bitboards relevant data for a single square
-struct Magic {
-    Bitboard  mask;
-    Bitboard* attacks;
-#ifndef USE_PEXT
-    Bitboard magic;
-    unsigned shift;
-#endif
-
-    // Compute the attack's index using the 'magic bitboards' approach
-    unsigned index(Bitboard occupied) const {
-
-#ifdef USE_PEXT
-        return unsigned(pext(occupied, mask));
-#else
-        if (Is64Bit)
-            return unsigned(((occupied & mask) * magic) >> shift);
-
-        unsigned lo = unsigned(occupied) & unsigned(mask);
-        unsigned hi = unsigned(occupied >> 32) & unsigned(mask >> 32);
-        return (lo * unsigned(magic) ^ hi * unsigned(magic >> 32)) >> shift;
-#endif
-    }
-
-    Bitboard attacks_bb(Bitboard occupied) const { return attacks[index(occupied)]; }
-};
-
-extern Magic Magics[SQUARE_NB][2];
+extern std::uint8_t PopCnt16[1 << 16];
+extern std::uint8_t SquareDistance[SQUARE_NB][SQUARE_NB];
 
 constexpr Bitboard square_bb(Square s) {
     assert(is_ok(s));
@@ -168,31 +134,6 @@ constexpr Bitboard pawn_single_push_bb(Color c, Bitboard b) {
     return c == WHITE ? shift<NORTH>(b) : shift<SOUTH>(b);
 }
 
-
-// Returns a bitboard representing an entire line (from board edge
-// to board edge) that intersects the two given squares. If the given squares
-// are not on a same file/rank/diagonal, the function returns 0. For instance,
-// line_bb(SQ_C4, SQ_F7) will return a bitboard with the A2-G8 diagonal.
-inline Bitboard line_bb(Square s1, Square s2) {
-
-    assert(is_ok(s1) && is_ok(s2));
-    return LineBB[s1][s2];
-}
-
-
-// Returns a bitboard representing the squares in the semi-open
-// segment between the squares s1 and s2 (excluding s1 but including s2). If the
-// given squares are not on a same file/rank/diagonal, it returns s2. For instance,
-// between_bb(SQ_C4, SQ_F7) will return a bitboard with squares D5, E6 and F7, but
-// between_bb(SQ_E6, SQ_F8) will return a bitboard with the square F8. This trick
-// allows to generate non-king evasion moves faster: the defending piece must either
-// interpose itself to cover the check or capture the checking piece.
-inline Bitboard between_bb(Square s1, Square s2) {
-
-    assert(is_ok(s1) && is_ok(s2));
-    return BetweenBB[s1][s2];
-}
-
 // distance() functions return the distance between x and y, defined as the
 // number of steps for a king in x to reach y.
 
@@ -236,13 +177,24 @@ inline int popcount(Bitboard b) {
 
 #elif defined(_MSC_VER)
 
-    return int(_mm_popcnt_u64(b));
+    return int(_mm_popcnt_std::uint64_t(b));
 
 #else  // Assumed gcc or compatible compiler
 
     return __builtin_popcountll(b);
 
 #endif
+}
+
+inline constexpr int lsb_index64[64] = {
+  0,  47, 1,  56, 48, 27, 2,  60, 57, 49, 41, 37, 28, 16, 3,  61, 54, 58, 35, 52, 50, 42,
+  21, 44, 38, 32, 29, 23, 17, 11, 4,  62, 46, 55, 26, 59, 40, 36, 15, 53, 34, 51, 20, 43,
+  31, 22, 10, 45, 25, 39, 14, 33, 19, 30, 9,  24, 13, 18, 8,  12, 7,  6,  5,  63};
+
+constexpr int constexpr_lsb(std::uint64_t bb) {
+    assert(bb != 0);
+    constexpr std::uint64_t debruijn64 = 0x03F79D71B4CB0A89ULL;
+    return lsb_index64[((bb ^ (bb - 1)) * debruijn64) >> 58];
 }
 
 // Returns the least significant bit in a non-zero bitboard.
@@ -265,12 +217,12 @@ inline Square lsb(Bitboard b) {
 
     if (b & 0xffffffff)
     {
-        _BitScanForward(&idx, int32_t(b));
+        _BitScanForward(&idx, i32(b));
         return Square(idx);
     }
     else
     {
-        _BitScanForward(&idx, int32_t(b >> 32));
+        _BitScanForward(&idx, i32(b >> 32));
         return Square(idx + 32);
     }
     #endif
@@ -300,12 +252,12 @@ inline Square msb(Bitboard b) {
 
     if (b >> 32)
     {
-        _BitScanReverse(&idx, int32_t(b >> 32));
+        _BitScanReverse(&idx, i32(b >> 32));
         return Square(idx + 32);
     }
     else
     {
-        _BitScanReverse(&idx, int32_t(b));
+        _BitScanReverse(&idx, i32(b));
         return Square(idx);
     }
     #endif
@@ -327,155 +279,6 @@ inline Square pop_lsb(Bitboard& b) {
     const Square s = lsb(b);
     b &= b - 1;
     return s;
-}
-
-namespace Bitboards {
-// Returns the bitboard of target square for the given step
-// from the given square. If the step is off the board, returns empty bitboard.
-constexpr Bitboard safe_destination(Square s, int step) {
-    constexpr auto abs = [](int v) { return v < 0 ? -v : v; };
-    Square         to  = Square(s + step);
-    return is_ok(to) && abs(file_of(s) - file_of(to)) <= 2 ? square_bb(to) : Bitboard(0);
-}
-
-constexpr Bitboard sliding_attack(PieceType pt, Square sq, Bitboard occupied) {
-    Bitboard  attacks             = 0;
-    Direction RookDirections[4]   = {NORTH, SOUTH, EAST, WEST};
-    Direction BishopDirections[4] = {NORTH_EAST, SOUTH_EAST, SOUTH_WEST, NORTH_WEST};
-
-    for (Direction d : (pt == ROOK ? RookDirections : BishopDirections))
-    {
-        Square s = sq;
-        while (safe_destination(s, d))
-        {
-            attacks |= (s += d);
-            if (occupied & s)
-            {
-                break;
-            }
-        }
-    }
-
-    return attacks;
-}
-
-constexpr Bitboard knight_attack(Square sq) {
-    Bitboard b = {};
-    for (int step : {-17, -15, -10, -6, 6, 10, 15, 17})
-        b |= safe_destination(sq, step);
-    return b;
-}
-
-constexpr Bitboard king_attack(Square sq) {
-    Bitboard b = {};
-    for (int step : {-9, -8, -7, -1, 1, 7, 8, 9})
-        b |= safe_destination(sq, step);
-    return b;
-}
-
-constexpr Bitboard pseudo_attacks(PieceType pt, Square sq) {
-    switch (pt)
-    {
-    case PieceType::ROOK :
-    case PieceType::BISHOP :
-        return sliding_attack(pt, sq, 0);
-    case PieceType::QUEEN :
-        return sliding_attack(PieceType::ROOK, sq, 0) | sliding_attack(PieceType::BISHOP, sq, 0);
-    case PieceType::KNIGHT :
-        return knight_attack(sq);
-    case PieceType::KING :
-        return king_attack(sq);
-    default :
-        assert(false);
-        return 0;
-    }
-}
-
-}
-
-inline constexpr auto PseudoAttacks = []() constexpr {
-    std::array<std::array<Bitboard, SQUARE_NB>, PIECE_TYPE_NB> attacks{};
-
-    for (Square s1 = SQ_A1; s1 <= SQ_H8; ++s1)
-    {
-        attacks[WHITE][s1] = pawn_attacks_bb<WHITE>(square_bb(s1));
-        attacks[BLACK][s1] = pawn_attacks_bb<BLACK>(square_bb(s1));
-
-        attacks[KING][s1]   = Bitboards::pseudo_attacks(KING, s1);
-        attacks[KNIGHT][s1] = Bitboards::pseudo_attacks(KNIGHT, s1);
-        attacks[QUEEN][s1] = attacks[BISHOP][s1] = Bitboards::pseudo_attacks(BISHOP, s1);
-        attacks[QUEEN][s1] |= attacks[ROOK][s1]  = Bitboards::pseudo_attacks(ROOK, s1);
-    }
-
-    return attacks;
-}();
-
-inline constexpr auto PawnPushOrAttacks = []() constexpr {
-    std::array<std::array<Bitboard, SQUARE_NB>, COLOR_NB> attacks{};
-
-    for (Square s1 = SQ_A1; s1 <= SQ_H8; ++s1)
-    {
-        attacks[WHITE][s1] = pawn_single_push_bb(WHITE, square_bb(s1)) | PseudoAttacks[WHITE][s1];
-        attacks[BLACK][s1] = pawn_single_push_bb(BLACK, square_bb(s1)) | PseudoAttacks[BLACK][s1];
-    }
-
-    return attacks;
-}();
-
-
-// Returns the pseudo attacks of the given piece type
-// assuming an empty board.
-template<PieceType Pt>
-inline Bitboard attacks_bb(Square s, Color c = COLOR_NB) {
-
-    assert((Pt != PAWN || c < COLOR_NB) && is_ok(s));
-    return Pt == PAWN ? PseudoAttacks[c][s] : PseudoAttacks[Pt][s];
-}
-
-
-// Returns the attacks by the given piece
-// assuming the board is occupied according to the passed Bitboard.
-// Sliding piece attacks do not continue passed an occupied square.
-template<PieceType Pt>
-inline Bitboard attacks_bb(Square s, Bitboard occupied) {
-
-    assert(Pt != PAWN && is_ok(s));
-
-    switch (Pt)
-    {
-    case BISHOP :
-    case ROOK :
-        return Magics[s][Pt - BISHOP].attacks_bb(occupied);
-    case QUEEN :
-        return attacks_bb<BISHOP>(s, occupied) | attacks_bb<ROOK>(s, occupied);
-    default :
-        return PseudoAttacks[Pt][s];
-    }
-}
-
-// Returns the attacks by the given piece
-// assuming the board is occupied according to the passed Bitboard.
-// Sliding piece attacks do not continue passed an occupied square.
-inline Bitboard attacks_bb(PieceType pt, Square s, Bitboard occupied) {
-
-    assert(pt != PAWN && is_ok(s));
-
-    switch (pt)
-    {
-    case BISHOP :
-        return attacks_bb<BISHOP>(s, occupied);
-    case ROOK :
-        return attacks_bb<ROOK>(s, occupied);
-    case QUEEN :
-        return attacks_bb<BISHOP>(s, occupied) | attacks_bb<ROOK>(s, occupied);
-    default :
-        return PseudoAttacks[pt][s];
-    }
-}
-
-inline Bitboard attacks_bb(Piece pc, Square s, Bitboard occupied) {
-    return type_of(pc) == PAWN ? PseudoAttacks[color_of(pc)][s]
-                               : attacks_bb(type_of(pc), s, occupied);
 }
 
 }  // namespace Stockfish

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,7 @@
 #include <iostream>
 #include <memory>
 
+#include "attacks.h"
 #include "bitboard.h"
 #include "misc.h"
 #include "position.h"
@@ -32,6 +33,7 @@ int main(int argc, char* argv[]) {
     std::cout << "Developed by " << engine_author_info() << std::endl;
 
     Bitboards::init();
+    Attacks::init();
     Position::init();
 
     auto uci = std::make_unique<UCIEngine>(argc, argv);

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -21,6 +21,7 @@
 #include <cassert>
 #include <initializer_list>
 
+#include "attacks.h"
 #include "bitboard.h"
 #include "position.h"
 

--- a/src/position.h
+++ b/src/position.h
@@ -27,6 +27,7 @@
 #include <new>
 #include <string>
 
+#include "attacks.h"
 #include "bitboard.h"
 #include "types.h"
 


### PR DESCRIPTION
### Motivation
- Replace monolithic Wordfish bitboard attack ownership with the official Stockfish dev attacks topology to prepare for downstream RankAttacks/HQ changes while preserving runtime semantics.
- Move runtime attack tables and magic/HQ initialization out of `bitboard.*` into an `Attacks` authority to improve code separation and follow Stockfish topology.
- Preserve all Wordfish-local bitboard primitives and public helpers relied on by Position/Search/MoveGen so no movegen or search semantics change.

### Description
- Add `src/attacks.h` and `src/attacks.cpp` based on `official/master` at `86f1df7134fa54fe93e90dc086d978e917256c2f` and implement `Stockfish::Attacks::init()` with magic/HQ/RankAttacks topology and runtime `LineBB`/`BetweenBB`/`RayPassBB`. 
- Reduce `src/bitboard.cpp`/`src/bitboard.h` to bitboard primitives and popcount/square-distance initialization, removing duplicated runtime attack table definitions and magic initialization from `bitboard.*`.
- Wire the new files into the build by adding `attacks.cpp` to `SRCS` and `attacks.h` to `HEADERS` in `src/Makefile` and call `Attacks::init()` at startup in `main.cpp`.
- Preserve compatibility at call sites by adding `#include "attacks.h"` where required and supplying `using Attacks::...` declarations so existing unqualified `attacks_bb`, `PseudoAttacks`, `LineBB`, `BetweenBB`, `RayPassBB`, etc. continue to compile without logic changes.

### Testing
- `make -C src net` completed and validated `nn-71d6d32cb962.nnue` with SHA-256 prefix `71d6d32cb962` (success).
- Baseline build `make -C src -j2 build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS='-fuse-ld=lld' NNUE_EMBEDDING_OFF=yes` completed without warning/error diagnostics and produced a runnable binary (success).
- UCI runtime smoke `uci/isready/ucinewgame` + `go depth 1` confirmed `uciok`, `readyok`, `bestmove`, and NNUE load message (success).
- EvalFile default check confirmed `EvalFile` still points to `nn-71d6d32cb962.nnue` (success).
- Perft-1 from startpos returned 20 nodes and depth-2 tactical smoke returned a `bestmove` (success).
- `bench` ran and reported nodes searched (success).
- Final source-scope and protected-file gates passed, attack runtime tables are defined only in `src/attacks.cpp`, and only allowed files were changed (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bd941624083279c9dbd3770df9827)