### PR TITLE
WORDFISH-P8A-R2: port Stockfish June 14 2026 topological block

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -148,7 +148,7 @@ using LowPlyHistory = Stats<std::int16_t, 7183, LOW_PLY_HISTORY_SIZE, UINT_16_HI
 using CapturePieceToHistory = Stats<std::int16_t, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB>;
 
 // PieceToHistory is like ButterflyHistory but is addressed by a move's [piece][to]
-using PieceToHistory = Stats<std::int16_t, 30000, PIECE_NB, SQUARE_NB>;
+using PieceToHistory = AtomicStats<std::int16_t, 30000, PIECE_NB, SQUARE_NB>;
 
 // ContinuationHistory is the combined history of a given pair of moves, usually
 // the current one given a previous one. The nested history table is based on
@@ -264,6 +264,7 @@ struct SharedHistories {
     }
 
     UnifiedCorrectionHistory correctionHistory;
+    ContinuationHistory      continuationHistory[2][2];
     PawnHistory              pawnHistory;
 
    private:

--- a/src/misc.h
+++ b/src/misc.h
@@ -349,8 +349,8 @@ class RelaxedAtomic {
         if constexpr (UseAtomic) return inner.load(std::memory_order_relaxed);
         else return inner;
     }
-    RelaxedAtomic& operator+=(int val) { store(load(std::memory_order_relaxed) + val, std::memory_order_relaxed); return *this; }
-    RelaxedAtomic& operator-=(int val) { store(load(std::memory_order_relaxed) - val, std::memory_order_relaxed); return *this; }
+    RelaxedAtomic& operator+=(T val) { store(load(std::memory_order_relaxed) + val, std::memory_order_relaxed); return *this; }
+    RelaxedAtomic& operator-=(T val) { store(load(std::memory_order_relaxed) - val, std::memory_order_relaxed); return *this; }
     RelaxedAtomic& operator++() { store(load(std::memory_order_relaxed) + 1, std::memory_order_relaxed); return *this; }
     RelaxedAtomic& operator--() { store(load(std::memory_order_relaxed) - 1, std::memory_order_relaxed); return *this; }
     T operator++(int) { T val = load(std::memory_order_relaxed); store(val + 1, std::memory_order_relaxed); return val; }

--- a/src/nnue/features/full_threats.cpp
+++ b/src/nnue/features/full_threats.cpp
@@ -290,8 +290,6 @@ void FullThreats::append_changed_indices(Color                   perspective,
                                          const DiffType&         diff,
                                          IndexList&              removed,
                                          IndexList&              added,
-                                         FusedUpdateData*        fusedData,
-                                         bool                    first,
                                          const ThreatWeightType* prefetchBase,
                                          IndexType               prefetchStride) {
 
@@ -303,37 +301,6 @@ void FullThreats::append_changed_indices(Color                   perspective,
         auto to       = dirty.threatened_sq();
         auto add      = dirty.add();
 
-        if (fusedData)
-        {
-            if (from == fusedData->dp2removed)
-            {
-                if (add)
-                {
-                    if (first)
-                    {
-                        fusedData->dp2removedOriginBoard |= to;
-                        continue;
-                    }
-                }
-                else if (fusedData->dp2removedOriginBoard & to)
-                    continue;
-            }
-
-            if (to != SQ_NONE && to == fusedData->dp2removed)
-            {
-                if (add)
-                {
-                    if (first)
-                    {
-                        fusedData->dp2removedTargetBoard |= from;
-                        continue;
-                    }
-                }
-                else if (fusedData->dp2removedTargetBoard & from)
-                    continue;
-            }
-        }
-
         auto&           insert = add ? added : removed;
         const IndexType index  = make_index(perspective, attacker, from, to, attacked, ksq);
 
@@ -342,10 +309,6 @@ void FullThreats::append_changed_indices(Color                   perspective,
               reinterpret_cast<uintptr_t>(prefetchBase) + index * prefetchStride));
         insert.push_back_if_lt(index, Dimensions);
     }
-}
-
-bool FullThreats::requires_refresh(const DiffType& diff, Color perspective) {
-    return perspective == diff.us && (int8_t(diff.ksq) & 0b100) != (int8_t(diff.prevKsq) & 0b100);
 }
 
 }  // namespace Stockfish::Eval::NNUE::Features

--- a/src/nnue/features/full_threats.h
+++ b/src/nnue/features/full_threats.h
@@ -13,7 +13,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-//Definition of input features Simplified_Threats of NNUE evaluation function
+//Definition of input features Full_Threats of NNUE evaluation function
 
 #ifndef NNUE_FEATURES_FULL_THREATS_INCLUDED
 #define NNUE_FEATURES_FULL_THREATS_INCLUDED
@@ -35,9 +35,6 @@ static constexpr int numValidTargets[PIECE_NB] = {0, 6, 10, 8, 8, 10, 0, 0,
 
 class FullThreats {
    public:
-    // Feature name
-    static constexpr const char* Name = "Full_Threats(Friend)";
-
     // Hash value embedded in the evaluation file
     static constexpr std::uint32_t HashValue = 0x8f234cb8u;
 
@@ -67,13 +64,6 @@ class FullThreats {
     };
     // clang-format on
 
-    struct FusedUpdateData {
-        Bitboard dp2removedOriginBoard = 0;
-        Bitboard dp2removedTargetBoard = 0;
-
-        Square dp2removed;
-    };
-
     // Maximum number of simultaneously active features.
     static constexpr IndexType MaxActiveDimensions = 128;
     using IndexList                                = ValueList<IndexType, MaxActiveDimensions>;
@@ -91,14 +81,8 @@ class FullThreats {
                                        const DiffType&         diff,
                                        IndexList&              removed,
                                        IndexList&              added,
-                                       FusedUpdateData*        fd             = nullptr,
-                                       bool                    first          = false,
                                        const ThreatWeightType* prefetchBase   = nullptr,
                                        IndexType               prefetchStride = 0);
-
-    // Returns whether the change stored in this DirtyPiece means
-    // that a full accumulator refresh is required.
-    static bool requires_refresh(const DiffType& diff, Color perspective);
 };
 
 }  // namespace Stockfish::Eval::NNUE::Features

--- a/src/nnue/features/half_ka_v2_hm.cpp
+++ b/src/nnue/features/half_ka_v2_hm.cpp
@@ -20,10 +20,12 @@
 
 #include "half_ka_v2_hm.h"
 
-#include "../../bitboard.h"
-#include "../../position.h"
 #include "../../types.h"
 #include "../nnue_common.h"
+
+#if defined(USE_AVX512ICL)
+    #include "../../bitboard.h"
+#endif
 
 namespace Stockfish::Eval::NNUE::Features {
 
@@ -89,18 +91,6 @@ IndexType HalfKAv2_hm::make_index(Color perspective, Square s, Piece pc, Square 
     const IndexType flip = 56 * perspective;
     return (IndexType(s) ^ OrientTBL[ksq] ^ flip) + PieceSquareIndex[perspective][pc]
          + KingBuckets[int(ksq) ^ flip];
-}
-
-// Get a list of indices for active features
-
-void HalfKAv2_hm::append_active_indices(Color perspective, const Position& pos, IndexList& active) {
-    Square   ksq = pos.square<KING>(perspective);
-    Bitboard bb  = pos.pieces();
-    while (bb)
-    {
-        Square s = pop_lsb(bb);
-        active.push_back(make_index(perspective, s, pos.piece_on(s), ksq));
-    }
 }
 
 // Get a list of indices for recently changed features

--- a/src/nnue/features/half_ka_v2_hm.h
+++ b/src/nnue/features/half_ka_v2_hm.h
@@ -16,7 +16,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-//Definition of input features HalfKP of NNUE evaluation function
+//Definition of input features HalfKAv2_hm of NNUE evaluation function
 
 #ifndef NNUE_FEATURES_HALF_KA_V2_HM_H_INCLUDED
 #define NNUE_FEATURES_HALF_KA_V2_HM_H_INCLUDED
@@ -27,9 +27,6 @@
 #include "../../types.h"
 #include "../nnue_common.h"
 
-namespace Stockfish {
-class Position;
-}
 
 namespace Stockfish::Eval::NNUE::Features {
 
@@ -63,9 +60,6 @@ class HalfKAv2_hm {
        PS_NONE, PS_W_PAWN, PS_W_KNIGHT, PS_W_BISHOP, PS_W_ROOK, PS_W_QUEEN, PS_KING, PS_NONE}};
 
    public:
-    // Feature name
-    static constexpr const char* Name = "HalfKAv2_hm(Friend)";
-
     // Hash value embedded in the evaluation file
     static constexpr std::uint32_t HashValue = 0x7f234cb8u;
 
@@ -121,10 +115,6 @@ class HalfKAv2_hm {
     // Index of a feature for a given king position and another piece on some square
 
     static IndexType make_index(Color perspective, Square s, Piece pc, Square ksq);
-
-    // Get a list of indices for active features
-
-    static void append_active_indices(Color perspective, const Position& pos, IndexList& active);
 
     // Get a list of indices for recently changed features
     static void append_changed_indices(

--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -363,13 +363,13 @@ void update_accumulator_incremental(Color                                 perspe
     if constexpr (Forward)
     {
         ThreatFeatureSet::append_changed_indices(perspective, ksq, dirtyThreats, thrRemoved,
-                                                 thrAdded, nullptr, false, pfBase, pfStride);
+                                                 thrAdded, pfBase, pfStride);
         PSQFeatureSet::append_changed_indices(perspective, ksq, dirtyPiece, psqRemoved, psqAdded);
     }
     else
     {
         ThreatFeatureSet::append_changed_indices(perspective, ksq, dirtyThreats, thrAdded,
-                                                 thrRemoved, nullptr, false, pfBase, pfStride);
+                                                 thrRemoved, pfBase, pfStride);
         PSQFeatureSet::append_changed_indices(perspective, ksq, dirtyPiece, psqAdded, psqRemoved);
     }
 

--- a/src/nnue/nnue_common.h
+++ b/src/nnue/nnue_common.h
@@ -67,10 +67,8 @@ constexpr std::uint32_t Version = 0x6A448AFAu;
 // Constant used in evaluation value calculation
 constexpr int OutputScale     = 16;
 constexpr int WeightScaleBits = 6;
-constexpr int FtOneVal        = 256;
 constexpr int FtMaxVal        = 255;
 constexpr int HiddenOneVal    = 128;
-constexpr int HiddenMaxVal    = 127;
 
 // Size of cache line (in bytes)
 constexpr std::size_t CacheLineSize = 64;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -725,8 +725,6 @@ void Position::do_move(Move                      m,
     dp.from           = from;
     dp.to             = to;
     dp.add_sq         = SQ_NONE;
-    dts.us            = us;
-    dts.prevKsq       = square<KING>(us);
     dts.threatenedSqs = dts.threateningSqs = 0;
 
     assert(color_of(pc) == us);
@@ -966,7 +964,6 @@ void Position::do_move(Move                      m,
         }
     }
 
-    dts.ksq = square<KING>(us);
 
     assert(pos_is_ok());
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -188,6 +188,7 @@ Search::Worker::Worker(SharedState&                    sharedState,
                        NumaReplicatedAccessToken       token) :
     // Unpack the SharedState struct into member variables
     sharedHistory(sharedState.sharedHistories.at(token.get_numa_index())),
+    continuationHistory(sharedHistory.continuationHistory),
     threadIdx(threadId),
     numaAccessToken(token),
     manager(std::move(sm)),
@@ -464,9 +465,9 @@ void Search::Worker::iterative_deepening() {
 
     Move pv[MAX_PLY + 1];
 
-    Move  lastBestMove      = Move::none();
-    Depth lastBestMoveDepth = 0;
-    auto  lastBestPV        = std::vector{Move::none()};
+    std::vector<Move> lastBestMovePV;
+    Depth             lastBestMoveDepth = 0;
+    Value             lastBestMoveScore = -VALUE_INFINITE;
 
     Value  alpha, beta;
     Value  bestValue     = -VALUE_INFINITE;
@@ -525,10 +526,11 @@ void Search::Worker::iterative_deepening() {
 
         // Save the last iteration's scores before the first PV line is searched and
         // all the move scores except the (new) PV are set to -VALUE_INFINITE.
-        for (RootMove& rm : rootMoves)
+        for (size_t i = 0; i < rootMoves.size(); ++i)
         {
-            rm.previousScore = rm.score;
-            rm.previousPV    = rm.pv;
+            rootMoves[i].previousScore      = rootMoves[i].score;
+            rootMoves[i].previousPV         = rootMoves[i].pv;
+            rootMoves[i].previousScoreExact = i < multiPV;
         }
 
         size_t pvFirst = 0;
@@ -625,36 +627,47 @@ void Search::Worker::iterative_deepening() {
             // Sort the PV lines searched so far and update the GUI
             std::stable_sort(rootMoves.begin() + pvFirst, rootMoves.begin() + pvIdx + 1);
 
-            // In multiPV analysis we do not let aborted searches spoil mated-in/
-            // TB loss scores from a completed search in an earlier PV line.
-            if (threads.stop && pvIdx
-                && ((is_loss(rootMoves[pvIdx - 1].score) && rootMoves[pvIdx] < rootMoves[pvIdx - 1])
-                    || rootMoves[pvIdx].score_is_exact_loss()))
+            if (threads.stop && pvIdx)
             {
-                if (rootMoves[pvIdx].previousScore != -VALUE_INFINITE
-                    && rootMoves[pvIdx].previousScore <= rootMoves[pvIdx - 1].score)
+                // In multiPV analysis we do not let aborted searches spoil mated-in/
+                // TB loss scores from a completed search in an earlier PV line.
+                // Hence we guard against an aborted pvIdx line overtaking pvIdx - 1
+                // when pvIdx - 1 is a proven loss.
+                // Moreover, we do not trust an exact loss score from an aborted search.
+                if ((is_loss(rootMoves[pvIdx - 1].score) && rootMoves[pvIdx] < rootMoves[pvIdx - 1])
+                    || rootMoves[pvIdx].score_is_exact_loss())
                 {
-                    rootMoves[pvIdx].score = rootMoves[pvIdx].uciScore =
-                      rootMoves[pvIdx].previousScore;
-                    rootMoves[pvIdx].previousScore = -VALUE_INFINITE;
-                    rootMoves[pvIdx].pv            = rootMoves[pvIdx].previousPV;
-                    rootMoves[pvIdx].unset_bound_flags();
-                }
-                else
-                {
-                    if (is_loss(rootMoves[pvIdx - 1].score))
+                    if (rootMoves[pvIdx].previousScore != -VALUE_INFINITE
+                        && rootMoves[pvIdx].previousScoreExact
+                        && rootMoves[pvIdx].previousScore <= rootMoves[pvIdx - 1].score)
                     {
                         rootMoves[pvIdx].score = rootMoves[pvIdx].uciScore =
-                          rootMoves[pvIdx - 1].score;
+                          rootMoves[pvIdx].previousScore;
                         rootMoves[pvIdx].previousScore = -VALUE_INFINITE;
-                        rootMoves[pvIdx].pv.resize(1);
-                        rootMoves[pvIdx].scoreUpperbound = true;
+                        rootMoves[pvIdx].pv            = rootMoves[pvIdx].previousPV;
+                        rootMoves[pvIdx].unset_bound_flags();
                     }
                     else
-                        rootMoves[pvIdx].scoreUpperbound = false;
+                    {
+                        if (is_loss(rootMoves[pvIdx - 1].score))
+                        {
+                            rootMoves[pvIdx].score = rootMoves[pvIdx].uciScore =
+                              rootMoves[pvIdx - 1].score;
+                            rootMoves[pvIdx].previousScore = -VALUE_INFINITE;
+                            rootMoves[pvIdx].pv.resize(1);
+                            rootMoves[pvIdx].scoreUpperbound = true;
+                        }
+                        else
+                            rootMoves[pvIdx].scoreUpperbound = false;
 
-                    rootMoves[pvIdx].scoreLowerbound = !rootMoves[pvIdx].scoreUpperbound;
+                        rootMoves[pvIdx].scoreLowerbound = !rootMoves[pvIdx].scoreUpperbound;
+                    }
                 }
+
+                // Finally, we mark all loss scores from partially searched moves as a bound.
+                for (size_t i = pvIdx + 1; i < multiPV; ++i)
+                    if (rootMoves[i].score_is_exact_loss())
+                        rootMoves[i].scoreLowerbound = true;
             }
 
             if (mainThread
@@ -674,25 +687,39 @@ void Search::Worker::iterative_deepening() {
         if (!threads.stop)
             completedDepth = rootDepth;
 
-        // We make sure not to pick an unproven mated-in score,
-        // in case this thread prematurely stopped search (aborted-search).
-        if (threads.abortedSearch && rootMoves[0].score_is_exact_loss())
+        const bool forgottenMate = lastBestMoveScore != -VALUE_INFINITE
+                                && is_decisive(lastBestMoveScore)
+                                && (std::abs(rootMoves[0].score) < std::abs(lastBestMoveScore)
+                                    || rootMoves[0].score_is_bound());
+
+        if (!threads.stop)
         {
-            // Bring the last best move to the front for best thread selection.
-            if (lastBestMove != Move::none())
+            if (lastBestMovePV.empty() || lastBestMovePV[0] != rootMoves[0].pv[0])
+                lastBestMoveDepth = rootDepth;
+
+            // Do not replace (shorter) mate scores from a previous iteration.
+            if (!forgottenMate)
             {
-                Utility::move_to_front(
-                  rootMoves, [lastBestMove](const auto& rm) { return rm == lastBestMove; });
-                rootMoves[0].score = rootMoves[0].uciScore = rootMoves[0].previousScore;
-                rootMoves[0].pv                            = rootMoves[0].previousPV;
-                rootMoves[0].unset_bound_flags();
+                lastBestMovePV    = rootMoves[0].pv;
+                lastBestMoveScore = rootMoves[0].score;
             }
         }
-        else if (rootMoves[0].pv[0] != lastBestPV[0])
+
+        // We make sure not to pick an unproven mated-in score,
+        // in case this thread prematurely stopped search (aborted-search), or remember a
+        // forgotten mate.
+        if ((threads.abortedSearch && rootMoves[0].score_is_exact_loss())
+            || (rootMoves[0].score != -VALUE_INFINITE && forgottenMate))
         {
-            lastBestMove      = rootMoves[0].pv[0];
-            lastBestPV        = rootMoves[0].pv;
-            lastBestMoveDepth = rootDepth;
+            // Bring the last best move to the front for best thread selection.
+            if (!lastBestMovePV.empty())
+            {
+                Utility::move_to_front(rootMoves, [&lastPV = std::as_const(lastBestMovePV)](
+                                                    const auto& rm) { return rm == lastPV[0]; });
+                rootMoves[0].score = rootMoves[0].uciScore = lastBestMoveScore;
+                rootMoves[0].pv                            = lastBestMovePV;
+                rootMoves[0].unset_bound_flags();
+            }
         }
 
         if (!mainThread)

--- a/src/search.h
+++ b/src/search.h
@@ -98,16 +98,17 @@ struct RootMove {
         return m.score != score ? m.score < score : m.previousScore < previousScore;
     }
 
-    uint64_t          effort           = 0;
-    Value             score            = -VALUE_INFINITE;
-    Value             previousScore    = -VALUE_INFINITE;
-    Value             averageScore     = -VALUE_INFINITE;
-    Value             meanSquaredScore = -VALUE_INFINITE * VALUE_INFINITE;
-    Value             uciScore         = -VALUE_INFINITE;
-    bool              scoreLowerbound  = false;
-    bool              scoreUpperbound  = false;
-    int               selDepth         = 0;
-    int               tbRank           = 0;
+    uint64_t          effort             = 0;
+    Value             score              = -VALUE_INFINITE;
+    Value             previousScore      = -VALUE_INFINITE;
+    Value             averageScore       = -VALUE_INFINITE;
+    Value             meanSquaredScore   = -VALUE_INFINITE * VALUE_INFINITE;
+    Value             uciScore           = -VALUE_INFINITE;
+    bool              scoreLowerbound    = false;
+    bool              scoreUpperbound    = false;
+    bool              previousScoreExact = false;
+    int               selDepth           = 0;
+    int               tbRank             = 0;
     Value             tbScore;
     std::vector<Move> pv, previousPV;
 };
@@ -296,7 +297,6 @@ class Worker {
     LowPlyHistory    lowPlyHistory;
 
     CapturePieceToHistory captureHistory;
-    ContinuationHistory   continuationHistory[2][2];
     CorrectionHistory<Pawn>         pawnCorrectionHistory;
     CorrectionHistory<Minor>        minorPieceCorrectionHistory;
     CorrectionHistory<NonPawn>      nonPawnCorrectionHistory;
@@ -304,6 +304,7 @@ class Worker {
 
     TTMoveHistory ttMoveHistory;
     SharedHistories& sharedHistory;
+    ContinuationHistory (&continuationHistory)[2][2];
 
    private:
    void iterative_deepening();

--- a/src/types.h
+++ b/src/types.h
@@ -323,8 +323,6 @@ using DirtyThreatList = ValueList<DirtyThreat, 80>;
 
 struct DirtyThreats {
     DirtyThreatList list;
-    Color           us;
-    Square          prevKsq, ksq;
 
     Bitboard threatenedSqs, threateningSqs;
 };


### PR DESCRIPTION
### Motivation
- Bring Wordfish up to date with the official Stockfish June 14, 2026 topological block while preserving Wordfish protected surfaces and single-net NNUE public surface.
- Apply only source changes that map cleanly to the current Wordfish P7I / P8A0-R2 topology and skip CI-only or type-replacement changes that do not fit the existing aliases/topology.
- Ensure `f9b002cf` (continuation-history sharing) is structurally applicable on the current base and wire it safely into Wordfish search/SharedHistories.

### Description
- Ported `Fixup RelaxedAtomic operator Types` by changing `RelaxedAtomic` arithmetic operator parameters from `int` to the template type `T` in `src/misc.h` (`operator+=` / `operator-=`) to match official semantics. (`718a001e`)
- Applied NNUE cleanup from `Remove unused code from the post NNUE accumulator merge` by removing unreachable fused-update helpers and related APIs in `src/nnue/features/*`, updating calls in `src/nnue/nnue_accumulator.cpp`, and removing now-unused DirtyThreats king/color fields; preserved active changed-indices paths and single-net public surface. (`ed8e35d7`)
- Implemented `Share continuation history between threads` by converting `PieceToHistory` to `AtomicStats`, adding `ContinuationHistory continuationHistory[2][2]` to `SharedHistories`, and making each `Search::Worker` reference the shared continuation history (`src/history.h`, `src/search.h`, `src/search.cpp`). (`f9b002cf`)
- Ported `Final fix for MultiPV mate PV corner cases` by adding `previousScoreExact` tracking to `RootMove`, guarding reuse of `previousScore`/`previousPV` from aborted iterations, marking partially searched loss scores as bounds, and remembering last trusted best-move PV/score to handle forgotten mates (`src/search.h`, `src/search.cpp`). (`74a0a737`)
- Skipped CI-only `matetrack` workflow change (`0dc19b61`) and the official broad `Replace Remaining Types` type-alias rewrite (`6e4e03fd`) because the latter does not map cleanly to Wordfish's current type-alias topology; also treated `Reuse computed ray bitboard` as already equivalent in the current codebase. (`6e4e03fd` / `f9beec5f`) 
- Preserved protected surfaces and NNUE public surface: no changes to `src/experience.*`, `src/polybook.*`, `src/book/`, `src/mcts.*`, `src/sparsehash/`, `src/lichess_tablebase.cpp`, Brand/identity, and `EvalFile` remains present while `EvalFileSmall` remains absent.

### Testing
- Ran repository checks and evidence scans: `git status --short --branch`, `git rev-parse HEAD`, `git log --oneline -100`, and `rg` scans for the required topology markers and NNUE macros; these checks passed and prerequisites (`P7I`, `P8A0-R2`) were confirmed.
- Verified official Jun14 topological order with the official Stockfish repo and confirmed ancestry of the block commits using official commits range checks; `f9b002cf` was confirmed structurally applicable before porting.
- Built and validated binaries across targets: executed `make clean`, `make net`, and `make -j build` for `ARCH=x86-64-sse41-popcnt`, `x86-64-avx2`, `x86-64-bmi2`, `x86-64-avx512`, and `x86-64-vnni512` with `COMP=clang` and `EXTRALDFLAGS="-fuse-ld=lld"`; all builds completed successfully and automated forbidden-pattern scans found no `warning:|error:|fatal error:|undefined reference|ld: error|clang: error` occurrences.
- Ran UCI smoke and depth-1 smoke on the available binary with `printf "uci\nisready\nquit\n" | ./src/<binary>` and `printf "uci\nisready\nposition startpos\ngo depth 1\nquit\n" | ./src/<binary>`; expected outputs were observed (`id name Wordfish-5.0-120626`, `option name EvalFile` present, no `EvalFileSmall`, `uciok`, `readyok`, and `bestmove` at depth 1).
- Post-change `git diff --check` and protected-surface audit (`git diff 58e4ef2 --name-only | grep -E '^(src/experience|src/polybook|src/book/|src/mcts|src/sparsehash/|src/lichess_tablebase.cpp)'`) returned clean results; `rg -n 'EvalFileSmall' src` returned no hits; `NNUE_EMBEDDING_OFF` references remain opt-in/default-no as required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e7bc261e48327a1ff21c4f50de613)