### PR TITLE
Rebrand Wordfish release to 5.0-120626

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 ## Overview
 
-Wordfish is a Universal Chess Interface (UCI) engine derived from Stockfish. It retains the parent engine's search strength while adding dual-network neural evaluation, a persistent experience store, and configurable Monte Carlo search. The current release is **Wordfish-4.80-040526**, tuned around the latest Stockfish evaluation networks. The codebase is engineered for reproducible testing, efficient NUMA-aware threading, and transparent diagnostics.
+Wordfish is a Universal Chess Interface (UCI) engine derived from Stockfish. It retains the parent engine's search strength while adding dual-network neural evaluation, a persistent experience store, and configurable Monte Carlo search. The current release is **Wordfish-5.0-120626**, tuned around the latest Stockfish evaluation networks. The codebase is engineered for reproducible testing, efficient NUMA-aware threading, and transparent diagnostics.
 
-## What's new in 4.80-040526
+## What's new in 5.0-120626
 
-- Rebranded the engine to **Wordfish-4.80-040526** so executable filenames and GUI analysis headers include the compiled-in architecture suffix, such as `Wordfish-4.80-040526-sse41popcnt`, `Wordfish-4.80-040526-avx2`, `Wordfish-4.80-040526-bmi2`, `Wordfish-4.80-040526-fma3`, or `Wordfish-4.80-040526-avx512`.
+- Rebranded the engine to **Wordfish-5.0-120626** so executable filenames and GUI analysis headers include the compiled-in architecture suffix, such as `Wordfish-5.0-120626-sse41popcnt`, `Wordfish-5.0-120626-avx2`, `Wordfish-5.0-120626-bmi2`, `Wordfish-5.0-120626-fma3`, or `Wordfish-5.0-120626-avx512`.
 - Updated the main NNUE evaluator to `nn-2962dca31855.nnue` from Stockfish dev 20251130, keeping the paired small network in sync for dual-network evaluation.
 - Emphasized king safety, rook coordination, and supervised endgame patterns in recent network training and handcrafted heuristics.
 - Tightened king-safety heuristics around open files, rook lifts, and dark-square weaknesses while rewarding coordinated rooks and discouraging premature flank pawn storms.

--- a/src/Makefile
+++ b/src/Makefile
@@ -39,7 +39,7 @@ else ifeq ($(COMP),mingw)
 endif
 
 ### Executable name
-RELEASE_TAG ?= 4.90-220526
+RELEASE_TAG ?= 5.0-120626
 
 ### Installation dir definitions
 PREFIX = /usr/local

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -39,7 +39,7 @@ namespace Stockfish {
 
 namespace {
 
-constexpr std::string_view base = "Wordfish 4.90-220526";
+constexpr std::string_view base = "Wordfish-5.0-120626";
 
 constexpr std::string_view arch_tag() {
 #ifdef BUILD_ARCH_SUFFIX
@@ -137,7 +137,8 @@ std::string engine_version_info() {
 }
 
 std::string engine_info(bool to_uci) {
-    return engine_version_info() + (to_uci ? "\nid author " : " by ") + engine_author_info();
+    return (to_uci ? std::string(base) : engine_version_info())
+         + (to_uci ? "\nid author " : " by ") + engine_author_info();
 }
 
 std::string engine_author_info() {


### PR DESCRIPTION
### Motivation

- Align the engine release identity and produced executable basenames with the new release tag `Wordfish-5.0-120626` while preserving existing architecture-suffix formatting and runtime behavior.
- Keep the UCI `id name` concise (base release identity) while keeping GUI/analysis-facing compiled identity including the architecture suffix. 
- Preserve active NNUE authority and avoid any semantic or search changes.

### Description

- Updated the build release tag by changing `RELEASE_TAG` in `src/Makefile` from `4.90-220526` to `5.0-120626`, preserving the existing `BUILD_ARCH_SUFFIX` and `EXE` naming rules so compiled binaries are `Wordfish-5.0-120626-<arch>`.
- Replaced the base engine identity in `src/misc.cpp` with `constexpr std::string_view base = "Wordfish-5.0-120626"` and adjusted `engine_info(bool to_uci)` so UCI prints the architecture-free base while other outputs continue to show the full `base-<arch>` form via `engine_version_info()`.
- Updated user-facing documentation strings in `README.md` to reference the new release identity and examples for architecture-specific executables.
- Preserved author attribution, NNUE defaults (`nn-71d6d32cb962.nnue`), and all architecture detection/mapping logic; no sources outside the allowed identity surfaces were modified.
- Files changed: `src/Makefile`, `src/misc.cpp`, `README.md`.

### Testing

- Preflight repository checks passed (clean working tree). 
- `make -C src net` downloaded and validated `nn-71d6d32cb962.nnue` successfully and `sha256` started with expected `71d6d32cb962`.
- Built with the required validation target using `ARCH=x86-64-sse41-popcnt` via `make -C src -j2 build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld" NNUE_EMBEDDING_OFF=yes` and the build completed without matching `warning:/error:/undefined reference:/No rule to make target:/fatal:` patterns.
- Produced executable `src/Wordfish-5.0-120626-sse41popcnt` as expected.
- UCI identity verification: `printf 'uci\nquit\n' | src/Wordfish-5.0-120626-sse41popcnt` reported `id name Wordfish-5.0-120626`, `uciok`, and `EvalFile` default `nn-71d6d32cb962.nnue`.
- Binary-string checks (`strings`) exposed both the base `Wordfish-5.0-120626` and the architecture suffix `sse41popcnt`.
- Runtime smoke (UCI/isready/position/go) returned `uciok`, `readyok`, and produced `bestmove` as expected and referenced `nn-71d6d32cb962.nnue` in logs.
- `bench` run completed and reported `Nodes searched` / nodes-per-second output.
- Cleanup removed generated binaries, NNUE file, logs, and other artifacts before staging; only the three allowed source/docs files were staged and committed.

All automated gates passed and the change is scoped to identity/build-name surfaces only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c600520048327b660eb730e78aae8)