### PR TITLE
WORDFISH-P8B: port Stockfish June 25 2026 topological block

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -33,8 +33,8 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultNameBig "nn-71d6d32cb962.nnue"
-#define EvalFileDefaultName "nn-71d6d32cb962.nnue"
+#define EvalFileDefaultNameBig "nn-f8a759c05f9f.nnue"
+#define EvalFileDefaultName "nn-f8a759c05f9f.nnue"
 
 namespace NNUE {
 class Network;

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -56,8 +56,6 @@ class MovePicker {
     Move select(Pred);
     template<GenType T>
     ExtMove* score(MoveList<T>&);
-    ExtMove* begin() { return cur; }
-    ExtMove* end() { return endCur; }
 
     const Position&              pos;
     const ButterflyHistory*      mainHistory;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -227,6 +227,22 @@ Position::set(const string& fenStr, bool isChess960, StateInfo* si) {
     if (pieces(PAWN) & (Rank1BB | Rank8BB))
         return PositionSetError("Unsupported position. Pawns on the first or eighth rank.");
 
+    if (count<KING>(WHITE) != 1 || count<KING>(BLACK) != 1)
+        return PositionSetError("Unsupported position. Incorrect number of kings.");
+
+    for (Color c : {WHITE, BLACK})
+    {
+        if (count<PAWN>(c) > 8)
+            return PositionSetError(std::string("Unsupported position. ")
+                                    + (c == WHITE ? "WHITE" : "BLACK") + " has more than 8 pawns.");
+
+        int additional = std::max(count<KNIGHT>(c) - 2, 0) + std::max(count<BISHOP>(c) - 2, 0)
+                       + std::max(count<ROOK>(c) - 2, 0) + std::max(count<QUEEN>(c) - 1, 0);
+        if (additional > 8 - count<PAWN>(c))
+            return PositionSetError(std::string("Unsupported position. Too many pieces for ")
+                                    + (c == WHITE ? "WHITE." : "BLACK."));
+    }
+
     // 2. Active color
     ss >> token;
     sideToMove = (token == 'w' ? WHITE : BLACK);
@@ -610,26 +626,8 @@ bool Position::pseudo_legal(const Move m) const {
     else if (!(attacks_bb(type_of(pc), from, pieces()) & to))
         return false;
 
-    // Evasions generator already takes care to avoid some kind of illegal moves
-    // and legal() relies on this. We therefore have to take care that the same
-    // kind of moves are filtered out here.
     if (checkers())
-    {
-        if (type_of(pc) != KING)
-        {
-            // Double check? In this case, a king move is required
-            if (more_than_one(checkers()))
-                return false;
-
-            // Our move must be a blocking interposition or a capture of the checking piece
-            if (!(between_bb(square<KING>(us), lsb(checkers())) & to))
-                return false;
-        }
-        // In case of king moves under check we have to remove the king so as to catch
-        // invalid moves like b1a1 when opposite queen is on c1.
-        else if (attackers_to_exist(to, pieces() ^ from, ~us))
-            return false;
-    }
+        return MoveList<EVASIONS>(*this).contains(m);
 
     return true;
 }
@@ -693,6 +691,7 @@ void Position::do_move(Move                      m,
                        DirtyPiece&               dp,
                        DirtyThreats&             dts,
                        const TranspositionTable* tt = nullptr) {
+    (void) tt;
 
     assert(m.is_ok());
     assert(&newSt != st);
@@ -853,10 +852,6 @@ void Position::do_move(Move                      m,
         if (type_of(pc) <= BISHOP)
             st->minorPieceKey ^= Zobrist::psq[pc][from] ^ Zobrist::psq[pc][to];
     }
-
-    // If en passant is impossible, then k will not change and we can prefetch earlier
-    if (tt && !checkEP)
-        prefetch(tt->first_entry(adjust_key50(k)));
 
     // Move the piece. The tricky Chess960 castling is handled earlier
     if (m.type_of() != CASTLING)
@@ -1152,6 +1147,22 @@ void Position::update_piece_threats(Piece pc, Square s, DirtyThreats* const dts)
     }
 }
 
+
+Key Position::prefetch_key(Move m) const {
+    Square from     = m.from_sq();
+    Square to       = m.to_sq();
+    Piece  pc       = piece_on(from);
+    Piece  captured = piece_on(to);
+    Key    k        = st->key ^ Zobrist::side;
+
+    k ^= Zobrist::psq[captured][to] ^ Zobrist::psq[pc][to] ^ Zobrist::psq[pc][from];
+
+    if (captured || type_of(pc) == PAWN)
+        return k;
+
+    return adjust_key50<true>(k);
+}
+
 // Helper used to do/undo a castling move. This is a bit
 // tricky in Chess960 where from/to squares can overlap.
 template<bool Do>
@@ -1210,6 +1221,8 @@ void Position::do_null_move(StateInfo& newSt, const TranspositionTable& tt) {
     prefetch(tt.first_entry(key()));
 
     st->pliesFromNull = 0;
+
+    st->capturedPiece = NO_PIECE;
 
     sideToMove = ~sideToMove;
 

--- a/src/position.h
+++ b/src/position.h
@@ -159,6 +159,7 @@ class Position {
 
     // Accessing hash keys
     Key key() const;
+    Key prefetch_key(Move m) const;
     Key material_key() const;
     Key pawn_key() const;
     Key minor_piece_key() const;
@@ -206,7 +207,8 @@ class Position {
                      Square&             rto,
                      DirtyThreats* const dts = nullptr,
                      DirtyPiece* const   dp  = nullptr);
-    Key  adjust_key50(Key k) const;
+    template<bool AfterMove = false>
+    Key adjust_key50(Key k) const;
 
     // Data members
     std::array<Piece, SQUARE_NB>        board;
@@ -312,8 +314,9 @@ inline Bitboard Position::check_squares(PieceType pt) const { return st->checkSq
 
 inline Key Position::key() const { return adjust_key50(st->key); }
 
+template<bool AfterMove>
 inline Key Position::adjust_key50(Key k) const {
-    return st->rule50 < 14 ? k : k ^ make_key((st->rule50 - 14) / 8);
+    return st->rule50 < 14 - AfterMove ? k : k ^ make_key((st->rule50 - (14 - AfterMove)) / 8);
 }
 
 inline Key Position::pawn_key() const { return st->pawnKey; }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -824,6 +824,10 @@ void Search::Worker::do_move(Position& pos, const Move move, StateInfo& st, Stac
 
 void Search::Worker::do_move(
   Position& pos, const Move move, StateInfo& st, const bool givesCheck, Stack* const ss) {
+    // prefetch_key does not model castling, en passant or promotion keys
+    // exactly; for rare moves the prefetch lands on an unused line.
+    prefetch(tt.first_entry(pos.prefetch_key(move)));
+
     bool capture = pos.capture_stage(move);
     ++nodes;
 
@@ -1222,7 +1226,7 @@ Value Search::Worker::search(
         assert(probCutBeta < VALUE_INFINITE && probCutBeta > beta);
 
         MovePicker mp(pos, ttData.move, probCutBeta - ss->staticEval, &captureHistory);
-        Depth      probCutDepth = std::clamp(depth - 5 - (ss->staticEval - beta) / 306, 0, depth);
+        Depth      probCutDepth = std::clamp(depth - 5 - improving - (ss->staticEval - beta) / 306, 0, depth);
 
         while ((move = mp.next_move()) != Move::none())
         {
@@ -1490,7 +1494,7 @@ moves_loop:  // When in check, search starts here
 
         // For first picked move (ttMove) reduce reduction
         if (move == ttData.move)
-            r -= 2018;
+            r = std::max(0, r - 2018);
 
         if (capture)
             ss->statScore = 803 * int(PieceValue[pos.captured_piece()]) / 128
@@ -2015,15 +2019,10 @@ Depth Search::Worker::reduction(bool i, Depth d, int mn, int delta) const {
 // 'nodestime' option is enabled, it will return the count of nodes searched
 // instead. This function is called to check whether the search should be
 // stopped based on predefined thresholds like time limits or nodes searched.
-//
-// elapsed_time() returns the actual time elapsed since the start of the search.
-// This function is intended for use only when printing PV outputs, and not used
-// for making decisions within the search algorithm itself.
 TimePoint Search::Worker::elapsed() const {
     return main_manager()->tm.elapsed([this]() { return threads.nodes_searched(); });
 }
 
-TimePoint Search::Worker::elapsed_time() const { return main_manager()->tm.elapsed_time(); }
 
 Value Search::Worker::evaluate(const Position& pos) {
 

--- a/src/search.h
+++ b/src/search.h
@@ -334,7 +334,6 @@ class Worker {
     }
 
     TimePoint elapsed() const;
-    TimePoint elapsed_time() const;
 
     Value evaluate(const Position&);
 


### PR DESCRIPTION
### Motivation
- Apply the official Stockfish June 25, 2026 topological block to Wordfish in strict topo order while preserving Wordfish-specific systems and public single-net NNUE surface.
- Ensure `src/types.h` and `src/attacks.h` are audited against official Stockfish dev-20260625 and that any Stockfish-owned content aligns with dev25 or is explicitly justified.
- Keep protected Wordfish surfaces (Experience, PolyBook, MCTS, sparsehash, Lichess tablebase, branding, and single-net EvalFile) unchanged.

### Description
- Ported the applicable official Jun25 commits in topo order as separate Wordfish commits, including: prefetch TT entry earlier, more aggressive `probCut` when `improving`, NNUE authority update to `nn-f8a759c05f9f.nnue`, evasion logic simplification, removal of unused search-layer APIs, null-move `capturedPiece` clearing, two small search simplifications, and deduplicated color-specific piece validation.
- Introduced `Position::prefetch_key(Move)` and moved the TT prefetch to the search-layer `do_move` call path via `prefetch(tt.first_entry(pos.prefetch_key(move)))` while preserving existing material-key/adjust-key topology and behavior.
- Updated `EvalFileDefaultName` to `nn-f8a759c05f9f.nnue` and preserved the public `EvalFile` option and the absence of `EvalFileSmall`.
- Removed unused `MovePicker::begin()/end()` and the unused `Search::Worker::elapsed_time()` declaration/definition, adjusted a few reductions/history decay expressions, changed `Position::adjust_key50` to a `template<bool AfterMove>` form, and applied small code cleanups matching official simplifications.
- Audited `src/types.h` and `src/attacks.h` against official Stockfish dev25; these files were inspected and not modified by this block because the remaining differences are Wordfish-specific compatibility/topology overlays required by existing Wordfish systems (summary below).

### Testing
- Confirmed official target commit resolves: `47575ebd8bc092b091e496ea776dc56d22972487` and topological ancestry for each Jun25 commit.
- Per-commit porting checks and `git diff --check` were run for each applied commit and passed.
- Ran `make net` and successfully validated/downloaded `nn-f8a759c05f9f.nnue`.
- Built and validated binaries with `make -j build` for all required matrices: `x86-64-sse41-popcnt`, `x86-64-avx2`, `x86-64-bmi2`, `x86-64-avx512`, and `x86-64-vnni512` with `COMP=clang` and `EXTRALDFLAGS="-fuse-ld=lld"`, and found no forbidden diagnostics.
- Performed UCI smoke and depth-1 smoke with the sse41-popcnt binary; checks included `id name Wordfish-5.0-120626`, presence of `EvalFile` set to `nn-f8a759c05f9f.nnue`, absence of `EvalFileSmall`, and successful `uciok`/`readyok`/`bestmove` responses.

Notes on `src/types.h` and `src/attacks.h` audit (summary):
- Both files were compared to official Stockfish dev25 before and after applying the Jun25 source commits; they were not changed by this block because the differences present are Wordfish-specific compatibility overlays or P7H-preserved constructs required for existing Wordfish systems.
- Retained, justified deviations include preserving `pdep` mapping/fallbacks and `DirtyThreat`/`DirtyThreats`/`DirtyBoardData` layout in `src/types.h` for Wordfish threat/accumulator integration, and retaining a `RESTRICT` compatibility guard plus unqualified attack aliases in `src/attacks.h` to preserve existing Wordfish call sites and compile compatibility.
- If any reviewer requires full line-by-line mapping of the remaining differences against official dev25 (official line / Wordfish line / reason / safety justification / classification), that will be produced as an explicit follow-up artifact; the current port left these differences intentionally to avoid breaking protected Wordfish surfaces.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3eb0fa2ac48327b756d2aabad75cc5)