### PR TITLE
Return and propagate Position parsing errors; validate FEN before applying

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -308,10 +308,19 @@ void Engine::set_on_verify_network(std::function<void(std::string_view)>&& f) {
 
 void Engine::wait_for_search_finished() { threads.main_thread()->wait_for_search_finished(); }
 
-void Engine::set_position(const std::string& fen, const std::vector<std::string>& moves) {
+std::optional<PositionSetError> Engine::set_position(const std::string&              fen,
+                                                       const std::vector<std::string>& moves) {
+    // Validate before replacing the active position, so rejected input leaves it unchanged.
+    Position  candidate;
+    StateInfo candidateState;
+    auto      error = candidate.set(fen, options["UCI_Chess960"], &candidateState);
+    if (error.has_value())
+        return error;
+
     // Drop the old state and create a new one
     states = StateListPtr(new std::deque<StateInfo>(1));
-    pos.set(fen, options["UCI_Chess960"], &states->back());
+    error  = pos.set(fen, options["UCI_Chess960"], &states->back());
+    assert(!error.has_value());
 
     for (const auto& move : moves)
     {
@@ -323,6 +332,8 @@ void Engine::set_position(const std::string& fen, const std::vector<std::string>
         states->emplace_back();
         pos.do_move(m, states->back());
     }
+
+    return std::nullopt;
 }
 
 // modifiers

--- a/src/engine.h
+++ b/src/engine.h
@@ -65,7 +65,8 @@ class Engine {
     // blocking call to wait for search to finish
     void wait_for_search_finished();
     // set a new position, moves are in UCI format
-    void set_position(const std::string& fen, const std::vector<std::string>& moves);
+    std::optional<PositionSetError> set_position(const std::string&              fen,
+                                                 const std::vector<std::string>& moves);
 
     // modifiers
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -160,7 +160,8 @@ void Position::init() {
 // Initializes the position object with the given FEN string.
 // This function is not very robust - make sure that input FENs are correct,
 // this is assumed to be the responsibility of the GUI.
-Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si) {
+std::optional<PositionSetError>
+Position::set(const string& fenStr, bool isChess960, StateInfo* si) {
     /*
    A FEN string defines a particular position using only the ASCII character set.
 
@@ -222,6 +223,9 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si) {
             ++sq;
         }
     }
+
+    if (pieces(PAWN) & (Rank1BB | Rank8BB))
+        return PositionSetError("Unsupported position. Pawns on the first or eighth rank.");
 
     // 2. Active color
     ss >> token;
@@ -300,7 +304,7 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si) {
 
     assert(pos_is_ok());
 
-    return *this;
+    return std::nullopt;
 }
 
 
@@ -413,7 +417,9 @@ Position& Position::set(const string& code, Color c, StateInfo* si) {
     string fenStr = "8/" + sides[0] + char(8 - sides[0].length() + '0') + "/8/8/8/8/" + sides[1]
                   + char(8 - sides[1].length() + '0') + "/8 w - - 0 10";
 
-    return set(fenStr, false, si);
+    auto error = set(fenStr, false, si);
+    assert(!error.has_value());
+    return *this;
 }
 
 

--- a/src/position.h
+++ b/src/position.h
@@ -25,6 +25,8 @@
 #include <iosfwd>
 #include <memory>
 #include <new>
+#include <optional>
+#include <stdexcept>
 #include <string>
 
 #include "attacks.h"
@@ -70,6 +72,12 @@ struct StateInfo {
 // elements are not invalidated upon list resizing.
 using StateListPtr = std::unique_ptr<std::deque<StateInfo>>;
 
+// This error should be used whenever a position is suspected to be unsupported
+// by the engine. In particular positions that may cause hard errors like segmentation fault.
+struct PositionSetError: std::runtime_error {
+    using std::runtime_error::runtime_error;
+};
+
 
 // Position class stores information regarding the board representation as
 // pieces, side to move, hash keys, castling info, etc. Important methods are
@@ -84,9 +92,9 @@ class Position {
     Position& operator=(const Position&) = delete;
 
     // FEN string input/output
-    Position&   set(const std::string& fenStr, bool isChess960, StateInfo* si);
-    Position&   set(const std::string& code, Color c, StateInfo* si);
-    std::string fen() const;
+    std::optional<PositionSetError> set(const std::string& fenStr, bool isChess960, StateInfo* si);
+    Position&                       set(const std::string& code, Color c, StateInfo* si);
+    std::string                     fen() const;
 
     // Position representation
     Bitboard pieces() const;  // All pieces

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -608,7 +608,8 @@ void UCIEngine::position(std::istringstream& is) {
         moves.push_back(token);
     }
 
-    engine.set_position(fen, moves);
+    if (auto error = engine.set_position(fen, moves))
+        print_info_string(error->what());
 }
 
 namespace {


### PR DESCRIPTION
### Motivation
- Prevent crashes and undefined behaviour when loading unsupported FENs by validating the FEN before replacing the active `Position` state.
- Provide a clear error type for position setup failures so callers can react to invalid input instead of assuming success.

### Description
- Introduced `PositionSetError` (subclassing `std::runtime_error`) and changed `Position::set(const std::string&, bool, StateInfo*)` to return `std::optional<PositionSetError>` to signal parsing/validation failures.
- Added an explicit validation that rejects positions with pawns on rank 1 or rank 8 and return an error in that case.
- Updated the `Position::set(const string& code, Color, StateInfo*)` overload to call the new `set` and assert no error, and updated includes to add `<optional>` and `<stdexcept>`.
- Changed `Engine::set_position` to validate a candidate `Position` first and return `std::optional<PositionSetError>` on failure, and adjusted `uci::position` to print the error message when `set_position` returns an error.

### Testing
- Ran the existing automated test suite via `make test` and the suite completed successfully.
- Exercised the UCI `position` code path to confirm invalid FENs (e.g. pawns on rank 1/8) are rejected and produce an informational error message.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c17d9433083279c36c56140b8b0bb)