### PR TITLE
Add macOS universal build support (macos-lipo) and supporting scripts

### DIFF
--- a/scripts/check_universal_macos.sh
+++ b/scripts/check_universal_macos.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+# Usage: check_universal_macos.sh STOCKFISH_EXE [EXPECTED_BENCH]
+
+set -eu
+
+STOCKFISH_EXE=$1
+
+extract() {
+    awk -F: -v lbl="$1" '$0 ~ lbl {
+        sub(/^[[:space:]]+/, "", $2); sub(/[[:space:]]+$/, "", $2); print $2; exit
+    }'
+}
+
+FAIL=0
+
+BINARY_SIZE=$(wc -c < "$STOCKFISH_EXE")
+MAX_SIZE=$((150 * 1024 * 1024))
+if [ "$BINARY_SIZE" -gt "$MAX_SIZE" ]; then
+    printf 'check_universal_macos.sh: binary size %d bytes exceeds 150 MB limit\n' "$BINARY_SIZE" >&2
+    exit 1
+fi
+
+native_bench=$(arch -arm64 "$STOCKFISH_EXE" bench 2>&1 | extract "Nodes searched" || true)
+if [ -z "$native_bench" ]; then
+    echo "check_universal_macos.sh: arm64 run produced no bench" >&2
+    FAIL=1
+else
+    printf 'native (arm64) bench %s\n' "$native_bench" >&2
+fi
+
+x86_bench=$(arch -x86_64 "$STOCKFISH_EXE" bench 2>&1 | extract "Nodes searched" || true)
+if [ -z "$x86_bench" ]; then
+    echo "check_universal_macos.sh: x86_64 (Rosetta) run produced no bench (crashed?)" >&2
+    FAIL=1
+else
+    printf 'x86_64 (Rosetta) bench %s\n' "$x86_bench" >&2
+fi
+
+# Should match
+if [ "$native_bench" != "$x86_bench" ]; then
+    printf 'check_universal_macos.sh: slice bench mismatch: arm64=%s x86_64=%s\n' \
+        "$native_bench" "$x86_bench" >&2
+    FAIL=1
+fi
+
+# Check that under Rosetta, SSE41 is detected
+x86_compiler=$(arch -x86_64 "$STOCKFISH_EXE" compiler 2>&1 || true)
+if printf '%s\n' "$x86_compiler" | grep -q 'SSE41'; then
+    printf 'x86_64 (Rosetta) compiler reports SSE41 ok\n' >&2
+else
+    echo "check_universal_macos.sh: x86_64 compiler output missing SSE41" >&2
+    printf '%s\n' "$x86_compiler" >&2
+    FAIL=1
+fi
+
+if [ "$FAIL" != 0 ]; then
+    echo "check_universal_macos.sh: failed"
+    exit 1
+fi
+
+echo "check_universal_macos.sh: Good! Universal macOS binary works."

--- a/src/Makefile
+++ b/src/Makefile
@@ -967,6 +967,7 @@ help:
 	echo "help                    > Display architecture details" && \
 	echo "profile-build           > standard build with profile-guided optimization" && \
 	echo "build                   > skip profile-guided optimization" && \
+	echo "macos-lipo              > macOS x86-64 + Apple silicon universal binary" && \
 	echo "net                     > Download the default nnue nets" && \
 	echo "strip                   > Strip executable" && \
 	echo "install                 > Install executable" && \
@@ -1035,7 +1036,7 @@ ifneq ($(SUPPORTED_ARCH), true)
 endif
 
 
-.PHONY: help analyze build profile-build strip install clean net \
+.PHONY: help analyze build profile-build macos-lipo strip install clean net \
 	objclean profileclean universalclean config-sanity universal-object-nopgo \
 	icx-profile-use icx-profile-make \
 	gcc-profile-use gcc-profile-make \
@@ -1065,6 +1066,33 @@ profile-build: $(NNUE_TARGET) config-sanity objclean profileclean
 	@echo "Step 4/4. Deleting profile data ..."
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) profileclean
 endif
+
+# Build a Mach-O universal binary while keeping the existing Wordfish ISA-aware
+# executable names used by each thin slice.
+MACOS_X86_EXE   := Wordfish-$(RELEASE_TAG)-x86-64-universal
+MACOS_ARM64_EXE := Wordfish-$(RELEASE_TAG)-apple-silicon
+MACOS_LIPO_EXE  := Wordfish-$(RELEASE_TAG)-macos-universal
+
+# Default network filename, read from evaluate.h's EvalFileDefaultName.
+macos-lipo: NNUE_NET = $(shell grep -oE 'nn-[0-9a-f]+\.nnue' $(CURDIR)/evaluate.h | head -1)
+macos-lipo:
+	@echo ""
+	@echo "Step 1/4. Building x86-64 slice (network shared from Apple-silicon slice) ..."
+	$(MAKE) build ARCH=x86-64-universal COMP=$(COMP) MACOS_X86_SLICE=1
+	mv $(MACOS_X86_EXE) $(MACOS_X86_EXE).slice
+	@echo ""
+	@echo "Step 2/4. Building Apple silicon slice ..."
+	$(MAKE) profile-build ARCH=apple-silicon COMP=$(COMP)
+	mv $(MACOS_ARM64_EXE) $(MACOS_ARM64_EXE).slice
+	@echo ""
+	@echo "Step 3/4. Combining slices and locating the embedded network ..."
+	lipo -create $(MACOS_X86_EXE).slice $(MACOS_ARM64_EXE).slice -output $(MACOS_LIPO_EXE)
+	$(SHELL) universal/patch_x86_slice.sh $(MACOS_LIPO_EXE) $(MACOS_X86_EXE).slice $(NNUE_NET)
+	@echo ""
+	@echo "Step 4/4. Re-combining slices with the patched x86-64 slice ..."
+	lipo -create $(MACOS_X86_EXE).slice $(MACOS_ARM64_EXE).slice -output $(MACOS_LIPO_EXE)
+	@rm -f $(MACOS_X86_EXE).slice $(MACOS_ARM64_EXE).slice
+	@echo "Universal macOS Wordfish binary built: $(MACOS_LIPO_EXE)"
 
 strip:
 	$(STRIP) $(EXE)
@@ -1277,7 +1305,13 @@ OBJCOPY               ?= objcopy
 arch-suffix     = $(subst -,_,$(1))
 arch-namespace  = Stockfish_$(call arch-suffix,$(1))
 arch-main       = Wordfish_$(call arch-suffix,$(1))_main
-arch-cxxflags   = -DStockfish=$(call arch-namespace,$(1)) -Dmain=$(call arch-main,$(1)) -Wno-missing-prototypes
+ifeq ($(MACOS_X86_SLICE),1)
+  MACOS_SLICE_FLAGS := -DUNIVERSAL_BINARY -DUNIVERSAL_BINARY_MACOS_X86_SLICE
+  MACOS_NNUE_EMBED_OBJ := $(NNUE_EMBED_OBJ)
+endif
+
+arch-cxxflags   = -DStockfish=$(call arch-namespace,$(1)) -Dmain=$(call arch-main,$(1)) \
+                  $(MACOS_SLICE_FLAGS) -Wno-missing-prototypes
 
 build: $(UNIVERSAL_EXE)
 profile-build: $(UNIVERSAL_EXE)
@@ -1292,7 +1326,8 @@ $(UNIVERSAL_ENTRY_OBJ): $(UNIVERSAL_ENTRY_SRC) | $(TEMP_DIR)
 # validation matrix disables embedding, so slices retain Wordfish's existing
 # NNUE_EMBEDDING_OFF behavior and load EvalFileDefaultName from disk.
 $(NNUE_EMBED_OBJ): $(UNIVERSAL_SRC_DIR)/nnue_embed.cpp | $(TEMP_DIR)
-	$(CXX) -O2 -std=c++20 -Wno-c++26-extensions -c $< -o $@
+	$(CXX) -O2 -std=c++20 -Wno-c++26-extensions \
+		-DUNIVERSAL_BINARY_MACOS_X86_SLICE -c $< -o $@
 
 $(TEMP_DIR)/%/.setup: | $(TEMP_DIR)
 	@rm -rf $(TEMP_DIR)/$*
@@ -1310,8 +1345,8 @@ $(TEMP_DIR)/%/wordfish.o: $(TEMP_DIR)/%/.setup
 	$(OBJCOPY) --rename-section .init_array=$(call arch-suffix,$*)_init $@
 	$(OBJCOPY) --set-section-flags $(call arch-suffix,$*)_init=alloc,data $@
 
-$(UNIVERSAL_EXE): $(UNIVERSAL_ENTRY_OBJ) $(ARCH_OBJS)
-	$(CXX) -o $@ $(UNIVERSAL_ENTRY_OBJ) $(ARCH_OBJS) $(LDFLAGS)
+$(UNIVERSAL_EXE): $(UNIVERSAL_ENTRY_OBJ) $(ARCH_OBJS) $(MACOS_NNUE_EMBED_OBJ)
+	$(CXX) -o $@ $(UNIVERSAL_ENTRY_OBJ) $(ARCH_OBJS) $(MACOS_NNUE_EMBED_OBJ) $(LDFLAGS)
 	@echo "Universal Wordfish binary built: $@"
 
 endif

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -43,8 +43,12 @@
 //     const unsigned char *const gEmbeddedNNUEEnd;     // a marker to the end
 //     const unsigned int         gEmbeddedNNUESize;    // the size of the embedded file
 // Note that this does not work in Microsoft Visual Studio.
-#if !defined(_MSC_VER) && !defined(NNUE_EMBEDDING_OFF)
+#if !defined(UNIVERSAL_BINARY) && !defined(_MSC_VER) && !defined(NNUE_EMBEDDING_OFF)
 INCBIN(EmbeddedNNUE, EvalFileDefaultName);
+#elif defined(UNIVERSAL_BINARY_MACOS_X86_SLICE)
+// Determined at runtime, see universal/nnue_embed.cpp
+extern const unsigned char* const gEmbeddedNNUEData;
+extern const unsigned int         gEmbeddedNNUESize;
 #else
 const unsigned char gEmbeddedNNUEData[1] = {0x0};
 const unsigned int  gEmbeddedNNUESize    = 1;
@@ -260,6 +264,11 @@ void NetworkImpl<Arch, Transformer>::load_internal() {
             setp(p, p + n);
         }
     };
+
+#ifdef UNIVERSAL_BINARY_MACOS_X86_SLICE
+    if (gEmbeddedNNUEData == nullptr)  // failed embedded load
+        return;
+#endif
 
     MemoryBuffer buffer(const_cast<char*>(reinterpret_cast<const char*>(gEmbeddedNNUEData)),
                         size_t(gEmbeddedNNUESize));

--- a/src/universal/patch_x86_slice.sh
+++ b/src/universal/patch_x86_slice.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+
+# Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+# Copyright (C) 2004-2026 The Stockfish developers (see AUTHORS file)
+#
+# Stockfish is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Stockfish is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# This finds the gUniversalNNUEOffset/gUniversalNNUESize symbols in the x86 slice
+# and patches them to be an offset+size into the full executable.
+#
+# Usage: patch_x86_slice.sh <fat_binary> <x86_64_thin_slice> <nnue_file>
+
+set -eu
+
+FAT="$1"
+X86="$2"
+NET="$3"
+
+# Must match volatile initializers in nnue_embed.cpp; byte order
+# is reversed to match how it appears in the binary xxd
+OFFSET_MAGIC=e7f50fe7f50ffeca
+SIZE_MAGIC=2e51feca2e51feca
+
+die() { echo "patch_x86_slice: $*" >&2; exit 1; }
+
+# Find hex pattern in file, return byte offset
+# Optional $3 = bytes to skip, $4 = max bytes to scan
+find_bytes() {
+    file=$1; needle=$2; skip=${3:-0}; window=${4:-0}
+    [ "$window" -gt 0 ] && win="-l $window" || win=""
+    # Disassemble as hex, strip \n and search for the pattern
+    pos=$(xxd -s "$skip" $win -p "$file" | tr -d '\n' \
+            | awk -v n="$needle" '{ p = index($0, n); if (p) { print p; exit } }')
+    [ -n "$pos" ] || return 1
+    echo $(( skip + (pos - 1) / 2 ))
+}
+
+# Overwrite 8 bytes at a file offset
+write_u64_le() {
+    f="$1"; off="$2"; v="$3"; bytes=""; i=0
+    while [ "$i" -lt 8 ]; do
+        bytes="$bytes$(printf '\\%03o' "$(( v & 255 ))")"
+        v=$(( v >> 8 )); i=$(( i + 1 ))
+    done
+    printf "$bytes" | dd of="$f" bs=1 seek="$off" conv=notrunc 2>/dev/null
+}
+
+needle=$(xxd -p -l 64 "$NET" | tr -d '\n')  # take first bytes of network as needle
+net_size=$(wc -c < "$NET" | tr -d ' ')
+
+# The arm64 slice always follows the x86-64 slice in
+# the fat binary, so scan from ~after the x86-64 slice.
+x86_size=$(wc -c < "$X86" | tr -d ' ')
+net_off=$(find_bytes "$FAT" "$needle" "$x86_size" 8000000) || die "network not found"
+
+off_pos=$(find_bytes "$X86" "$OFFSET_MAGIC") || die "offset sentinel not found"
+size_pos=$(find_bytes "$X86" "$SIZE_MAGIC")  || die "size sentinel not found"
+
+write_u64_le "$X86" "$off_pos"  "$net_off"
+write_u64_le "$X86" "$size_pos" "$net_size"
+
+echo "patch_x86_slice.sh: network at offset $net_off + size $net_size "


### PR DESCRIPTION
### Motivation

- Provide a reproducible way to produce a single macOS universal binary (Apple silicon + x86_64) while preserving existing per-slice executable naming and behavior.
- Ensure the x86_64 slice can locate and use the NNUE network embedded in the fat binary and validate slices at build/test time.

### Description

- Added a new Makefile target `macos-lipo` and related variables `MACOS_X86_EXE`, `MACOS_ARM64_EXE`, and `MACOS_LIPO_EXE` to build x86-64 and Apple silicon slices, combine them with `lipo`, patch the x86 slice to reference the embedded NNUE, and produce a universal binary. 
- Introduced `MACOS_SLICE_FLAGS` and adjusted `arch-cxxflags` plus the `NNUE_EMBED_OBJ` build rule to pass `-DUNIVERSAL_BINARY_MACOS_X86_SLICE` when building the macOS x86 slice so the slice can be patched to reference the embedded network at runtime. 
- Modified `src/nnue/network.cpp` to avoid compiling the default embedded NNUE into universal builds and to allow the x86 slice to reference externally-patched embedded data via `UNIVERSAL_BINARY_MACOS_X86_SLICE` and a runtime `extern` pointer, with a null check to gracefully skip loading if the slice is not patched. 
- Added two helper scripts: `scripts/check_universal_macos.sh` to verify slice parity, SSE41 detection under Rosetta, and binary size limits; and `src/universal/patch_x86_slice.sh` to locate the embedded NNUE in the fat binary and patch the sentinel offsets in the x86 thin slice to point at the network data.
- Updated `help` output to advertise the new `macos-lipo` target and added the new target to `.PHONY`.

### Testing

- Ran a syntax check on the new shell scripts with `sh -n` to validate there are no syntax errors and they passed. 
- Performed a `make -n macos-lipo` dry-run to validate Makefile target expansion and that the new build steps and variable references are resolved. 
- No automated unit tests were added or executed against engine functionality as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c532c9a808327a85ef31845b79f8d)