### PR TITLE
NUMA-aware shared move histories: unify and relocate pawn/correction histories per NUMA node

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -364,7 +364,8 @@ void Engine::set_numa_config_from_option(const std::string& o) {
 
 void Engine::resize_threads() {
     threads.wait_for_search_finished();
-    threads.set(numaContext.get_numa_config(), {options, threads, tt, networks}, updateContext);
+    threads.set(numaContext.get_numa_config(), {options, threads, tt, sharedHists, networks},
+                updateContext);
 
     // Reallocate the hash with the new threadpool size
     set_tt_size(options["Hash"]);

--- a/src/engine.h
+++ b/src/engine.h
@@ -22,6 +22,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <map>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -122,6 +123,7 @@ class Engine {
     OptionsMap                                         options;
     ThreadPool                                         threads;
     TranspositionTable                                 tt;
+    std::map<NumaIndex, SharedHistories>               sharedHists;
     LazyNumaReplicatedSystemWide<Eval::NNUE::Network> networks;
 
     Search::SearchManager::UpdateContext  updateContext;

--- a/src/history.h
+++ b/src/history.h
@@ -25,9 +25,11 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <limits>
 #include <type_traits>  // IWYU pragma: keep
 
+#include "memory.h"
 #include "misc.h"
 #include "position.h"
 
@@ -35,6 +37,7 @@ namespace Stockfish {
 
 constexpr int PAWN_HISTORY_SIZE        = 8192;  // has to be a power of 2
 constexpr int UINT_16_HISTORY_SIZE     = std::numeric_limits<uint16_t>::max() + 1;
+constexpr int CORRHIST_BASE_SIZE       = UINT_16_HISTORY_SIZE;
 constexpr int CORRECTION_HISTORY_LIMIT = 1024;
 constexpr int LOW_PLY_HISTORY_SIZE     = 5;
 
@@ -75,7 +78,7 @@ class StatsEntry {
         entry = v;
         return *this;
     }
-    operator const T&() const { return entry; }
+    operator T() const { return entry; }
 
     void operator<<(int bonus) {
         // Make sure that bonus is in range [-D, D]
@@ -86,6 +89,9 @@ class StatsEntry {
     }
 };
 
+template<typename T, int D, std::size_t... Sizes>
+using AtomicStats = MultiArray<StatsEntry<T, D, true>, Sizes...>;
+
 enum StatsType {
     NoCaptures,
     Captures
@@ -93,6 +99,40 @@ enum StatsType {
 
 template<typename T, int D, std::size_t... Sizes>
 using Stats = MultiArray<StatsEntry<T, D>, Sizes...>;
+
+// DynStats is a dynamically sized array of Stats, used for thread-shared histories
+// which should scale with the total number of threads. The SizeMultiplier gives
+// the per-thread allocation count of T.
+template<typename T, int SizeMultiplier>
+struct DynStats {
+    explicit DynStats(size_t s) {
+        size = s * SizeMultiplier;
+        data = make_unique_large_page<T[]>(size);
+    }
+
+    void clear_range(size_t start, size_t end) {
+        assert(start < size);
+        assert(end <= size);
+        T* fill_start = &(*this)[start];
+        std::memset(reinterpret_cast<char*>(fill_start), 0, sizeof(T) * (end - start));
+    }
+
+    size_t get_size() const { return size; }
+
+    T& operator[](size_t index) {
+        assert(index < size);
+        return data.get()[index];
+    }
+
+    const T& operator[](size_t index) const {
+        assert(index < size);
+        return data.get()[index];
+    }
+
+   private:
+    size_t            size;
+    LargePagePtr<T[]> data;
+};
 
 // ButterflyHistory records how often quiet moves have been successful or unsuccessful
 // during the current search, and is used for reduction and move ordering decisions.
@@ -116,7 +156,8 @@ using PieceToHistory = Stats<std::int16_t, 30000, PIECE_NB, SQUARE_NB>;
 using ContinuationHistory = MultiArray<PieceToHistory, PIECE_NB, SQUARE_NB>;
 
 // PawnHistory is addressed by the pawn structure and a move's [piece][to]
-using PawnHistory = Stats<std::int16_t, 8192, PAWN_HISTORY_SIZE, PIECE_NB, SQUARE_NB>;
+using PawnHistory =
+  DynStats<AtomicStats<std::int16_t, 8192, PIECE_NB, SQUARE_NB>, PAWN_HISTORY_SIZE>;
 
 // Correction histories record differences between the static evaluation of
 // positions and their search score. It is used to improve the static evaluation
@@ -159,6 +200,75 @@ template<CorrHistType T>
 using CorrectionHistory = typename Detail::CorrHistTypedef<T>::type;
 
 using TTMoveHistory = StatsEntry<std::int16_t, 8192>;
+
+struct CorrectionBundle {
+    StatsEntry<std::int16_t, CORRECTION_HISTORY_LIMIT, true> pawn;
+    StatsEntry<std::int16_t, CORRECTION_HISTORY_LIMIT, true> minor;
+    StatsEntry<std::int16_t, CORRECTION_HISTORY_LIMIT, true> nonPawnWhite;
+    StatsEntry<std::int16_t, CORRECTION_HISTORY_LIMIT, true> nonPawnBlack;
+
+    void operator=(std::int16_t val) {
+        pawn         = val;
+        minor        = val;
+        nonPawnWhite = val;
+        nonPawnBlack = val;
+    }
+};
+
+using UnifiedCorrectionHistory =
+  DynStats<MultiArray<CorrectionBundle, COLOR_NB>, CORRHIST_BASE_SIZE>;
+
+// Set of histories shared between groups of threads. To avoid excessive
+// cross-node data transfer, histories are shared only between threads
+// on a given NUMA node. The passed size must be a power of two to make
+// the indexing more efficient.
+struct SharedHistories {
+    SharedHistories(size_t threadCount) :
+        correctionHistory(threadCount),
+        pawnHistory(threadCount) {
+        assert((threadCount & (threadCount - 1)) == 0 && threadCount != 0);
+        sizeMinus1         = correctionHistory.get_size() - 1;
+        pawnHistSizeMinus1 = pawnHistory.get_size() - 1;
+    }
+
+    size_t get_size() const { return sizeMinus1 + 1; }
+
+    auto& pawn_correction_entry(const Position& pos) {
+        return correctionHistory[pos.pawn_key() & sizeMinus1];
+    }
+    const auto& pawn_correction_entry(const Position& pos) const {
+        return correctionHistory[pos.pawn_key() & sizeMinus1];
+    }
+
+    auto& minor_piece_correction_entry(const Position& pos) {
+        return correctionHistory[pos.minor_piece_key() & sizeMinus1];
+    }
+    const auto& minor_piece_correction_entry(const Position& pos) const {
+        return correctionHistory[pos.minor_piece_key() & sizeMinus1];
+    }
+
+    template<Color c>
+    auto& nonpawn_correction_entry(const Position& pos) {
+        return correctionHistory[pos.non_pawn_key(c) & sizeMinus1];
+    }
+    template<Color c>
+    const auto& nonpawn_correction_entry(const Position& pos) const {
+        return correctionHistory[pos.non_pawn_key(c) & sizeMinus1];
+    }
+
+    auto& pawn_entry(const Position& pos) {
+        return pawnHistory[pos.pawn_key() & pawnHistSizeMinus1];
+    }
+    const auto& pawn_entry(const Position& pos) const {
+        return pawnHistory[pos.pawn_key() & pawnHistSizeMinus1];
+    }
+
+    UnifiedCorrectionHistory correctionHistory;
+    PawnHistory              pawnHistory;
+
+   private:
+    size_t sizeMinus1, pawnHistSizeMinus1;
+};
 
 }  // namespace Stockfish
 

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -87,14 +87,14 @@ MovePicker::MovePicker(const Position&              p,
                        const LowPlyHistory*         lph,
                        const CapturePieceToHistory* cph,
                        const PieceToHistory**       ch,
-                       const PawnHistory*           ph,
+                       const SharedHistories*       sh,
                        int                          pl) :
     pos(p),
     mainHistory(mh),
     lowPlyHistory(lph),
     captureHistory(cph),
     continuationHistory(ch),
-    pawnHistory(ph),
+    sharedHistory(sh),
     ttMove(ttm),
     depth(d),
     ply(pl) {
@@ -159,7 +159,7 @@ ExtMove* MovePicker::score(MoveList<Type>& ml) {
         {
             // histories
             m.value = 2 * (*mainHistory)[us][m.raw()];
-            m.value += 2 * (*pawnHistory)[pawn_history_index(pos)][pc][to];
+            m.value += 2 * sharedHistory->pawn_entry(pos)[pc][to];
             m.value += (*continuationHistory[0])[pc][to];
             m.value += (*continuationHistory[1])[pc][to];
             m.value += (*continuationHistory[2])[pc][to];

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -45,7 +45,7 @@ class MovePicker {
                const LowPlyHistory*,
                const CapturePieceToHistory*,
                const PieceToHistory**,
-               const PawnHistory*,
+               const SharedHistories*,
                int);
     MovePicker(const Position&, Move, int, const CapturePieceToHistory*);
     Move next_move();
@@ -64,7 +64,7 @@ class MovePicker {
     const LowPlyHistory*         lowPlyHistory;
     const CapturePieceToHistory* captureHistory;
     const PieceToHistory**       continuationHistory;
-    const PawnHistory*           pawnHistory;
+    const SharedHistories*       sharedHistory;
     Move                         ttMove;
     ExtMove *                    cur, *endCur, *endBadCaptures, *endCaptures, *endGenerated;
     int                          stage;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -80,12 +80,13 @@ using SearchedList                  = ValueList<Move, SEARCHEDLIST_CAPACITY>;
 // optimized for require verifications at longer time controls
 
 int correction_value(const Worker& w, const Position& pos, const Stack* const ss) {
-    const Color us    = pos.side_to_move();
-    const auto  m     = (ss - 1)->currentMove;
-    const auto  pcv   = w.pawnCorrectionHistory[pawn_correction_history_index(pos)][us];
-    const auto  micv  = w.minorPieceCorrectionHistory[minor_piece_index(pos)][us];
-    const auto  wnpcv = w.nonPawnCorrectionHistory[non_pawn_index<WHITE>(pos)][WHITE][us];
-    const auto  bnpcv = w.nonPawnCorrectionHistory[non_pawn_index<BLACK>(pos)][BLACK][us];
+    const Color us     = pos.side_to_move();
+    const auto  m      = (ss - 1)->currentMove;
+    const auto& shared = w.sharedHistory;
+    const int   pcv    = shared.pawn_correction_entry(pos)[us].pawn;
+    const int   micv   = shared.minor_piece_correction_entry(pos)[us].minor;
+    const int   wnpcv  = shared.nonpawn_correction_entry<WHITE>(pos)[us].nonPawnWhite;
+    const int   bnpcv  = shared.nonpawn_correction_entry<BLACK>(pos)[us].nonPawnBlack;
     const auto  cntcv =
       m.is_ok() ? (*(ss - 2)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
                     + (*(ss - 4)->continuationCorrectionHistory)[pos.piece_on(m.to_sq())][m.to_sq()]
@@ -108,13 +109,12 @@ void update_correction_history(const Position& pos,
     const Color us = pos.side_to_move();
 
     constexpr int nonPawnWeight = 165;
+    auto&         shared        = workerThread.sharedHistory;
 
-    workerThread.pawnCorrectionHistory[pawn_correction_history_index(pos)][us] << bonus;
-    workerThread.minorPieceCorrectionHistory[minor_piece_index(pos)][us] << bonus * 145 / 128;
-    workerThread.nonPawnCorrectionHistory[non_pawn_index<WHITE>(pos)][WHITE][us]
-      << bonus * nonPawnWeight / 128;
-    workerThread.nonPawnCorrectionHistory[non_pawn_index<BLACK>(pos)][BLACK][us]
-      << bonus * nonPawnWeight / 128;
+    shared.pawn_correction_entry(pos)[us].pawn << bonus;
+    shared.minor_piece_correction_entry(pos)[us].minor << bonus * 145 / 128;
+    shared.nonpawn_correction_entry<WHITE>(pos)[us].nonPawnWhite << bonus * nonPawnWeight / 128;
+    shared.nonpawn_correction_entry<BLACK>(pos)[us].nonPawnBlack << bonus * nonPawnWeight / 128;
 
     if (m.is_ok())
     {
@@ -187,6 +187,7 @@ Search::Worker::Worker(SharedState&                    sharedState,
                        size_t                          threadId,
                        NumaReplicatedAccessToken       token) :
     // Unpack the SharedState struct into member variables
+    sharedHistory(sharedState.sharedHistories.at(token.get_numa_index())),
     threadIdx(threadId),
     numaAccessToken(token),
     manager(std::move(sm)),
@@ -831,10 +832,9 @@ void Search::Worker::undo_null_move(Position& pos) { pos.undo_null_move(); }
 void Search::Worker::clear() {
     mainHistory.fill(0);
     captureHistory.fill(-689);
-    pawnHistory.fill(-1238);
-    pawnCorrectionHistory.fill(5);
-    minorPieceCorrectionHistory.fill(0);
-    nonPawnCorrectionHistory.fill(0);
+
+    sharedHistory.correctionHistory.clear_range(0, sharedHistory.get_size());
+    sharedHistory.pawnHistory.clear_range(0, sharedHistory.pawnHistory.get_size());
 
     ttMoveHistory = 0;
 
@@ -1098,7 +1098,7 @@ Value Search::Worker::search(
         mainHistory[~us][((ss - 1)->currentMove).raw()] << evalDiff * 9;
         if (!ttHit && type_of(pos.piece_on(prevSq)) != PAWN
             && ((ss - 1)->currentMove).type_of() != PROMOTION)
-            pawnHistory[pawn_history_index(pos)][pos.piece_on(prevSq)][prevSq] << evalDiff * 14;
+            sharedHistory.pawn_entry(pos)[pos.piece_on(prevSq)][prevSq] << evalDiff * 14;
     }
 
     // Set up the improving flag, which is true if current static evaluation is
@@ -1244,7 +1244,7 @@ moves_loop:  // When in check, search starts here
 
 
     MovePicker mp(pos, ttData.move, depth, &mainHistory, &lowPlyHistory, &captureHistory, contHist,
-                  &pawnHistory, ss->ply);
+                  &sharedHistory, ss->ply);
 
     value = bestValue;
 
@@ -1333,7 +1333,7 @@ moves_loop:  // When in check, search starts here
             {
                 int history = (*contHist[0])[movedPiece][move.to_sq()]
                             + (*contHist[1])[movedPiece][move.to_sq()]
-                            + pawnHistory[pawn_history_index(pos)][movedPiece][move.to_sq()];
+                            + sharedHistory.pawn_entry(pos)[movedPiece][move.to_sq()];
 
                 // Continuation history based pruning
                 if (history < -4312 * depth)
@@ -1689,7 +1689,7 @@ moves_loop:  // When in check, search starts here
         mainHistory[~us][((ss - 1)->currentMove).raw()] << scaledBonus * 220 / 32768;
 
         if (type_of(pos.piece_on(prevSq)) != PAWN && ((ss - 1)->currentMove).type_of() != PROMOTION)
-            pawnHistory[pawn_history_index(pos)][pos.piece_on(prevSq)][prevSq]
+            sharedHistory.pawn_entry(pos)[pos.piece_on(prevSq)][prevSq]
               << scaledBonus * 1164 / 32768;
     }
 
@@ -1858,7 +1858,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
     // the moves. We presently use two stages of move generator in quiescence search:
     // captures, or evasions only when in check.
     MovePicker mp(pos, ttData.move, DEPTH_QS, &mainHistory, &lowPlyHistory, &captureHistory,
-                  contHist, &pawnHistory, ss->ply);
+                  contHist, &sharedHistory, ss->ply);
 
     // Step 5. Loop through all pseudo-legal moves until no moves remain or a beta
     // cutoff occurs.
@@ -2152,8 +2152,7 @@ void update_quiet_histories(
 
     update_continuation_histories(ss, pos.moved_piece(move), move.to_sq(), bonus * 955 / 1024);
 
-    int pIndex = pawn_history_index(pos);
-    workerThread.pawnHistory[pIndex][pos.moved_piece(move)][move.to_sq()]
+    workerThread.sharedHistory.pawn_entry(pos)[pos.moved_piece(move)][move.to_sq()]
       << bonus * (bonus > 0 ? 850 : 550) / 1024;
 }
 

--- a/src/search.h
+++ b/src/search.h
@@ -26,6 +26,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <map>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -141,10 +142,12 @@ struct SharedState {
     SharedState(const OptionsMap&                                         optionsMap,
                 ThreadPool&                                               threadPool,
                 TranspositionTable&                                       transpositionTable,
+                std::map<NumaIndex, SharedHistories>&                     sharedHistories,
                 const LazyNumaReplicatedSystemWide<Eval::NNUE::Network>& nets) :
         options(optionsMap),
         threads(threadPool),
         tt(transpositionTable),
+        sharedHistories(sharedHistories),
         networks(nets) {}
 
     const LazyNumaReplicatedSystemWide<Eval::NNUE::Network>& nnue_networks() const {
@@ -154,6 +157,7 @@ struct SharedState {
     const OptionsMap&                                         options;
     ThreadPool&                                               threads;
     TranspositionTable&                                       tt;
+    std::map<NumaIndex, SharedHistories>&                     sharedHistories;
     const LazyNumaReplicatedSystemWide<Eval::NNUE::Network>& networks;
 };
 
@@ -293,14 +297,13 @@ class Worker {
 
     CapturePieceToHistory captureHistory;
     ContinuationHistory   continuationHistory[2][2];
-    PawnHistory           pawnHistory;
-
     CorrectionHistory<Pawn>         pawnCorrectionHistory;
     CorrectionHistory<Minor>        minorPieceCorrectionHistory;
     CorrectionHistory<NonPawn>      nonPawnCorrectionHistory;
     CorrectionHistory<Continuation> continuationCorrectionHistory;
 
     TTMoveHistory ttMoveHistory;
+    SharedHistories& sharedHistory;
 
    private:
    void iterative_deepening();

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <cassert>
 #include <deque>
+#include <map>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -37,6 +38,17 @@
 #include "ucioption.h"
 
 namespace Stockfish {
+
+namespace {
+
+size_t next_power_of_two(size_t n) {
+    size_t result = 1;
+    while (result < n)
+        result <<= 1;
+    return result;
+}
+
+}
 
 // Constructor launches the thread and waits until it goes to sleep
 // in idle_loop(). Note that 'searching' and 'exit' should be already set.
@@ -176,6 +188,30 @@ void ThreadPool::set(const NumaConfig&                           numaConfig,
         boundThreadToNumaNode = doBindThreads
                                 ? numaConfig.distribute_threads_among_numa_nodes(requested)
                                 : std::vector<NumaIndex>{};
+
+        std::map<NumaIndex, size_t> counts;
+        if (boundThreadToNumaNode.empty())
+            counts[0] = requested;
+        else
+        {
+            for (NumaIndex n : boundThreadToNumaNode)
+                counts[n]++;
+        }
+
+        sharedState.sharedHistories.clear();
+        for (const auto& countEntry : counts)
+        {
+            const NumaIndex numaIndex = countEntry.first;
+            const size_t    count     = countEntry.second;
+            auto allocate = [&]() {
+                sharedState.sharedHistories.try_emplace(numaIndex, next_power_of_two(count));
+            };
+
+            if (doBindThreads)
+                numaConfig.execute_on_numa_node(numaIndex, allocate);
+            else
+                allocate();
+        }
 
         while (threads.size() < requested)
         {


### PR DESCRIPTION
### Motivation

- Reduce cross-NUMA traffic and memory duplication by sharing move history tables between threads on the same NUMA node.
- Make history containers dynamically sized to scale with the number of threads and aligned to large pages for performance.
- Prepare Thread/Engine/Search plumbing to allocate and provide per-NUMA shared histories to worker threads.

### Description

- Add `DynStats`, `AtomicStats`, `CorrectionBundle`, `UnifiedCorrectionHistory` and `SharedHistories` in `history.h` to provide dynamically sized, large-page backed shared history containers and atomic entries for cross-thread use.
- Replace per-thread `PawnHistory`/correction history usage with shared per-NUMA `SharedHistories` and update the `StatsEntry` conversion operator to return by value (`operator T() const`).
- Propagate the new shared-histories through the codebase: add `std::map<NumaIndex, SharedHistories> sharedHists` to `Engine`, include the shared-histories map in `Search::SharedState`, and make `Search::Worker` reference the appropriate `SharedHistories` via its `NumaReplicatedAccessToken`.
- Update move-picking and search code to use `SharedHistories` (change `MovePicker` constructor and uses), and switch all history updates/accesses to the new shared structures across `movepick.cpp`, `search.cpp`, and related headers.
- Update thread allocation (`thread.cpp`) to build and populate `sharedHistories` keyed by NUMA index using a `next_power_of_two` size, and allocate on the correct NUMA node when binding is enabled.
- Adjust `Engine::resize_threads()` call site to pass the new `sharedHists` map into the thread pool initialization path.
- Add necessary includes (`<map>`, `<cstring>`, and `memory.h`) to support the new types and helpers.

### Testing

- Built the project with `make -j` on Linux x86_64 and the build completed successfully.
- Ran the project's basic smoke tests (`make test`) and the included search sanity checks, and they passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e4f0564948327b36070c2b8b86c25)