### PR TITLE
Apply Stockfish atomic do_move material-key correction to Wordfish

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -809,18 +809,6 @@ void Position::do_move(Move                      m,
         k ^= Zobrist::castling[st->castlingRights];
     }
 
-    // Move the piece. The tricky Chess960 castling is handled earlier
-    if (m.type_of() != CASTLING)
-    {
-        if (captured && m.type_of() != EN_PASSANT)
-        {
-            remove_piece(from, &dts);
-            swap_piece(to, pc, &dts);
-        }
-        else
-            move_piece(from, to, &dts);
-    }
-
     // If the moving piece is a pawn do some special extra work
     if (type_of(pc) == PAWN)
     {
@@ -836,8 +824,6 @@ void Position::do_move(Move                      m,
             assert(relative_rank(us, to) == RANK_8);
             assert(type_of(promotion) >= KNIGHT && type_of(promotion) <= QUEEN);
 
-            swap_piece(to, promotion, &dts);
-
             dp.add_pc = promotion;
             dp.add_sq = to;
             dp.to     = SQ_NONE;
@@ -845,8 +831,8 @@ void Position::do_move(Move                      m,
             // Update hash keys
             // Zobrist::psq[pc][to] is zero, so we don't need to clear it
             k ^= Zobrist::psq[promotion][to];
-            st->materialKey ^= Zobrist::psq[promotion][8 + pieceCount[promotion] - 1]
-                             ^ Zobrist::psq[pc][8 + pieceCount[pc]];
+            st->materialKey ^= Zobrist::psq[promotion][8 + pieceCount[promotion]]
+                             ^ Zobrist::psq[pc][8 + pieceCount[pc] - 1];
 
             if (promotionType <= BISHOP)
                 st->minorPieceKey ^= Zobrist::psq[promotion][to];
@@ -873,6 +859,27 @@ void Position::do_move(Move                      m,
     // If en passant is impossible, then k will not change and we can prefetch earlier
     if (tt && !checkEP)
         prefetch(tt->first_entry(adjust_key50(k)));
+
+    // Move the piece. The tricky Chess960 castling is handled earlier
+    if (m.type_of() != CASTLING)
+    {
+        Piece toPc = pc;
+        if (m.type_of() == PROMOTION)
+            toPc = make_piece(us, m.promotion_type());
+
+        if (captured && m.type_of() != EN_PASSANT)
+        {
+            remove_piece(from, &dts);
+            swap_piece(to, toPc, &dts);
+        }
+        else if (pc == toPc)
+            move_piece(from, to, &dts);
+        else
+        {
+            remove_piece(from, &dts);
+            put_piece(toPc, to, &dts);
+        }
+    }
 
     // Set capture piece
     st->capturedPiece = captured;
@@ -1456,7 +1463,7 @@ bool Position::material_key_is_ok() const { return compute_material_key() == st-
 // This is meant to be helpful when debugging.
 bool Position::pos_is_ok() const {
 
-    constexpr bool Fast = true;  // Quick (default) or full check?
+    constexpr bool Fast = false;  // Quick (default) or full check?
 
     if ((sideToMove != WHITE && sideToMove != BLACK) || piece_on(square<KING>(WHITE)) != W_KING
         || piece_on(square<KING>(BLACK)) != B_KING


### PR DESCRIPTION
### Motivation
- Align Wordfish `Position::do_move` temporal ordering with the official Stockfish atomic change so promotion material-key updates use pre-mutation piece counts and avoid corrupting the material key on promotions.

### Description
- Atomically import the do_move reorder + material-key fix so the non-castling physical board mutation is delayed until after key/material updates and the early TT prefetch, and is performed just prior to checker calculation and `set_check_info()`; only `src/position.cpp` was modified.
- Replace the promotion material-key XOR to use pre-mutation counts: `st->materialKey ^= Zobrist::psq[promotion][8 + pieceCount[promotion]] ^ Zobrist::psq[pc][8 + pieceCount[pc] - 1];` so the slots match the reordered topology.
- Route promotions through a delayed `toPc` path so `pieceCount` is unchanged at the material-key update point and then perform the physical `put_piece`/`swap_piece`/`move_piece` block afterwards.
- Enable the fuller debug check in `pos_is_ok()` by setting `constexpr bool Fast = false;` for improved material-key assertions in debug builds.

### Testing
- Downloaded and validated `nn-71d6d32cb962.nnue` with matching SHA-256 prefix `71d6d32cb962`; `make -C src net` succeeded.
- Built release (`ARCH=x86-64-sse41-popcnt`, `NNUE_EMBEDDING_OFF=yes`, clang); release build completed with no warning/error grep matches.
- UCI startpos smoke and `EvalFile` default check both succeeded and reported `nn-71d6d32cb962.nnue` and `bestmove` responses.
- Promotion/material-key smoke tests for white and black promotion positions and repeated-hash promotion repeat returned `bestmove` as expected.
- Built debug (`debug=yes`) and ran promotion smoke under debug `pos_is_ok()` with `bestmove` observed, showing debug checks are supported.
- Bench run completed (nodes searched recorded during validation: ~2,873,699 nodes) and basic bench output present.
- All preservation and protected-area gates were checked and passed, and only `src/position.cpp` was changed; no `.nnue` or generated artifacts were committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c597b9044832798cace719963c84f)