### PR TITLE
WORDFISH-P8D: close TT memset Clang warning

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -198,7 +198,7 @@ void TranspositionTable::clear(ThreadPool& threads) {
             const size_t start  = stride * i;
             const size_t len    = i + 1 != threadCount ? stride : clusterCount - start;
 
-            std::memset(&table[start], 0, len * sizeof(Cluster));
+            std::memset(static_cast<void*>(&table[start]), 0, len * sizeof(Cluster));
         });
     }
 


### PR DESCRIPTION
### Motivation
- Silence a Clang diagnostic in the transposition-table clear loop by matching the official Stockfish dev25 topology which explicitly casts the pointer to `void*` before calling `std::memset`, without changing semantics.

### Description
- Change a single line in `src/tt.cpp` from `std::memset(&table[start], 0, len * sizeof(Cluster));` to `std::memset(static_cast<void*>(&table[start]), 0, len * sizeof(Cluster));`, and do not modify any other files.

### Testing
- Ran `git diff -- src/tt.cpp` and `git diff --check`, verified identity and `EvalFile` via `rg -n 'Wordfish-5\.10-260626|EvalFileSmall|EvalFile'`, confirmed official Stockfish dev25 line with `git show 47575ebd8bc092b091e496ea776dc56d22972487:src/tt.cpp`, attempted `make net && make -j profile-build ...` which failed due to the environment's Swift clang LTO linker (`ld.gold`) being unable to load `LLVMgold.so` (toolchain/environment issue), then built a host-compatible binary with `make -j build ...` which produced a runnable sse41 executable and passed UCI smoke returning `id name Wordfish-5.10-260626`, `option name EvalFile type string default nn-f8a759c05f9f.nnue`, `uciok`, and `readyok`, and committed the single change in one commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fa36a4f988327bfcdfe17e9a34b0c)