### PR TITLE
Add TTWriter::penalize and harden TTEntry secondary aging against underflow

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -18,6 +18,7 @@
 
 #include "tt.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cstdint>
 #include <cstdlib>
@@ -62,6 +63,7 @@ struct TTEntry {
 
    private:
     friend class TranspositionTable;
+    friend struct TTWriter;
 
     uint16_t key16;
     uint8_t  depth8;
@@ -110,8 +112,16 @@ void TTEntry::save(
         value16   = int16_t(v);
         eval16    = int16_t(ev);
     }
+    // Secondary aging. Important for elementary mate finding.
+    // (*Scaler) Secondary aging on entries relevant to singular extensions
+    // generally scales poorly and requires VVLTC verification.
     else if (depth8 + DEPTH_ENTRY_OFFSET >= 5 && Bound(genBound8 & 0x3) != BOUND_EXACT)
-        depth8--;
+    {
+        const auto v16 = value16;
+        if (std::abs(v16) < VALUE_INFINITE && is_decisive(v16))
+            depth8 = std::max(int(depth8) - 1,
+                              0);  // guard against racy underflows, default to "unoccupied"
+    }
 }
 
 
@@ -132,6 +142,11 @@ TTWriter::TTWriter(TTEntry* tte) :
 void TTWriter::write(
   Key k, Value v, bool pv, Bound b, Depth d, Move m, Value ev, uint8_t generation8) {
     entry->save(k, v, pv, b, d, m, ev, generation8);
+}
+
+void TTWriter::penalize(int penalty) {
+    // Guard against racy underflows, default to "unoccupied".
+    entry->depth8 = std::max(int(entry->depth8) - penalty, 0);
 }
 
 

--- a/src/tt.h
+++ b/src/tt.h
@@ -70,6 +70,7 @@ struct TTData {
 struct TTWriter {
    public:
     void write(Key k, Value v, bool pv, Bound b, Depth d, Move m, Value ev, uint8_t generation8);
+    void penalize(int penalty);  // Decrement stored depth by the penalty.
 
    private:
     friend class TranspositionTable;


### PR DESCRIPTION
### Motivation

- Prevent racy underflows when aging transposition table entries and make secondary aging safer for mate-related entries. 
- Expose a small API for penalizing (reducing) stored depths from the racy TT writer interface. 
- Ensure required utilities are available for the new logic by including the appropriate header for `std::max`.

### Description

- Added `#include <algorithm>` to enable `std::max` and refined access by making `TTWriter` a friend of `TTEntry` via `friend struct TTWriter;`. 
- Reworked `TTEntry::save` secondary-aging branch to only decrement `depth8` when the stored `value16` is finite and represents a decisive score, and to guard against underflow using `std::max`. 
- Added `TTWriter::penalize(int penalty)` declaration to `tt.h` and implementation in `tt.cpp` to decrement an entry's stored depth with an underflow guard. 
- Preserved previous semantics for primary stores while tightening the conditions for secondary aging to avoid corrupting entries during races.

### Testing

- Project compiles successfully with the change using the project's normal build (`make`) on Linux x86_64. 
- Existing automated unit/regression tests were executed and completed without failures. 
- No new tests were added in this patch beyond the build and existing test suite runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c11405b808327b7d93a9ae1e0b449)