### PR TITLE
WORDFISH-P7H: close Stockfish-authority attacks compile blocker for AVX2/BMI2/AVX512

### DIFF
--- a/src/attacks.h
+++ b/src/attacks.h
@@ -27,6 +27,16 @@
 #include "types.h"
 #include "bitboard.h"
 
+#ifndef RESTRICT
+    #ifdef __GNUC__
+        #define RESTRICT __restrict__
+    #elif defined(_MSC_VER)
+        #define RESTRICT __restrict
+    #else
+        #define RESTRICT
+    #endif
+#endif
+
 #ifdef __aarch64__
     #include <arm_acle.h>
     #define USE_HYPERBOLA_QUINT

--- a/src/types.h
+++ b/src/types.h
@@ -87,6 +87,7 @@
     #if defined(USE_PEXT)
         #include <immintrin.h>  // Header for _pext_u64() intrinsic
         #define pext(b, m) _pext_u64(b, m)
+        #define pdep(b, m) _pdep_u64(b, m)
     #else
         #define pext(b, m) 0
     #endif


### PR DESCRIPTION
### Motivation
- Fix clang/lld compile failures when building the AVX2/BMI2/AVX512 Linux targets caused by a missing `RESTRICT` portability macro and a missing `pdep` intrinsic mapping that the official Stockfish sources define.

### Description
- Add a guarded `RESTRICT` fallback macro in `src/attacks.h` (local consumer) so `DualMagic::rankAttacksLookup` parses correctly and matches official Stockfish behavior.
- Add the missing `pdep(b, m) -> _pdep_u64(b, m)` mapping in `src/types.h` alongside the existing `pext` mapping to match the official Stockfish intrinsics usage.
- Changes are minimal, limited to `src/attacks.h` and `src/types.h`, and preserve existing AVX/PEXT routing, NNUE embedding and all protected surfaces.

### Testing
- Built and audited the mandatory targets with clang/lld: `make clean && make net && make -j$(nproc) build ARCH=x86-64-avx2 COMP=clang EXTRALDFLAGS="-fuse-ld=lld"`, `make ... ARCH=x86-64-bmi2 ...`, and `make ... ARCH=x86-64-avx512 ...`, all completed with zero warnings/errors/linker-blockers.
- Verified baseline profile-build and runtime smoke using `make -j$(nproc) profile-build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld"` (using a temporary clang driver wrapper to ensure `lld` during profile linking) and ran UCI checks and a depth-1 NNUE smoke that returned `uciok`, `readyok`, `EvalFile` present, `EvalFileSmall` absent, and `bestmove`.
- All automated log audits returned zero matches for the forbidden error/warning/linker patterns and no `NNUE_EMBEDDING_OFF` usage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ca8f7bef8832799f5e5f821eac952)