### PR TITLE
WORDFISH-P7I: close Stockfish Jun9-Jun10 topology coverage gaps

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -139,7 +139,7 @@ ifeq ($(ARCH), $(filter $(ARCH), \
                  x86-64-bmi2 x86-64-avx2 x86-64-sse41-popcnt x86-64-modern x86-64-ssse3 x86-64-sse3-popcnt \
                  x86-64 x86-32-sse41-popcnt x86-32-sse2 x86-32 ppc-64 ppc-64-altivec ppc-64-vsx ppc-32 e2k \
                  armv7 armv7-neon armv8 armv8-dotprod apple-silicon general-64 general-32 riscv64 \
-                 loongarch64 loongarch64-lsx loongarch64-lasx))
+                 loongarch64 loongarch64-lsx loongarch64-lasx wasm32 wasm32-relaxed-simd))
    SUPPORTED_ARCH=true
 else
    SUPPORTED_ARCH=false
@@ -196,6 +196,8 @@ dotprod = no
 arm_version = 0
 lsx = no
 lasx = no
+relaxedsimd = no
+syzygy = yes
 STRIP = strip
 
 ifneq ($(shell which clang-format-20 2> /dev/null),)
@@ -404,6 +406,27 @@ ifeq ($(ARCH),apple-silicon)
 	arm_version = 8
 endif
 
+# WASM is largely compiled using emcc's x86 compatibility layer, with occasional
+# WASM-specific intrinsics.
+ifeq ($(ARCH),wasm32)
+	arch = wasm32
+	sse = yes
+	sse2 = yes
+	ssse3 = yes
+	sse41 = yes
+	syzygy = no
+endif
+
+ifeq ($(ARCH),wasm32-relaxed-simd)
+	arch = wasm32
+	sse = yes
+	sse2 = yes
+	ssse3 = yes
+	sse41 = yes
+	relaxedsimd = yes
+	syzygy = no
+endif
+
 ifeq ($(ARCH),ppc-32)
 	arch = ppc
 	bits = 32
@@ -495,7 +518,7 @@ ifeq ($(COMP),gcc)
 		endif
 	else ifeq ($(arch),loongarch64)
 		CXXFLAGS += -latomic
-	else
+	else ifneq ($(arch),wasm32)
 		CXXFLAGS += -m$(bits)
 		LDFLAGS += -m$(bits)
 	endif
@@ -670,6 +693,7 @@ ifneq ($(OS),Android)
 # Haiku has pthreads in its libroot, so only link it in on other platforms
 ifneq ($(KERNEL),Haiku)
 ifneq ($(COMP),ndk)
+ifneq ($(arch),wasm32)
 LDFLAGS += -lpthread
 
 add_lrt = yes
@@ -686,6 +710,7 @@ LDFLAGS += -lrt
 endif
 
 LDFLAGS += -lz
+endif
 endif
 endif
 endif
@@ -877,6 +902,19 @@ ifeq ($(pext),yes)
 	ifeq ($(comp),$(filter $(comp),gcc clang mingw icx))
 		CXXFLAGS += -mbmi2
 	endif
+endif
+
+ifeq ($(arch),wasm32)
+	CXXFLAGS += -pthread -msimd128 -DUSE_POPCNT -DNNUE_EMBEDDING_OFF
+	LDFLAGS += -pthread -sINITIAL_MEMORY=64MB -sALLOW_MEMORY_GROWTH -sSTACK_SIZE=3MB
+	ifeq ($(relaxedsimd),yes)
+		CXXFLAGS += -mrelaxed-simd
+	endif
+endif
+
+### Syzygy tablebases
+ifeq ($(syzygy),no)
+	CXXFLAGS += -DNO_TABLEBASES
 endif
 
 ### NNUE embedding options (Revolution-compatible)
@@ -1171,6 +1209,7 @@ config-sanity: $(NNUE_TARGET)
 	echo "arm_version: '$(arm_version)'" && \
 	echo "lsx: '$(lsx)'" && \
 	echo "lasx: '$(lasx)'" && \
+	echo "syzygy: '$(syzygy)'" && \
 	echo "target_windows: '$(target_windows)'" && \
 	echo "" && \
 	echo "Flags:" && \
@@ -1186,7 +1225,8 @@ config-sanity: $(NNUE_TARGET)
 	(test "$(arch)" = "any" || test "$(arch)" = "x86_64" || test "$(arch)" = "i386" || \
 	 test "$(arch)" = "ppc64" || test "$(arch)" = "ppc" || test "$(arch)" = "e2k" || \
 	 test "$(arch)" = "armv7" || test "$(arch)" = "armv8" || test "$(arch)" = "arm64" || \
-	 test "$(arch)" = "riscv64" || test "$(arch)" = "loongarch64") && \
+	 test "$(arch)" = "riscv64" || test "$(arch)" = "loongarch64" || \
+	 test "$(arch)" = "wasm32") && \
 	(test "$(bits)" = "32" || test "$(bits)" = "64") && \
 	(test "$(prefetch)" = "yes" || test "$(prefetch)" = "no") && \
 	(test "$(popcnt)" = "yes" || test "$(popcnt)" = "no") && \

--- a/src/history.h
+++ b/src/history.h
@@ -62,13 +62,13 @@ inline uint16_t non_pawn_index(const Position& pos) {
 // the entry. The first template parameter T is the base type of the array,
 // and the second template parameter D limits the range of updates in [-D, D]
 // when we update values with the << operator
-template<typename T, int D>
+template<typename T, int D, bool Shared = false>
 class StatsEntry {
 
     static_assert(std::is_arithmetic_v<T>, "Not an arithmetic type");
     static_assert(D <= std::numeric_limits<T>::max(), "D overflows T");
 
-    T entry;
+    std::conditional_t<Shared, RelaxedAtomic<T>, T> entry;
 
    public:
     StatsEntry& operator=(const T& v) {

--- a/src/misc.h
+++ b/src/misc.h
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cassert>
 #include <chrono>
 #include <cstdint>
@@ -316,6 +317,59 @@ class MultiArray {
 };
 
 
+// Wrapper around std::atomic<T> which uses relaxed accesses or plain
+// accesses, depending on the config. Intended use is e.g. wasm where
+// the overhead of atomic instructions can be significant, and we only
+// require non-tearing for the updates, while ensuring we use relaxed
+// accesses otherwise.
+template<typename T>
+class RelaxedAtomic {
+    static constexpr bool UseAtomic =
+#ifdef USE_SLOPPY_ATOMICS
+      !std::atomic<T>::is_always_lock_free || sizeof(T) > sizeof(size_t);
+#else
+      true;
+#endif
+
+   public:
+    RelaxedAtomic() = default;
+    RelaxedAtomic(T val) : inner(val) {}
+    RelaxedAtomic(const RelaxedAtomic& a) : inner(static_cast<T>(a)) {}
+
+    T operator=(T val) {
+        if constexpr (UseAtomic) inner.store(val, std::memory_order_relaxed);
+        else inner = val;
+        return val;
+    }
+    RelaxedAtomic& operator=(const RelaxedAtomic& a) {
+        store(static_cast<T>(a), std::memory_order_relaxed);
+        return *this;
+    }
+    operator T() const {
+        if constexpr (UseAtomic) return inner.load(std::memory_order_relaxed);
+        else return inner;
+    }
+    RelaxedAtomic& operator+=(int val) { store(load(std::memory_order_relaxed) + val, std::memory_order_relaxed); return *this; }
+    RelaxedAtomic& operator-=(int val) { store(load(std::memory_order_relaxed) - val, std::memory_order_relaxed); return *this; }
+    RelaxedAtomic& operator++() { store(load(std::memory_order_relaxed) + 1, std::memory_order_relaxed); return *this; }
+    RelaxedAtomic& operator--() { store(load(std::memory_order_relaxed) - 1, std::memory_order_relaxed); return *this; }
+    T operator++(int) { T val = load(std::memory_order_relaxed); store(val + 1, std::memory_order_relaxed); return val; }
+    T operator--(int) { T val = load(std::memory_order_relaxed); store(val - 1, std::memory_order_relaxed); return val; }
+    T load(std::memory_order order) const {
+        assert(order == std::memory_order_relaxed);
+        if constexpr (UseAtomic) return inner.load(order);
+        else return inner;
+    }
+    void store(T val, std::memory_order order) {
+        assert(order == std::memory_order_relaxed);
+        if constexpr (UseAtomic) inner.store(val, order);
+        else inner = val;
+    }
+
+   private:
+    std::conditional_t<UseAtomic, std::atomic<T>, T> inner;
+};
+
 // xorshift64star Pseudo-Random Number Generator
 // This class is based on original code written and dedicated
 // to the public domain by Sebastiano Vigna (2014).
@@ -361,7 +415,7 @@ class PRNG {
 };
 
 inline uint64_t mul_hi64(uint64_t a, uint64_t b) {
-#if defined(__GNUC__) && defined(IS_64BIT)
+#if defined(__GNUC__) && defined(IS_64BIT) && !defined(__wasm__)
     __extension__ using uint128 = unsigned __int128;
     return (uint128(a) * uint128(b)) >> 64;
 #else

--- a/src/nnue/simd.h
+++ b/src/nnue/simd.h
@@ -493,10 +493,13 @@ fused(const typename VecWrapper::type& in, const T& operand, const Ts&... operan
 }
 
 [[maybe_unused]] static void m128_add_dpbusd_epi32(__m128i& acc, __m128i a, __m128i b) {
-
+#if defined(__wasm_relaxed_simd__)
+    acc = wasm_i32x4_relaxed_dot_i8x16_i7x16_add(b, a, acc);
+#else
     __m128i product0 = _mm_maddubs_epi16(a, b);
     product0         = _mm_madd_epi16(product0, _mm_set1_epi16(1));
     acc              = _mm_add_epi32(acc, product0);
+#endif
 }
 
 #endif

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -946,8 +946,6 @@ void Position::do_move(Move                      m,
 
     // Update the key with the final value
     st->key = k;
-    if (tt)
-        prefetch(tt->first_entry(key()));
 
     // Calculate the repetition info. It is the ply distance from the previous
     // occurrence of the same position, negative in the 3-fold case, or zero

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -463,8 +463,8 @@ void Search::Worker::iterative_deepening() {
 
     Move pv[MAX_PLY + 1];
 
+    Move  lastBestMove      = Move::none();
     Depth lastBestMoveDepth = 0;
-    Value lastBestScore     = -VALUE_INFINITE;
     auto  lastBestPV        = std::vector{Move::none()};
 
     Value  alpha, beta;
@@ -525,7 +525,10 @@ void Search::Worker::iterative_deepening() {
         // Save the last iteration's scores before the first PV line is searched and
         // all the move scores except the (new) PV are set to -VALUE_INFINITE.
         for (RootMove& rm : rootMoves)
+        {
             rm.previousScore = rm.score;
+            rm.previousPV    = rm.pv;
+        }
 
         size_t pvFirst = 0;
         pvLast         = 0;
@@ -536,6 +539,8 @@ void Search::Worker::iterative_deepening() {
         // MultiPV loop. We perform a full root search for each PV line
         for (pvIdx = 0; pvIdx < multiPV; ++pvIdx)
         {
+            lastIterationIdxPV = rootMoves[pvIdx].previousPV;
+
             if (pvIdx == pvLast)
             {
                 pvFirst = pvLast;
@@ -619,6 +624,38 @@ void Search::Worker::iterative_deepening() {
             // Sort the PV lines searched so far and update the GUI
             std::stable_sort(rootMoves.begin() + pvFirst, rootMoves.begin() + pvIdx + 1);
 
+            // In multiPV analysis we do not let aborted searches spoil mated-in/
+            // TB loss scores from a completed search in an earlier PV line.
+            if (threads.stop && pvIdx
+                && ((is_loss(rootMoves[pvIdx - 1].score) && rootMoves[pvIdx] < rootMoves[pvIdx - 1])
+                    || rootMoves[pvIdx].score_is_exact_loss()))
+            {
+                if (rootMoves[pvIdx].previousScore != -VALUE_INFINITE
+                    && rootMoves[pvIdx].previousScore <= rootMoves[pvIdx - 1].score)
+                {
+                    rootMoves[pvIdx].score = rootMoves[pvIdx].uciScore =
+                      rootMoves[pvIdx].previousScore;
+                    rootMoves[pvIdx].previousScore = -VALUE_INFINITE;
+                    rootMoves[pvIdx].pv            = rootMoves[pvIdx].previousPV;
+                    rootMoves[pvIdx].unset_bound_flags();
+                }
+                else
+                {
+                    if (is_loss(rootMoves[pvIdx - 1].score))
+                    {
+                        rootMoves[pvIdx].score = rootMoves[pvIdx].uciScore =
+                          rootMoves[pvIdx - 1].score;
+                        rootMoves[pvIdx].previousScore = -VALUE_INFINITE;
+                        rootMoves[pvIdx].pv.resize(1);
+                        rootMoves[pvIdx].scoreUpperbound = true;
+                    }
+                    else
+                        rootMoves[pvIdx].scoreUpperbound = false;
+
+                    rootMoves[pvIdx].scoreLowerbound = !rootMoves[pvIdx].scoreUpperbound;
+                }
+            }
+
             if (mainThread
                 && (threads.stop || pvIdx + 1 == multiPV || nodes > 10000000)
                 // A thread that aborted search can have mated-in/TB-loss PV and
@@ -638,19 +675,22 @@ void Search::Worker::iterative_deepening() {
 
         // We make sure not to pick an unproven mated-in score,
         // in case this thread prematurely stopped search (aborted-search).
-        if (threads.abortedSearch && rootMoves[0].score != -VALUE_INFINITE
-            && is_loss(rootMoves[0].score))
+        if (threads.abortedSearch && rootMoves[0].score_is_exact_loss())
         {
             // Bring the last best move to the front for best thread selection.
-            Utility::move_to_front(rootMoves, [&lastBestPV = std::as_const(lastBestPV)](
-                                                const auto& rm) { return rm == lastBestPV[0]; });
-            rootMoves[0].pv    = lastBestPV;
-            rootMoves[0].score = rootMoves[0].uciScore = lastBestScore;
+            if (lastBestMove != Move::none())
+            {
+                Utility::move_to_front(
+                  rootMoves, [lastBestMove](const auto& rm) { return rm == lastBestMove; });
+                rootMoves[0].score = rootMoves[0].uciScore = rootMoves[0].previousScore;
+                rootMoves[0].pv                            = rootMoves[0].previousPV;
+                rootMoves[0].unset_bound_flags();
+            }
         }
         else if (rootMoves[0].pv[0] != lastBestPV[0])
         {
+            lastBestMove      = rootMoves[0].pv[0];
             lastBestPV        = rootMoves[0].pv;
-            lastBestScore     = rootMoves[0].score;
             lastBestMoveDepth = rootDepth;
         }
 
@@ -757,7 +797,7 @@ void Search::Worker::do_move(Position& pos, const Move move, StateInfo& st, Stac
 void Search::Worker::do_move(
   Position& pos, const Move move, StateInfo& st, const bool givesCheck, Stack* const ss) {
     bool capture = pos.capture_stage(move);
-    nodes.fetch_add(1, std::memory_order_relaxed);
+    ++nodes;
 
     auto [dirtyPiece, dirtyThreats] = accumulatorStack.push();
     pos.do_move(move, st, givesCheck, dirtyPiece, dirtyThreats, &tt);
@@ -980,7 +1020,7 @@ Value Search::Worker::search(
 
             if (err != TB::ProbeState::FAIL)
             {
-                tbHits.fetch_add(1, std::memory_order_relaxed);
+                ++tbHits;
 
                 int drawScore = tbConfig.useRule50 ? 1 : 0;
 
@@ -2403,15 +2443,17 @@ void SearchManager::pv(Search::Worker&           worker,
         bool tb = worker.tbConfig.rootInTB && std::abs(v) <= VALUE_TB;
         v       = tb ? rootMoves[i].tbScore : v;
 
+        bool usePreviousScore = !updated;
         bool isExact = i != pvIdx || tb || !updated;  // tablebase- and previous-scores are exact
 
-        // Potentially correct and extend the PV, and in exceptional cases v
-        if (is_decisive(v) && std::abs(v) < VALUE_MATE_IN_MAX_PLY
+        // Potentially correct and extend the PV, and in exceptional cases v.
+        // Previous PVs have already been extended. Bound flags indicate an unreliable PV.
+        if (is_decisive(v) && std::abs(v) < VALUE_MATE_IN_MAX_PLY && !usePreviousScore
             && ((!rootMoves[i].scoreLowerbound && !rootMoves[i].scoreUpperbound) || isExact))
             syzygy_extend_pv(worker.options, worker.limits, pos, rootMoves[i], v);
 
         std::string pv;
-        for (Move m : rootMoves[i].pv)
+        for (Move m : usePreviousScore ? rootMoves[i].previousPV : rootMoves[i].pv)
             pv += UCIEngine::move(m, pos.is_chess960()) + " ";
 
         // Remove last whitespace

--- a/src/search.h
+++ b/src/search.h
@@ -86,6 +86,11 @@ struct RootMove {
     explicit RootMove(Move m) :
         pv(1, m) {}
     bool extract_ponder_from_tt(const TranspositionTable& tt, Position& pos);
+    bool score_is_bound() const { return scoreLowerbound || scoreUpperbound; }
+    bool score_is_exact_loss() const {
+        return score != -VALUE_INFINITE && is_loss(score) && !score_is_bound();
+    }
+    void unset_bound_flags() { scoreLowerbound = scoreUpperbound = false; }
     bool operator==(const Move& m) const { return pv[0] == m; }
     // Sort in descending order
     bool operator<(const RootMove& m) const {
@@ -103,7 +108,7 @@ struct RootMove {
     int               selDepth         = 0;
     int               tbRank           = 0;
     Value             tbScore;
-    std::vector<Move> pv;
+    std::vector<Move> pv, previousPV;
 };
 
 using RootMoves = std::vector<RootMove>;
@@ -332,7 +337,7 @@ class Worker {
     LimitsType limits;
 
     size_t                pvIdx, pvLast;
-    std::atomic<uint64_t> nodes, tbHits, bestMoveChanges;
+    RelaxedAtomic<uint64_t> nodes, tbHits, bestMoveChanges;
     int                   selDepth, nmpMinPly;
 
     Value optimism[COLOR_NB];
@@ -344,6 +349,8 @@ class Worker {
     RootMoves rootMoves;
     Depth     rootDepth, completedDepth;
     Value     rootDelta;
+
+    std::vector<Move> lastIterationIdxPV;
 
     size_t                    threadIdx;
     NumaReplicatedAccessToken numaAccessToken;

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -56,6 +56,39 @@
     #include <windows.h>
 #endif
 
+#ifdef NO_TABLEBASES
+
+namespace Stockfish::Tablebases {
+
+int MaxCardinality;
+
+void init(const std::string&) {}
+
+WDLScore probe_wdl(Position&, ProbeState* result) {
+    *result = FAIL;
+    return WDLDraw;
+}
+
+int probe_dtz(Position&, ProbeState* result) {
+    *result = FAIL;
+    return 0;
+}
+
+bool root_probe(Position&, Search::RootMoves&, bool, bool, const std::function<bool()>&) {
+    return false;
+}
+
+bool root_probe_wdl(Position&, Search::RootMoves&, bool) { return false; }
+
+Config rank_root_moves(
+  const OptionsMap&, Position&, Search::RootMoves&, bool, const std::function<bool()>&) {
+    return Config{};
+}
+
+}  // namespace Stockfish::Tablebases
+
+#else
+
 using namespace Stockfish::Tablebases;
 
 int Stockfish::Tablebases::MaxCardinality;
@@ -1768,3 +1801,5 @@ Config Tablebases::rank_root_moves(const OptionsMap&            options,
     return config;
 }
 }  // namespace Stockfish
+
+#endif  // NO_TABLEBASES

--- a/src/thread.h
+++ b/src/thread.h
@@ -165,7 +165,7 @@ class ThreadPool {
     std::vector<std::unique_ptr<Thread>> threads;
     std::vector<NumaIndex>               boundThreadToNumaNode;
 
-    uint64_t accumulate(std::atomic<uint64_t> Search::Worker::* member) const {
+    uint64_t accumulate(RelaxedAtomic<uint64_t> Search::Worker::* member) const {
 
         uint64_t sum = 0;
         for (auto&& th : threads)

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -65,12 +65,12 @@ struct TTEntry {
     friend class TranspositionTable;
     friend struct TTWriter;
 
-    uint16_t key16;
-    uint8_t  depth8;
-    uint8_t  genBound8;
-    Move     move16;
-    int16_t  value16;
-    int16_t  eval16;
+    RelaxedAtomic<uint16_t> key16;
+    RelaxedAtomic<uint8_t>  depth8;
+    RelaxedAtomic<uint8_t>  genBound8;
+    RelaxedAtomic<Move>     move16;
+    RelaxedAtomic<int16_t>  value16;
+    RelaxedAtomic<int16_t>  eval16;
 };
 
 // `genBound8` is where most of the details are. We use the following constants to manipulate 5 leading generation bits


### PR DESCRIPTION
### Motivation

- Close four confirmed Stockfish Jun 9–10 topology coverage gaps so later P8A/P8B work can proceed in proper topological order. 
- Preserve Wordfish protected surfaces, identity, and single-net NNUE topology while porting only source/build-topology pieces required by Stockfish official commits. 

### Description

- Port `8e711c29` by adding `wasm32` / `wasm32-relaxed-simd` topology and isolated wasm build flags and intrinsics; changes applied to `src/Makefile`, `src/nnue/simd.h`, and `src/syzygy/tbprobe.cpp` while skipping CI/workflow/test-only pieces. 
- Port `1eff8b03` multiPV mate-PV topology by adding `previousPV`, `score_is_exact_loss()`/bound handling and restoring previous PVs when needed; changes applied to `src/search.h` and `src/search.cpp`. 
- Port `0111d11e` relaxed-atomics topology by introducing `RelaxedAtomic` in `src/misc.h`, using `RelaxedAtomic` in `src/history.h`, `src/search.h`, `src/thread.h`, and replacing TT/worker atomic fields in `src/tt.cpp` and `src/search.cpp`; tests-only harness changes were skipped. 
- Port `278a755f` do_move reorder by removing the late TT prefetch, preserving earlier `adjust_key50(k)` prefetch and material-key fixes; change applied to `src/position.cpp`. 
- Minor NNUE SIMD adaptation for wasm relaxed SIMD was added in `src/nnue/simd.h`. 
- Each official source-relevant commit produced exactly one Wordfish commit with P7I-style commit messages that include the official SHA, official title, applied files, skipped non-applicable pieces, and protected-surface status. 

### Testing

- Inspected and fetched official Stockfish history with `git log --reverse --topo-order` covering `8e711c29^..86f1df71` and examined `git show` for each target SHA. 
- Verified working tree, `git status --short --branch` and `git rev-parse HEAD` after each change and ran `git diff --check` with no index errors. 
- Protected-surface audits run via `git diff HEAD~1 --name-only | grep -E '^(src/experience.cpp|src/experience.h|src/experience_compat.h|src/experience_zobrist.h|src/Wordfish_zobrist.h|src/polybook.cpp|src/polybook.h|src/book/|src/mcts.cpp|src/mcts.h|src/mcts/|src/sparsehash/|src/lichess_tablebase.cpp)'` produced no output. 
- `rg -n 'EvalFileSmall' src` found no occurrences, and `rg -n 'NNUE_EMBEDDING_OFF'` showed only opt-in/default-no and isolated wasm use. 
- Built and validated the product: `make clean`, `make net`, and successful builds for `ARCH=x86-64-sse41-popcnt`, `x86-64-avx2`, `x86-64-bmi2`, and `x86-64-avx512` with `COMP=clang EXTRALDFLAGS='-fuse-ld=lld'` produced no errors or link failures. 
- UCI smoke with the produced SSE binary returned `id name Wordfish-5.0-120626`, showed the `EvalFile` option present and no `EvalFileSmall`, printed `uciok` and `readyok`, and a depth-1 smoke returned `readyok` and a `bestmove`. 
- `make_pr` was called successfully with the required PR title/body; the PR creation step completed (no remote URL returned by the tool in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e371724748327b1acbbe672c10fca)